### PR TITLE
Fix match animation to use theme border colors

### DIFF
--- a/components/onboarding/multiplayer-intro.tsx
+++ b/components/onboarding/multiplayer-intro.tsx
@@ -6,6 +6,7 @@ import Animated, {
   withRepeat,
   withTiming,
   interpolate,
+  interpolateColor,
   Extrapolation,
   FadeIn,
 } from 'react-native-reanimated';
@@ -17,6 +18,7 @@ import { useTheme } from '@/contexts/theme-context';
 const { width } = Dimensions.get('window');
 
 const LOOP_DURATION = 5000;
+const MATCH_GREEN = '#4ADE80';
 
 export function MultiplayerIntro({ isActive }: { isActive: boolean }) {
   const { colors } = useTheme();
@@ -29,25 +31,31 @@ export function MultiplayerIntro({ isActive }: { isActive: boolean }) {
   }, [isActive]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── Card animations ──────────────────────────────────────────────
-  // Timeline (5s): Slide together 0-10% | Banner pop 10-16% |
-  //   Hold 3s 16-76% | Dismiss + apart 76-86% | Rest 86-100%
-  // Cards stay visible the whole time (no fade out/in)
+  // Timeline (5s): Slide together 0-10% | Border fades green 10-18% |
+  //   Banner pop 28-34% | Hold 34-70% | Dismiss + apart 70-82% | Rest 82-100%
+  // Cards start with theme border, transition to green when they meet
   const youCardStyle = useAnimatedStyle(() => {
     const p = progress.value;
     const translateX = interpolate(
       p,
-      [0, 0.10, 0.76, 0.86, 1.0],
+      [0, 0.10, 0.70, 0.82, 1.0],
       [-70, 0, 0, -70, -70],
       Extrapolation.CLAMP,
     );
     const rotate = interpolate(
       p,
-      [0, 0.10, 0.76, 0.86, 1.0],
+      [0, 0.10, 0.70, 0.82, 1.0],
       [-6, 0, 0, -6, -6],
       Extrapolation.CLAMP,
     );
+    const borderColor = interpolateColor(
+      p,
+      [0, 0.10, 0.18, 0.70, 0.82, 1.0],
+      [colors.border, colors.border, MATCH_GREEN, MATCH_GREEN, colors.border, colors.border],
+    );
     return {
       transform: [{ rotate: `${rotate}deg` }, { translateX }],
+      borderColor,
     };
   });
 
@@ -55,34 +63,40 @@ export function MultiplayerIntro({ isActive }: { isActive: boolean }) {
     const p = progress.value;
     const translateX = interpolate(
       p,
-      [0, 0.10, 0.76, 0.86, 1.0],
+      [0, 0.10, 0.70, 0.82, 1.0],
       [70, 0, 0, 70, 70],
       Extrapolation.CLAMP,
     );
     const rotate = interpolate(
       p,
-      [0, 0.10, 0.76, 0.86, 1.0],
+      [0, 0.10, 0.70, 0.82, 1.0],
       [6, 0, 0, 6, 6],
       Extrapolation.CLAMP,
     );
+    const borderColor = interpolateColor(
+      p,
+      [0, 0.10, 0.18, 0.70, 0.82, 1.0],
+      [colors.border, colors.border, MATCH_GREEN, MATCH_GREEN, colors.border, colors.border],
+    );
     return {
       transform: [{ rotate: `${rotate}deg` }, { translateX }],
+      borderColor,
     };
   });
 
   // ── Match banner animation ───────────────────────────────────────
-  // Appears after cards meet, holds for ~3s (16-76% of 5s = 3s)
+  // Appears ~1s after cards meet (28% = ~1.4s after meeting at 10% = 500ms)
   const bannerStyle = useAnimatedStyle(() => {
     const p = progress.value;
     const scale = interpolate(
       p,
-      [0, 0.10, 0.14, 0.16, 0.76, 0.84, 1.0],
+      [0, 0.28, 0.32, 0.34, 0.70, 0.78, 1.0],
       [0, 0, 1.08, 1, 1, 0, 0],
       Extrapolation.CLAMP,
     );
     const opacity = interpolate(
       p,
-      [0, 0.10, 0.14, 0.76, 0.84, 1.0],
+      [0, 0.28, 0.32, 0.70, 0.78, 1.0],
       [0, 0, 1, 1, 0, 0],
       Extrapolation.CLAMP,
     );
@@ -231,7 +245,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#FFFFFF',
     borderRadius: 18,
     borderWidth: 4,
-    borderColor: '#34D399',
+    // borderColor animated via useAnimatedStyle
     paddingVertical: 14,
     paddingHorizontal: 10,
     alignItems: 'center',

--- a/components/ui/match-animation.tsx
+++ b/components/ui/match-animation.tsx
@@ -6,6 +6,7 @@ import Animated, {
   withRepeat,
   withTiming,
   interpolate,
+  interpolateColor,
   Extrapolation,
 } from 'react-native-reanimated';
 import { Ionicons } from '@expo/vector-icons';
@@ -13,6 +14,7 @@ import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 
 const LOOP_DURATION = 5000;
+const MATCH_GREEN = '#4ADE80';
 
 export function MatchAnimation() {
   const { colors } = useTheme();
@@ -23,51 +25,64 @@ export function MatchAnimation() {
     progress.value = withRepeat(withTiming(1, { duration: LOOP_DURATION }), -1, false);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Timeline (5s): Slide together 0-10% | Border fades green 10-18% |
+  //   Banner pop 18-24% | Hold 24-70% | Dismiss 70-82% | Rest 82-100%
   const youCardStyle = useAnimatedStyle(() => {
     const p = progress.value;
     const translateX = interpolate(
       p,
-      [0, 0.1, 0.76, 0.86, 1.0],
+      [0, 0.1, 0.70, 0.82, 1.0],
       [-70, 0, 0, -70, -70],
       Extrapolation.CLAMP,
     );
     const rotate = interpolate(
       p,
-      [0, 0.1, 0.76, 0.86, 1.0],
+      [0, 0.1, 0.70, 0.82, 1.0],
       [-6, 0, 0, -6, -6],
       Extrapolation.CLAMP,
     );
-    return { transform: [{ rotate: `${rotate}deg` }, { translateX }] };
+    const borderColor = interpolateColor(
+      p,
+      [0, 0.10, 0.18, 0.70, 0.82, 1.0],
+      [colors.border, colors.border, MATCH_GREEN, MATCH_GREEN, colors.border, colors.border],
+    );
+    return { transform: [{ rotate: `${rotate}deg` }, { translateX }], borderColor };
   });
 
   const partnerCardStyle = useAnimatedStyle(() => {
     const p = progress.value;
     const translateX = interpolate(
       p,
-      [0, 0.1, 0.76, 0.86, 1.0],
+      [0, 0.1, 0.70, 0.82, 1.0],
       [70, 0, 0, 70, 70],
       Extrapolation.CLAMP,
     );
     const rotate = interpolate(
       p,
-      [0, 0.1, 0.76, 0.86, 1.0],
+      [0, 0.1, 0.70, 0.82, 1.0],
       [6, 0, 0, 6, 6],
       Extrapolation.CLAMP,
     );
-    return { transform: [{ rotate: `${rotate}deg` }, { translateX }] };
+    const borderColor = interpolateColor(
+      p,
+      [0, 0.10, 0.18, 0.70, 0.82, 1.0],
+      [colors.border, colors.border, MATCH_GREEN, MATCH_GREEN, colors.border, colors.border],
+    );
+    return { transform: [{ rotate: `${rotate}deg` }, { translateX }], borderColor };
   });
 
+  // Banner appears ~1s after cards meet (18% = 900ms after 10% = 500ms)
   const bannerStyle = useAnimatedStyle(() => {
     const p = progress.value;
     const scale = interpolate(
       p,
-      [0, 0.1, 0.14, 0.16, 0.76, 0.84, 1.0],
+      [0, 0.28, 0.32, 0.34, 0.70, 0.78, 1.0],
       [0, 0, 1.08, 1, 1, 0, 0],
       Extrapolation.CLAMP,
     );
     const opacity = interpolate(
       p,
-      [0, 0.1, 0.14, 0.76, 0.84, 1.0],
+      [0, 0.28, 0.32, 0.70, 0.78, 1.0],
       [0, 0, 1, 1, 0, 0],
       Extrapolation.CLAMP,
     );
@@ -125,7 +140,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#FFFFFF',
     borderRadius: 18,
     borderWidth: 4,
-    borderColor: '#34D399',
+    // borderColor animated via useAnimatedStyle
     paddingVertical: 14,
     paddingHorizontal: 10,
     alignItems: 'center',


### PR DESCRIPTION
## Summary
- Card borders in the match animation now start with the active theme's border color instead of hardcoded green, matching the main swipe cards
- When cards meet in the middle, borders smoothly fade to green via `interpolateColor`
- "It's a Match!" banner now appears ~1s after the cards meet (delayed from immediate)
- Applied to both the matches empty state (`MatchAnimation`) and onboarding step 3 (`MultiplayerIntro`)

## Test plan
- [ ] Switch between all 4 themes (pink, mint, blue, yellow) and verify card borders match the theme initially
- [ ] Watch the animation loop — borders should fade to green after cards meet
- [ ] "It's a Match!" banner should appear ~1 second after cards finish sliding together
- [ ] Verify same behavior on onboarding step 3 (multiplayer intro)
- [ ] Check animation looks smooth on both iOS and Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)