### PR TITLE
feat: pre-launch audit - enriched names, feedback, and polish

### DIFF
--- a/app/(tabs)/explore/filters.tsx
+++ b/app/(tabs)/explore/filters.tsx
@@ -30,7 +30,7 @@ export default function Filters() {
     if (loaded.current || !user) return;
     loaded.current = true;
     setGenderFilter((user.genderFilter as GenderFilter) ?? 'both');
-    setOriginFilter(user.originFilter ?? null);
+    setOriginFilter(user.originFilter?.length ? user.originFilter : null);
   }, [user]);
 
   // Refs track latest state so saveFilters can read current values

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -26,7 +26,12 @@ import { useEffectivePremium } from '@/hooks/use-effective-premium';
 import { Paywall } from '@/components/paywall';
 import { PartnerLinkModal } from '@/components/partner/partner-link-modal';
 import { NameConfirmationModal } from '@/components/partner/name-confirmation-modal';
-import { ThemePickerSection, SkinToneSection, VoiceSettingsSection } from '@/components/settings';
+import {
+  ThemePickerSection,
+  SkinToneSection,
+  VoiceSettingsSection,
+  FeedbackSection,
+} from '@/components/settings';
 import { GradientBackground } from '@/components/ui/gradient-background';
 import { GradientButton } from '@/components/ui/gradient-button';
 import { Fonts } from '@/constants/theme';
@@ -167,21 +172,6 @@ export default function Profile() {
     }
   }, [partnerInfo?.shareCode]);
 
-  const handlePartnerAction = useCallback(
-    (action: 'copy' | 'share' | 'link') => {
-      // Gate 1: Name confirmation check
-      if (convexUser?.nameConfirmed !== true) {
-        setPendingAction(action);
-        setShowNameConfirmation(true);
-        return;
-      }
-
-      // Gate 2: Execute action (backend enforces premium requirement for linking)
-      executePartnerAction(action);
-    },
-    [convexUser?.nameConfirmed, executePartnerAction],
-  );
-
   const executePartnerAction = useCallback(
     (action: 'copy' | 'share' | 'link') => {
       switch (action) {
@@ -197,6 +187,19 @@ export default function Profile() {
       }
     },
     [handleCopyCode, handleShareCode],
+  );
+
+  const handlePartnerAction = useCallback(
+    (action: 'copy' | 'share' | 'link') => {
+      if (convexUser?.nameConfirmed !== true) {
+        setPendingAction(action);
+        setShowNameConfirmation(true);
+        return;
+      }
+
+      executePartnerAction(action);
+    },
+    [convexUser?.nameConfirmed, executePartnerAction],
   );
 
   const handleNameConfirmed = useCallback(() => {
@@ -443,11 +446,16 @@ export default function Profile() {
         >
           <Text style={styles.sectionTitle}>Settings</Text>
           <ThemePickerSection />
-          <View style={{ height: 8 }} />
           <SkinToneSection />
-          <View style={{ height: 8 }} />
           <VoiceSettingsSection />
-          <View style={{ height: 8 }} />
+        </Animated.View>
+
+        {/* Other */}
+        <Animated.View
+          entering={FadeInUp.delay(250).duration(400).springify()}
+          style={styles.section}
+        >
+          <Text style={styles.sectionTitle}>Other</Text>
           <View style={styles.settingsCard}>
             <Pressable style={styles.settingsCardRow} onPress={resetOnboarding}>
               <Ionicons
@@ -460,14 +468,7 @@ export default function Profile() {
               <Ionicons name="chevron-forward" size={22} color="#A89BB5" />
             </Pressable>
           </View>
-        </Animated.View>
-
-        {/* Legal */}
-        <Animated.View
-          entering={FadeInUp.delay(250).duration(400).springify()}
-          style={styles.section}
-        >
-          <Text style={styles.sectionTitle}>Legal</Text>
+          <FeedbackSection />
           <View style={styles.settingsCard}>
             <Pressable
               style={styles.settingsCardRow}
@@ -487,7 +488,6 @@ export default function Profile() {
               <Ionicons name="chevron-forward" size={22} color="#A89BB5" />
             </Pressable>
           </View>
-          <View style={{ height: 8 }} />
           <View style={styles.settingsCard}>
             <Pressable
               style={styles.settingsCardRow}
@@ -704,7 +704,7 @@ const styles = StyleSheet.create({
   },
   /* Sections — matches filters.tsx pattern */
   section: {
-    gap: 12,
+    gap: 8,
     marginBottom: 24,
   },
   sectionTitle: {

--- a/components/settings/feedback-section.tsx
+++ b/components/settings/feedback-section.tsx
@@ -1,0 +1,229 @@
+import { useCallback, useState } from 'react';
+import { View, Text, Pressable, TextInput, StyleSheet } from 'react-native';
+import { useFocusEffect } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { useAction } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { Fonts } from '@/constants/theme';
+import { useTheme } from '@/contexts/theme-context';
+import { GradientButton } from '@/components/ui/gradient-button';
+
+const CATEGORIES = [
+  { key: 'bug' as const, label: 'Bug Report', icon: 'bug-outline' as const },
+  { key: 'feature' as const, label: 'Feature Request', icon: 'bulb-outline' as const },
+  { key: 'general' as const, label: 'General Feedback', icon: 'chatbubbles-outline' as const },
+];
+
+const PLACEHOLDERS: Record<string, string> = {
+  bug: 'What went wrong?',
+  feature: 'What would you like to see?',
+  general: 'Tell us what you think...',
+};
+
+type Category = 'bug' | 'feature' | 'general';
+
+export function FeedbackSection() {
+  const { colors } = useTheme();
+  const submitFeedback = useAction(api.feedback.submitFeedback);
+
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [category, setCategory] = useState<Category | null>(null);
+  const [message, setMessage] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useFocusEffect(
+    useCallback(() => {
+      return () => setIsExpanded(false);
+    }, []),
+  );
+
+  const handleSubmit = useCallback(async () => {
+    if (!category || !message.trim()) return;
+    setIsSubmitting(true);
+    setErrorMessage(null);
+    try {
+      await submitFeedback({ category, message: message.trim() });
+      setShowSuccess(true);
+      setTimeout(() => {
+        setShowSuccess(false);
+        setIsExpanded(false);
+        setCategory(null);
+        setMessage('');
+      }, 2000);
+    } catch {
+      setErrorMessage('Something went wrong. Try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [category, message, submitFeedback]);
+
+  return (
+    <View style={styles.container}>
+      <Pressable style={styles.headerRow} onPress={() => setIsExpanded(!isExpanded)}>
+        <Ionicons name="chatbubble-outline" size={22} color="#6B5B7B" style={{ marginRight: 12 }} />
+        <View style={styles.headerContent}>
+          <Text style={styles.headerTitle}>Share Feedback</Text>
+        </View>
+        <Ionicons name={isExpanded ? 'chevron-up' : 'chevron-down'} size={22} color="#A89BB5" />
+      </Pressable>
+
+      {isExpanded && (
+        <View style={styles.expandedContent}>
+          {showSuccess ? (
+            <View style={styles.successContainer}>
+              <Ionicons name="checkmark-circle" size={32} color={colors.primary} />
+              <Text style={styles.successText}>Thanks for your feedback!</Text>
+            </View>
+          ) : (
+            <>
+              <View style={styles.categoryRow}>
+                {CATEGORIES.map((cat) => {
+                  const isSelected = category === cat.key;
+                  return (
+                    <Pressable
+                      key={cat.key}
+                      style={[
+                        styles.categoryPill,
+                        {
+                          backgroundColor: isSelected ? colors.primary : colors.surface,
+                          borderColor: isSelected ? colors.primary : colors.border,
+                        },
+                      ]}
+                      onPress={() => setCategory(cat.key)}
+                      disabled={isSubmitting}
+                    >
+                      <Ionicons
+                        name={cat.icon}
+                        size={16}
+                        color={isSelected ? '#ffffff' : '#6B5B7B'}
+                      />
+                      <Text
+                        style={[
+                          styles.categoryLabel,
+                          { color: isSelected ? '#ffffff' : '#6B5B7B' },
+                        ]}
+                      >
+                        {cat.label}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+
+              <TextInput
+                style={[
+                  styles.textInput,
+                  {
+                    backgroundColor: colors.surfaceSubtle,
+                    borderColor: colors.border,
+                    opacity: category ? 1 : 0.4,
+                  },
+                ]}
+                multiline
+                numberOfLines={4}
+                textAlignVertical="top"
+                editable={category !== null && !isSubmitting}
+                placeholder={category ? PLACEHOLDERS[category] : 'Select a category first...'}
+                placeholderTextColor="#A89BB5"
+                value={message}
+                onChangeText={setMessage}
+              />
+
+              {category && (
+                <GradientButton
+                  title="Submit Feedback"
+                  onPress={handleSubmit}
+                  variant="primary"
+                  loading={isSubmitting}
+                  disabled={isSubmitting || message.trim().length === 0}
+                />
+              )}
+
+              {errorMessage && <Text style={styles.errorText}>{errorMessage}</Text>}
+            </>
+          )}
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#ffffff',
+    borderRadius: 16,
+    padding: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 2,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  headerContent: {
+    flex: 1,
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontFamily: Fonts?.sans,
+    fontWeight: '600',
+    color: '#2D1B4E',
+  },
+  expandedContent: {
+    marginTop: 16,
+  },
+  categoryRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 12,
+  },
+  categoryPill: {
+    flex: 1,
+    borderRadius: 10,
+    borderWidth: 1,
+    paddingVertical: 10,
+    paddingHorizontal: 8,
+    alignItems: 'center',
+    gap: 4,
+  },
+  categoryLabel: {
+    fontSize: 11,
+    fontFamily: Fonts?.sans,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  textInput: {
+    borderRadius: 12,
+    borderWidth: 1,
+    padding: 14,
+    fontSize: 15,
+    fontFamily: Fonts?.sans,
+    color: '#2D1B4E',
+    minHeight: 100,
+    marginBottom: 12,
+  },
+  successContainer: {
+    paddingVertical: 24,
+    alignItems: 'center',
+    gap: 8,
+  },
+  successText: {
+    fontSize: 16,
+    fontFamily: Fonts?.sans,
+    fontWeight: '600',
+    color: '#2D1B4E',
+  },
+  errorText: {
+    fontSize: 13,
+    fontFamily: Fonts?.sans,
+    color: '#FF6B6B',
+    textAlign: 'center',
+    marginTop: 8,
+  },
+});

--- a/components/settings/index.ts
+++ b/components/settings/index.ts
@@ -1,3 +1,4 @@
 export { ThemePickerSection } from './theme-picker-section';
 export { SkinToneSection } from './skin-tone-section';
 export { VoiceSettingsSection } from './voice-settings-section';
+export { FeedbackSection } from './feedback-section';

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -9,6 +9,7 @@
  */
 
 import type * as admin from "../admin.js";
+import type * as feedback from "../feedback.js";
 import type * as matches from "../matches.js";
 import type * as migrations from "../migrations.js";
 import type * as names from "../names.js";
@@ -26,6 +27,7 @@ import type {
 
 declare const fullApi: ApiFromModules<{
   admin: typeof admin;
+  feedback: typeof feedback;
   matches: typeof matches;
   migrations: typeof migrations;
   names: typeof names;

--- a/convex/feedback.ts
+++ b/convex/feedback.ts
@@ -1,0 +1,83 @@
+import { v } from 'convex/values';
+import { action } from './_generated/server';
+
+const CATEGORY_LABELS: Record<string, string> = {
+  bug: 'Bug Report',
+  feature: 'Feature Request',
+  general: 'General Feedback',
+};
+
+const CATEGORY_EMOJI: Record<string, string> = {
+  bug: ':bug:',
+  feature: ':bulb:',
+  general: ':speech_balloon:',
+};
+
+export const submitFeedback = action({
+  args: {
+    category: v.union(v.literal('bug'), v.literal('feature'), v.literal('general')),
+    message: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error('Not authenticated');
+    }
+
+    const trimmed = args.message.trim();
+    if (!trimmed) {
+      throw new Error('Message cannot be empty');
+    }
+
+    const webhookUrl = process.env.SLACK_FEEDBACK_WEBHOOK_URL;
+    if (!webhookUrl) {
+      throw new Error('Slack webhook URL not configured');
+    }
+
+    const label = CATEGORY_LABELS[args.category];
+    const emoji = CATEGORY_EMOJI[args.category];
+    const userName = identity.name ?? 'Unknown';
+    const userEmail = identity.email ?? 'No email';
+
+    const payload = {
+      blocks: [
+        {
+          type: 'header',
+          text: {
+            type: 'plain_text',
+            text: `${emoji} [${label}]`,
+            emoji: true,
+          },
+        },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: trimmed,
+          },
+        },
+        {
+          type: 'context',
+          elements: [
+            {
+              type: 'mrkdwn',
+              text: `*From:* ${userName} (${userEmail}) — ${new Date().toISOString()}`,
+            },
+          ],
+        },
+      ],
+    };
+
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to send feedback to Slack');
+    }
+
+    return { success: true };
+  },
+});


### PR DESCRIPTION
## Summary
- Enriched 11,444 baby names with origin, meaning, and phonetic data via Claude API
- Added in-app feedback form (bug report, feature request, general) that posts to Slack via webhook
- Added skin tone selection for emoji personalization
- Reorganized profile settings into Settings and Other sections
- Fixed origin filter treating empty array as truthy
- Fixed bubble pill animation reset on tab re-focus
- Added SSA name extraction and LLM enrichment scripts

## Test plan
- [ ] Verify feedback form submits and posts to Slack (requires `SLACK_FEEDBACK_WEBHOOK_URL` env var in Convex)
- [ ] Verify profile sections render correctly (Settings, Other)
- [ ] Verify origin filter works with no origins selected
- [ ] Verify swipe card animations reset when switching tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)