### PR TITLE
fix: only scroll meaning box when content overflows

### DIFF
--- a/components/swipe/swipe-card.tsx
+++ b/components/swipe/swipe-card.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useImperativeHandle, useEffect, useState, useRef, useCallback } from 'react';
-import { View, Text, StyleSheet, LayoutChangeEvent } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, LayoutChangeEvent } from 'react-native';
 import * as Speech from 'expo-speech';
 import Animated, {
   useAnimatedStyle,
@@ -463,7 +463,9 @@ export const SwipeCard = forwardRef<SwipeCardRef, SwipeCardProps>(function Swipe
                 isTop && meaningAnimatedStyle,
               ]}
             >
-              <Text style={styles.meaningText}>{name.meaning}</Text>
+              <ScrollView showsVerticalScrollIndicator nestedScrollEnabled bounces={false}>
+                <Text style={styles.meaningText}>{name.meaning}</Text>
+              </ScrollView>
             </Animated.View>
           )}
 
@@ -684,6 +686,8 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     padding: 16,
     marginBottom: 16,
+    flexShrink: 1,
+    minHeight: 0,
   },
   meaningText: {
     fontSize: 17,


### PR DESCRIPTION
## Summary
- Replace fixed `maxHeight: 140` on the meaning box with `flexShrink: 1` and `minHeight: 0`
- Short descriptions now display fully without scrolling
- Long descriptions shrink and scroll only when they would push the rank/trend tiles offscreen

## Test plan
- [ ] Swipe through names with short meanings — description should not scroll
- [ ] Swipe through names with long meanings — description scrolls only when needed
- [ ] Rank and 10 Year Trend tiles remain visible at the bottom in all cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>