### PR TITLE
Fix: reset match animation on tab focus and randomize swipe queue

### DIFF
--- a/app/(tabs)/matches.tsx
+++ b/app/(tabs)/matches.tsx
@@ -76,12 +76,14 @@ export default function Matches() {
 
   const lastSeenChosenId = useRef<string | null>(null);
 
-  // Clear search when returning to this tab
+  // Reset state when returning to this tab
+  const [focusCount, setFocusCount] = useState(0);
   useFocusEffect(
     useCallback(() => {
       trackScreen('Matches');
       setSearchInput('');
       setSubmittedSearch('');
+      setFocusCount((c) => c + 1);
     }, []),
   );
 
@@ -279,7 +281,7 @@ export default function Matches() {
                 ? 'Upgrade to connect with your partner and discover the baby names you both love.'
                 : 'Share your partner code and start discovering the names you both love. Matches appear when you both swipe right!'}
             </Text>
-            <MatchAnimation />
+            <MatchAnimation key={focusCount} />
             {isFreeUser && (
               <View style={styles.ctaContainer}>
                 <Pressable

--- a/components/swipe/swipe-card-stack.tsx
+++ b/components/swipe/swipe-card-stack.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useQuery, useMutation } from 'convex/react';
 import { useRouter } from 'expo-router';
@@ -18,9 +18,13 @@ export function SwipeCardStack() {
   const router = useRouter();
   const { colors } = useTheme();
 
+  // Stable random seed per mount — changes when component remounts (e.g. filter change)
+  const randomSeed = useMemo(() => Math.random(), []);
+
   // Fetch initial queue from backend
   const serverQueue = useQuery(api.selections.getSwipeQueue, {
     limit: 50,
+    randomSeed,
   });
 
   // Mutations

--- a/convex/names.ts
+++ b/convex/names.ts
@@ -35,6 +35,7 @@ export const seedNames = internalMutation({
         phonetic: nameData.phonetic,
         length: nameData.name.length,
         firstLetter: nameData.name[0].toUpperCase(),
+        sortKey: Math.random(),
         createdAt: now,
       });
       inserted++;
@@ -174,5 +175,31 @@ export const searchNames = query({
     }
 
     return results.slice(0, limit);
+  },
+});
+
+export const backfillSortKeys = internalMutation({
+  args: {
+    cursor: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const BATCH_SIZE = 500;
+    const results = await ctx.db
+      .query('names')
+      .paginate({ numItems: BATCH_SIZE, cursor: args.cursor ?? null });
+
+    let patched = 0;
+    for (const name of results.page) {
+      if (name.sortKey === undefined) {
+        await ctx.db.patch(name._id, { sortKey: Math.random() });
+        patched++;
+      }
+    }
+
+    return {
+      patched,
+      isDone: results.isDone,
+      cursor: results.continueCursor,
+    };
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -33,6 +33,7 @@ export default defineSchema({
     firstLetter: v.string(),
     currentRank: v.optional(v.number()),
     primaryGender: v.optional(v.union(v.literal('male'), v.literal('female'))),
+    sortKey: v.optional(v.number()),
     createdAt: v.number(),
   })
     .index('by_name', ['name'])
@@ -40,7 +41,9 @@ export default defineSchema({
     .index('by_first_letter', ['firstLetter'])
     .index('by_gender_and_first_letter', ['gender', 'firstLetter'])
     .index('by_origin', ['origin'])
-    .index('by_gender_origin', ['gender', 'origin']),
+    .index('by_gender_origin', ['gender', 'origin'])
+    .index('by_sort_key', ['sortKey'])
+    .index('by_gender_sort_key', ['gender', 'sortKey']),
 
   namePopularity: defineTable({
     name: v.string(),

--- a/convex/selections.ts
+++ b/convex/selections.ts
@@ -183,6 +183,7 @@ export const recordSelection = mutation({
 export const getSwipeQueue = query({
   args: {
     limit: v.optional(v.number()),
+    randomSeed: v.number(),
   },
   handler: async (ctx, args) => {
     const user = await getCurrentUserOrNull(ctx);
@@ -200,33 +201,36 @@ export const getSwipeQueue = query({
     const genderFilter = user.genderFilter ?? 'both';
     const originFilter = user.originFilter;
     const genderValue = genderFilter === 'boy' ? 'male' : genderFilter === 'girl' ? 'female' : null;
-    const singleOrigin = originFilter && originFilter.length === 1 ? originFilter[0] : null;
+    const originSet = originFilter && originFilter.length > 0 ? new Set(originFilter) : null;
 
-    let namesQuery;
-    if (genderValue && singleOrigin) {
-      namesQuery = ctx.db
-        .query('names')
-        .withIndex('by_gender_origin', (q) =>
-          q.eq('gender', genderValue).eq('origin', singleOrigin),
-        );
-    } else if (genderValue) {
-      namesQuery = ctx.db.query('names').withIndex('by_gender', (q) => q.eq('gender', genderValue));
-    } else if (singleOrigin) {
-      namesQuery = ctx.db
-        .query('names')
-        .withIndex('by_origin', (q) => q.eq('origin', singleOrigin));
-    } else {
-      namesQuery = ctx.db.query('names');
-    }
+    const buildQuery = (startKey: number) =>
+      genderValue !== null
+        ? ctx.db
+            .query('names')
+            .withIndex('by_gender_sort_key', (q) =>
+              q.eq('gender', genderValue).gte('sortKey', startKey),
+            )
+        : ctx.db.query('names').withIndex('by_sort_key', (q) => q.gte('sortKey', startKey));
 
-    const originSet = originFilter && originFilter.length > 1 ? new Set(originFilter) : null;
     const results: Doc<'names'>[] = [];
 
-    for await (const name of namesQuery) {
+    // First pass: from randomSeed to end
+    for await (const name of buildQuery(args.randomSeed)) {
       if (results.length >= limit) break;
       if (swipedNameIds.has(name._id)) continue;
       if (originSet && !originSet.has(name.origin)) continue;
       results.push(name);
+    }
+
+    // Wrap around: from 0 to randomSeed if we need more
+    if (results.length < limit) {
+      for await (const name of buildQuery(0)) {
+        if (results.length >= limit) break;
+        if (name.sortKey !== undefined && name.sortKey >= args.randomSeed) break;
+        if (swipedNameIds.has(name._id)) continue;
+        if (originSet && !originSet.has(name.origin)) continue;
+        results.push(name);
+      }
     }
 
     return results;


### PR DESCRIPTION
## Summary
- Reset the `MatchAnimation` component each time the Matches tab regains focus, so the animation always starts from the beginning instead of continuing mid-loop
- Randomize swipe queue order using a `sortKey` field on names with wraparound index scanning, so users see names in a different shuffled order each session
- Add `backfillSortKeys` migration to populate `sortKey` on existing names

## Test plan
- [ ] Navigate to Matches tab (empty state), observe animation starts from beginning
- [ ] Switch to another tab and back — animation restarts cleanly
- [ ] Swipe through names on Explore tab — names appear in randomized order
- [ ] Change filters and return — new random seed produces different order
- [ ] Run `backfillSortKeys` migration on dev to populate existing names

🤖 Generated with [Claude Code](https://claude.com/claude-code)