### PR TITLE
fix: add sortKey to names schema and randomize swipe order

### DIFF
--- a/convex/names.ts
+++ b/convex/names.ts
@@ -35,6 +35,7 @@ export const seedNames = internalMutation({
         phonetic: nameData.phonetic,
         length: nameData.name.length,
         firstLetter: nameData.name[0].toUpperCase(),
+        sortKey: Math.random(),
         createdAt: now,
       });
       inserted++;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -33,6 +33,7 @@ export default defineSchema({
     firstLetter: v.string(),
     currentRank: v.optional(v.number()),
     primaryGender: v.optional(v.union(v.literal('male'), v.literal('female'))),
+    sortKey: v.number(),
     createdAt: v.number(),
   })
     .index('by_name', ['name'])
@@ -40,7 +41,8 @@ export default defineSchema({
     .index('by_first_letter', ['firstLetter'])
     .index('by_gender_and_first_letter', ['gender', 'firstLetter'])
     .index('by_origin', ['origin'])
-    .index('by_gender_origin', ['gender', 'origin']),
+    .index('by_gender_origin', ['gender', 'origin'])
+    .index('by_sort_key', ['sortKey']),
 
   namePopularity: defineTable({
     name: v.string(),

--- a/convex/selections.ts
+++ b/convex/selections.ts
@@ -200,31 +200,13 @@ export const getSwipeQueue = query({
     const genderFilter = user.genderFilter ?? 'both';
     const originFilter = user.originFilter;
     const genderValue = genderFilter === 'boy' ? 'male' : genderFilter === 'girl' ? 'female' : null;
-    const singleOrigin = originFilter && originFilter.length === 1 ? originFilter[0] : null;
-
-    let namesQuery;
-    if (genderValue && singleOrigin) {
-      namesQuery = ctx.db
-        .query('names')
-        .withIndex('by_gender_origin', (q) =>
-          q.eq('gender', genderValue).eq('origin', singleOrigin),
-        );
-    } else if (genderValue) {
-      namesQuery = ctx.db.query('names').withIndex('by_gender', (q) => q.eq('gender', genderValue));
-    } else if (singleOrigin) {
-      namesQuery = ctx.db
-        .query('names')
-        .withIndex('by_origin', (q) => q.eq('origin', singleOrigin));
-    } else {
-      namesQuery = ctx.db.query('names');
-    }
-
-    const originSet = originFilter && originFilter.length > 1 ? new Set(originFilter) : null;
+    const originSet = originFilter && originFilter.length > 0 ? new Set(originFilter) : null;
     const results: Doc<'names'>[] = [];
 
-    for await (const name of namesQuery) {
+    for await (const name of ctx.db.query('names').withIndex('by_sort_key')) {
       if (results.length >= limit) break;
       if (swipedNameIds.has(name._id)) continue;
+      if (genderValue && name.gender !== genderValue) continue;
       if (originSet && !originSet.has(name.origin)) continue;
       results.push(name);
     }


### PR DESCRIPTION
## Summary
- Adds the `sortKey` field to the `names` table schema (was present in DB documents but missing from the schema validator, causing validation errors)
- Adds `by_sort_key` index for efficient ordered scanning
- Updates `getSwipeQueue` to scan names by `sortKey` for randomized presentation order instead of default insertion order
- `seedNames` now sets `sortKey: Math.random()` on new inserts

## Test plan
- [x] Lint passes on all changed files
- [ ] Verify schema validation error no longer occurs when navigating to Search tab
- [ ] Verify swipe queue shows names in randomized order
- [ ] Verify gender and origin filters still work correctly