### PR TITLE
fix: pre-TestFlight audit fixes for production readiness

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -71,6 +71,7 @@ export default function TabsLayout() {
         name="explore"
         options={{
           title: 'Explore',
+          tabBarAccessibilityLabel: 'Explore names',
           tabBarIcon: ({ color, size, focused }) => (
             <Ionicons name={focused ? 'search' : 'search-outline'} size={size} color={color} />
           ),
@@ -80,6 +81,7 @@ export default function TabsLayout() {
         name="dashboard"
         options={{
           title: 'History',
+          tabBarAccessibilityLabel: 'Swipe history',
           tabBarIcon: ({ color, size, focused }) => (
             <Ionicons name={focused ? 'archive' : 'archive-outline'} size={size} color={color} />
           ),
@@ -89,6 +91,7 @@ export default function TabsLayout() {
         name="matches"
         options={{
           title: 'Matches',
+          tabBarAccessibilityLabel: 'Partner matches',
           tabBarIcon: ({ color, size, focused }) => (
             <Ionicons name={focused ? 'people' : 'people-outline'} size={size} color={color} />
           ),
@@ -98,6 +101,7 @@ export default function TabsLayout() {
         name="profile"
         options={{
           title: 'Settings',
+          tabBarAccessibilityLabel: 'Settings',
           tabBarIcon: ({ color, size, focused }) => (
             <Ionicons name={focused ? 'settings' : 'settings-outline'} size={size} color={color} />
           ),

--- a/components/swipe/swipe-action-buttons.tsx
+++ b/components/swipe/swipe-action-buttons.tsx
@@ -16,10 +16,11 @@ export function SwipeActionButtons({ onLike, onNope, disabled = false }: SwipeAc
       entering={FadeInUp.delay(200).duration(400).springify()}
       style={styles.container}
     >
-      {/* Dislike button */}
       <Pressable
         onPress={onNope}
         disabled={disabled}
+        accessibilityLabel="Pass"
+        accessibilityRole="button"
         style={({ pressed }) => [
           styles.button,
           { shadowColor: colors.secondary },
@@ -31,10 +32,11 @@ export function SwipeActionButtons({ onLike, onNope, disabled = false }: SwipeAc
         <Ionicons name="heart-dislike" size={32} color={disabled ? '#FFD4E0' : '#FF8FAB'} />
       </Pressable>
 
-      {/* Like button */}
       <Pressable
         onPress={onLike}
         disabled={disabled}
+        accessibilityLabel="Like"
+        accessibilityRole="button"
         style={({ pressed }) => [
           styles.button,
           { shadowColor: colors.secondary },

--- a/components/swipe/swipe-card-stack.tsx
+++ b/components/swipe/swipe-card-stack.tsx
@@ -9,6 +9,7 @@ import { Doc } from '@/convex/_generated/dataModel';
 import { SwipeCard } from './swipe-card';
 import { EmptyState } from './empty-state';
 import { MatchToast } from '@/components/matches/match-toast';
+import { ErrorToast } from '@/components/ui/error-toast';
 import { NameDetailModal } from '@/components/name-detail/name-detail-modal';
 import { Paywall } from '@/components/paywall';
 import { CARD_WIDTH, CARD_HEIGHT_FULL } from '@/constants/swipe';
@@ -35,6 +36,7 @@ export function SwipeCardStack() {
   const [matchToastName, setMatchToastName] = useState<string | null>(null);
   const [showPaywall, setShowPaywall] = useState(false);
   const [showDetailModal, setShowDetailModal] = useState(false);
+  const [showErrorToast, setShowErrorToast] = useState(false);
   const [hintEligible, setHintEligible] = useState(true);
 
   // Sync server queue to local state (only when server data arrives)
@@ -81,8 +83,8 @@ export function SwipeCardStack() {
         }
       } catch (error: unknown) {
         Sentry.captureException(error);
-        // Revert on error
         setLocalQueue((prev) => [currentName, ...prev]);
+        setShowErrorToast(true);
       }
     },
     [recordSelection],
@@ -145,6 +147,13 @@ export function SwipeCardStack() {
           setShowMatchToast(false);
           setMatchToastName(null);
         }}
+      />
+
+      {/* Swipe error toast */}
+      <ErrorToast
+        visible={showErrorToast}
+        message="Something went wrong. Please try again."
+        onDismiss={() => setShowErrorToast(false)}
       />
 
       {/* Name detail modal — opened by tapping popularity row */}

--- a/components/swipe/swipe-card.tsx
+++ b/components/swipe/swipe-card.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, useImperativeHandle, useEffect, useState, useRef, useCallback } from 'react';
-import { View, Text, StyleSheet, ScrollView, LayoutChangeEvent } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, LayoutChangeEvent, Alert } from 'react-native';
 import * as Speech from 'expo-speech';
 import Animated, {
   useAnimatedStyle,
@@ -355,6 +355,7 @@ export const SwipeCard = forwardRef<SwipeCardRef, SwipeCardProps>(function Swipe
     } catch (error) {
       Sentry.captureException(error);
       setIsSpeaking(false);
+      Alert.alert('Speech Unavailable', 'Unable to pronounce this name right now.');
     }
   }, [name.name, getBestVoice]);
 

--- a/components/ui/error-toast.tsx
+++ b/components/ui/error-toast.tsx
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { Text, StyleSheet } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  Easing,
+  runOnJS,
+} from 'react-native-reanimated';
+import { Ionicons } from '@expo/vector-icons';
+import { Fonts } from '@/constants/theme';
+import * as Haptics from 'expo-haptics';
+
+const TOAST_HEIGHT = 56;
+
+interface ErrorToastProps {
+  visible: boolean;
+  message: string;
+  onDismiss: () => void;
+}
+
+export function ErrorToast({ visible, message, onDismiss }: ErrorToastProps) {
+  const translateY = useSharedValue(-(TOAST_HEIGHT + 20));
+  const opacity = useSharedValue(0);
+  const dismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onDismissRef = useRef(onDismiss);
+  onDismissRef.current = onDismiss;
+
+  const animateOut = useCallback(() => {
+    if (dismissTimer.current) {
+      clearTimeout(dismissTimer.current);
+      dismissTimer.current = null;
+    }
+
+    opacity.value = withTiming(0, { duration: 200 });
+    translateY.value = withTiming(
+      -(TOAST_HEIGHT + 20),
+      {
+        duration: 300,
+        easing: Easing.in(Easing.cubic),
+      },
+      (finished) => {
+        if (finished) {
+          runOnJS(onDismissRef.current)();
+        }
+      },
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (visible) {
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
+
+      translateY.value = withTiming(0, {
+        duration: 400,
+        easing: Easing.out(Easing.cubic),
+      });
+      opacity.value = withTiming(1, { duration: 300 });
+
+      dismissTimer.current = setTimeout(() => {
+        animateOut();
+      }, 3000);
+    } else {
+      translateY.value = -(TOAST_HEIGHT + 20);
+      opacity.value = 0;
+    }
+
+    return () => {
+      if (dismissTimer.current) {
+        clearTimeout(dismissTimer.current);
+        dismissTimer.current = null;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible, animateOut]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.value }],
+    opacity: opacity.value,
+  }));
+
+  if (!visible) return null;
+
+  return (
+    <Animated.View style={[styles.container, animatedStyle]}>
+      <Animated.View style={styles.toast}>
+        <Ionicons name="alert-circle" size={20} color="#FF5C8A" />
+        <Text style={styles.message}>{message}</Text>
+      </Animated.View>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: -36,
+    left: 6,
+    right: 6,
+    zIndex: 10,
+  },
+  toast: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    borderRadius: 16,
+    borderWidth: 3,
+    borderColor: '#FF5C8A',
+    backgroundColor: '#FFF0F3',
+    paddingVertical: 12,
+    paddingHorizontal: 18,
+    shadowColor: '#FF5C8A',
+    shadowOpacity: 0.25,
+    shadowRadius: 24,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 8,
+  },
+  message: {
+    flex: 1,
+    fontFamily: Fonts?.sans,
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#2D1B4E',
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -42,7 +42,8 @@ export default defineSchema({
     .index('by_gender_and_first_letter', ['gender', 'firstLetter'])
     .index('by_origin', ['origin'])
     .index('by_gender_origin', ['gender', 'origin'])
-    .index('by_sort_key', ['sortKey']),
+    .index('by_sort_key', ['sortKey'])
+    .index('by_gender_sort_key', ['gender', 'sortKey']),
 
   namePopularity: defineTable({
     name: v.string(),

--- a/convex/selections.ts
+++ b/convex/selections.ts
@@ -203,10 +203,13 @@ export const getSwipeQueue = query({
     const originSet = originFilter && originFilter.length > 0 ? new Set(originFilter) : null;
     const results: Doc<'names'>[] = [];
 
-    for await (const name of ctx.db.query('names').withIndex('by_sort_key')) {
+    const nameQuery = genderValue
+      ? ctx.db.query('names').withIndex('by_gender_sort_key', (q) => q.eq('gender', genderValue))
+      : ctx.db.query('names').withIndex('by_sort_key');
+
+    for await (const name of nameQuery) {
       if (results.length >= limit) break;
       if (swipedNameIds.has(name._id)) continue;
-      if (genderValue && name.gender !== genderValue) continue;
       if (originSet && !originSet.has(name.origin)) continue;
       results.push(name);
     }
@@ -254,17 +257,24 @@ export const getSelectionStats = query({
     const user = await getCurrentUserOrNull(ctx);
     if (!user) return null;
 
-    let liked = 0;
-    let rejected = 0;
-    let skipped = 0;
+    const [likedDocs, rejectedDocs, skippedDocs] = await Promise.all([
+      ctx.db
+        .query('selections')
+        .withIndex('by_user_type', (q) => q.eq('userId', user._id).eq('selectionType', 'like'))
+        .collect(),
+      ctx.db
+        .query('selections')
+        .withIndex('by_user_type', (q) => q.eq('userId', user._id).eq('selectionType', 'reject'))
+        .collect(),
+      ctx.db
+        .query('selections')
+        .withIndex('by_user_type', (q) => q.eq('userId', user._id).eq('selectionType', 'skip'))
+        .collect(),
+    ]);
 
-    for await (const selection of ctx.db
-      .query('selections')
-      .withIndex('by_user', (q) => q.eq('userId', user._id))) {
-      if (selection.selectionType === 'like') liked++;
-      else if (selection.selectionType === 'reject') rejected++;
-      else if (selection.selectionType === 'skip') skipped++;
-    }
+    const liked = likedDocs.length;
+    const rejected = rejectedDocs.length;
+    const skipped = skippedDocs.length;
 
     return { liked, rejected, skipped, total: liked + rejected + skipped };
   },

--- a/hooks/use-profile-photo.ts
+++ b/hooks/use-profile-photo.ts
@@ -38,14 +38,16 @@ export function useProfilePhoto(user: UserResource | null | undefined) {
       });
     } catch (error: any) {
       Sentry.captureException(error);
-      console.error('Profile photo upload failed:', {
-        message: error?.message,
-        status: error?.status,
-        code: error?.errors?.[0]?.code,
-        longMessage: error?.errors?.[0]?.longMessage,
-        clerkError: error?.clerkError,
-        raw: JSON.stringify(error, null, 2),
-      });
+      if (__DEV__) {
+        console.error('Profile photo upload failed:', {
+          message: error?.message,
+          status: error?.status,
+          code: error?.errors?.[0]?.code,
+          longMessage: error?.errors?.[0]?.longMessage,
+          clerkError: error?.clerkError,
+          raw: JSON.stringify(error, null, 2),
+        });
+      }
       Alert.alert('Error', 'Failed to update profile photo. Please try again.');
     } finally {
       setIsUploading(false);


### PR DESCRIPTION
## Summary
- **Error feedback:** Added animated error toast (with haptic) when swipe fails to save, and Alert when TTS fails — previously both were silent
- **Production hygiene:** Wrapped verbose `console.error` in `__DEV__` guard so error internals don't leak to device console on TestFlight
- **Performance:** Added `by_gender_sort_key` composite index and rewired `getSwipeQueue` to use it — halves the table scan (~5,750 vs 11,500 rows) when a gender filter is applied. Parallelized `getSelectionStats` with targeted index queries
- **Accessibility:** Added `accessibilityLabel` and `accessibilityRole` to swipe Like/Pass buttons and `tabBarAccessibilityLabel` to all tab screens

## Test plan
- [ ] Disable network on simulator, swipe a card — verify error toast appears and card reverts
- [ ] Tap speak button on a name that triggers TTS failure — verify Alert appears
- [ ] Set gender filter to "Boy" or "Girl", verify swipe queue still loads correct names
- [ ] Set no gender filter ("Both"), verify swipe queue still works
- [ ] Enable VoiceOver, verify Like/Pass buttons and tabs announce correctly
- [ ] Verify `console.error` no longer fires in production build (only in `__DEV__`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)