### PR TITLE
chore: configure bundle identifiers and Apple submit credentials for TestFlight

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,7 +10,11 @@
     "newArchEnabled": true,
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.bambino.app"
+      "bundleIdentifier": "xyz.bambinobaby.app",
+      "infoPlist": {
+        "NSPhotoLibraryUsageDescription": "Bambino uses your photo library so you can choose a profile photo.",
+        "ITSAppUsesNonExemptEncryption": false
+      }
     },
     "android": {
       "adaptiveIcon": {
@@ -21,7 +25,7 @@
       },
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
-      "package": "com.bambino.app"
+      "package": "xyz.bambinobaby.app"
     },
     "web": {
       "output": "static",

--- a/eas.json
+++ b/eas.json
@@ -35,9 +35,9 @@
   "submit": {
     "production": {
       "ios": {
-        "appleId": "",
-        "ascAppId": "",
-        "appleTeamId": ""
+        "appleId": "george.fair@icloud.com",
+        "ascAppId": "6773164657",
+        "appleTeamId": "788KCHBRB8"
       }
     }
   }


### PR DESCRIPTION
## Summary
- Change iOS bundle ID and Android package to `xyz.bambinobaby.app`
- Add `NSPhotoLibraryUsageDescription` for the profile photo picker
- Set `ITSAppUsesNonExemptEncryption: false` to skip the export compliance prompt
- Populate Apple submit credentials in `eas.json` (appleId, ascAppId, appleTeamId)

Prep work for TestFlight submission.

## Test plan
- [ ] `npx expo prebuild --clean` succeeds with new bundle ID
- [ ] EAS production build picks up new identifiers
- [ ] `eas submit -p ios` uses the configured Apple credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)