### PR TITLE
chore: add --prod flag to seed scripts for production seeding

### DIFF
--- a/scripts/seed-names.ts
+++ b/scripts/seed-names.ts
@@ -7,7 +7,11 @@ import namesData from '../data/names.json';
 const BATCH_SIZE = 100;
 
 async function seedNames() {
+  const isProd = process.argv.includes('--prod');
+  const convexFlag = isProd ? '--prod ' : '';
+
   console.log(`Starting seed with ${namesData.length} names...`);
+  console.log(`Target: ${isProd ? 'PRODUCTION' : 'dev (from .env.local)'}`);
   console.log(`Batch size: ${BATCH_SIZE}`);
 
   let totalInserted = 0;
@@ -24,7 +28,7 @@ async function seedNames() {
 
     try {
       writeFileSync(tmpFile, JSON.stringify({ names: batch }));
-      const output = execSync(`npx convex run names:seedNames "$(cat ${tmpFile})"`, {
+      const output = execSync(`npx convex run ${convexFlag}names:seedNames "$(cat ${tmpFile})"`, {
         encoding: 'utf-8',
         cwd: process.cwd(),
       });

--- a/scripts/seed-popularity.ts
+++ b/scripts/seed-popularity.ts
@@ -43,7 +43,11 @@ async function seedPopularity() {
   const startBatch = startBatchArg ? parseInt(startBatchArg.split('=')[1], 10) : 1;
   const startIndex = (startBatch - 1) * BATCH_SIZE;
 
+  const isProd = process.argv.includes('--prod');
+  const convexFlag = isProd ? '--prod ' : '';
+
   console.log(`Starting seed with ${records.length} popularity records...`);
+  console.log(`Target: ${isProd ? 'PRODUCTION' : 'dev (from .env.local)'}`);
   console.log(`Batch size: ${BATCH_SIZE}, starting from batch ${startBatch}/${totalBatches}`);
 
   let totalInserted = 0;
@@ -60,7 +64,7 @@ async function seedPopularity() {
     try {
       writeFileSync(tmpFile, JSON.stringify({ records: batch }));
       const output = runWithRetry(
-        `npx convex run popularity:seedPopularity "$(cat ${tmpFile})"`,
+        `npx convex run ${convexFlag}popularity:seedPopularity "$(cat ${tmpFile})"`,
         batchNumber,
       );
       const parsed = JSON.parse(output.trim());


### PR DESCRIPTION
## Summary
- Add `--prod` flag handling to `seed-names.ts` and `seed-popularity.ts`
- When `--prod` is passed, prepend `--prod` to the `npx convex run` invocation so the script targets the production deployment instead of dev
- Log which environment is being targeted at the start of each run

## Test plan
- [ ] `npm run seed:names` still seeds dev (default behaviour unchanged)
- [ ] `npm run seed:names -- --prod` runs against production and prints `Target: PRODUCTION`
- [ ] Same for `seed:popularity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)