### PR TITLE
refactor: extract RevenueCat entitlement ID to shared constant

### DIFF
--- a/constants/purchases.ts
+++ b/constants/purchases.ts
@@ -1,0 +1,1 @@
+export const ENTITLEMENT_ID = 'premium';

--- a/hooks/use-purchases.ts
+++ b/hooks/use-purchases.ts
@@ -4,9 +4,9 @@ import Purchases, { PurchasesPackage, CustomerInfo, LOG_LEVEL } from 'react-nati
 import { useMutation } from 'convex/react';
 import * as Sentry from '@sentry/react-native';
 import { api } from '@/convex/_generated/api';
+import { ENTITLEMENT_ID } from '@/constants/purchases';
 
 const REVENUECAT_API_KEY = process.env.EXPO_PUBLIC_REVENUECAT_API_KEY ?? '';
-const ENTITLEMENT_ID = 'premium';
 
 let isConfigured = false;
 


### PR DESCRIPTION
## Summary
- Extract the `'premium'` entitlement ID from `hooks/use-purchases.ts` into a new shared constant at `constants/purchases.ts` so it can be reused and updated in one place.

Phase 7 (RevenueCat productionization) — minimal scope. Live App Store-formatted prices already render via `packages[0]?.product.priceString` once offerings load, so the `$4.99` paywall fallback is left as-is.

## Test plan
- [ ] App boots without runtime errors
- [ ] Paywall renders the entitlement check correctly (still sees `premium` entitlement)
- [ ] Purchase, restore, and entitlement detection unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)