### PR TITLE
feat: add Apple Sign-In to auth screens

### DIFF
--- a/app.json
+++ b/app.json
@@ -11,6 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "xyz.bambinobaby.app",
+      "usesAppleSignIn": true,
       "infoPlist": {
         "NSPhotoLibraryUsageDescription": "Bambino uses your photo library so you can choose a profile photo.",
         "ITSAppUsesNonExemptEncryption": false
@@ -48,6 +49,7 @@
       "expo-secure-store",
       "expo-web-browser",
       "expo-notifications",
+      "expo-apple-authentication",
       [
         "@sentry/react-native/expo",
         {

--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -140,6 +140,26 @@ export default function SignIn() {
     }
   }, [startSSOFlow, router]);
 
+  const handleAppleSignIn = useCallback(async () => {
+    setIsLoading(true);
+    setError('');
+
+    try {
+      const { createdSessionId, setActive: ssoSetActive } = await startSSOFlow({
+        strategy: 'oauth_apple',
+      });
+
+      if (createdSessionId && ssoSetActive) {
+        await ssoSetActive({ session: createdSessionId });
+        router.replace('/');
+      }
+    } catch (err: unknown) {
+      setError(getClerkError(err, 'Apple sign in failed'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [startSSOFlow, router]);
+
   return (
     <GradientBackground variant="auth">
       <View className="flex-1 justify-center px-8">
@@ -209,7 +229,7 @@ export default function SignIn() {
               <View className="h-px flex-1 bg-gray-300" />
             </Animated.View>
 
-            <Animated.View entering={FadeInUp.delay(500).duration(400).springify()} className="mb-6">
+            <Animated.View entering={FadeInUp.delay(500).duration(400).springify()} className="mb-4">
               <GradientButton
                 title="Continue with Google"
                 onPress={handleGoogleSignIn}
@@ -219,8 +239,18 @@ export default function SignIn() {
               />
             </Animated.View>
 
+            <Animated.View entering={FadeInUp.delay(600).duration(400).springify()} className="mb-6">
+              <GradientButton
+                title="Continue with Apple"
+                onPress={handleAppleSignIn}
+                variant="secondary"
+                icon="logo-apple"
+                disabled={isLoading}
+              />
+            </Animated.View>
+
             <Animated.View
-              entering={FadeInUp.delay(600).duration(400)}
+              entering={FadeInUp.delay(700).duration(400)}
               className="flex-row justify-center"
             >
               <Text className="text-gray-600">Don&apos;t have an account? </Text>

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -93,6 +93,28 @@ export default function SignUp() {
     }
   }, [startSSOFlow, router]);
 
+  const handleAppleSignUp = useCallback(async () => {
+    setIsLoading(true);
+    setError('');
+
+    try {
+      const { createdSessionId, setActive: ssoSetActive } = await startSSOFlow({
+        strategy: 'oauth_apple',
+      });
+
+      if (createdSessionId && ssoSetActive) {
+        await ssoSetActive({ session: createdSessionId });
+        trackEvent(Events.SIGN_UP, { method: 'apple' });
+        router.replace('/');
+      }
+    } catch (err: unknown) {
+      const clerkError = err as { errors?: { message: string }[] };
+      setError(clerkError.errors?.[0]?.message || 'Apple sign up failed');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [startSSOFlow, router]);
+
   if (pendingVerification) {
     return (
       <GradientBackground variant="auth">
@@ -224,7 +246,7 @@ export default function SignUp() {
           <View className="h-px flex-1 bg-gray-300" />
         </Animated.View>
 
-        <Animated.View entering={FadeInUp.delay(500).duration(400).springify()} className="mb-6">
+        <Animated.View entering={FadeInUp.delay(500).duration(400).springify()} className="mb-4">
           <GradientButton
             title="Continue with Google"
             onPress={handleGoogleSignUp}
@@ -234,8 +256,18 @@ export default function SignUp() {
           />
         </Animated.View>
 
+        <Animated.View entering={FadeInUp.delay(600).duration(400).springify()} className="mb-6">
+          <GradientButton
+            title="Continue with Apple"
+            onPress={handleAppleSignUp}
+            variant="secondary"
+            icon="logo-apple"
+            disabled={isLoading}
+          />
+        </Animated.View>
+
         <Animated.View
-          entering={FadeInUp.delay(600).duration(400)}
+          entering={FadeInUp.delay(700).duration(400)}
           className="flex-row justify-center"
         >
           <Text className="text-gray-600">Already have an account? </Text>

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@sentry/react-native": "~7.2.0",
         "convex": "^1.31.7",
         "expo": "~54.0.33",
+        "expo-apple-authentication": "~8.0.8",
         "expo-blur": "~15.0.8",
         "expo-clipboard": "~8.0.8",
         "expo-constants": "~18.0.10",
@@ -8376,6 +8377,16 @@
         "react-native-webview": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-apple-authentication": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/expo-apple-authentication/-/expo-apple-authentication-8.0.8.tgz",
+      "integrity": "sha512-TwCHWXYR1kS0zaeV7QZKLWYluxsvqL31LFJubzK30njZqeWoWO89HZ8nZVaeXbFV1LrArKsze4BmMb+94wS0AQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-application": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@sentry/react-native": "~7.2.0",
     "convex": "^1.31.7",
     "expo": "~54.0.33",
+    "expo-apple-authentication": "~8.0.8",
     "expo-blur": "~15.0.8",
     "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.10",


### PR DESCRIPTION
## Summary
- Wire up Clerk's `oauth_apple` SSO strategy on sign-in and sign-up screens
- Add styled "Continue with Apple" button matching the existing Google option
- Required by Apple Guideline 4.8 since the app offers Google SSO

## Test plan
- [ ] TestFlight build installs and launches
- [ ] Tap "Continue with Apple" on sign-up → completes Apple SSO flow → lands in app
- [ ] Tap "Continue with Apple" on sign-in → completes Apple SSO flow → lands in app
- [ ] PostHog event `sign_up` with `method: 'apple'` fires on first Apple sign-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)