### PR TITLE
ci: bump Node from 20 to 22 in EAS workflows

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Setup EAS

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Setup EAS


### PR DESCRIPTION
## Summary
Node 20's bundled npm 10 was failing `npm ci` with a lockfile-sync error after the Clerk bump (#69) — Node 22 ships npm 10.9 which handles the new transitive Clerk subdep cleanly. Also clears the Node 20 deprecation warning GitHub Actions surfaces on every run.

## Test plan
- [ ] Merge → `dev-build.yml` re-triggers and `npm ci` succeeds
- [ ] EAS build kicks off

🤖 Generated with [Claude Code](https://claude.com/claude-code)