### PR TITLE
ci: ignore Expo SDK majors and React minor/major in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,23 @@ updates:
     versioning-strategy: increase
     allow:
       - dependency-type: direct
+    # Expo SDK packages are version-locked to the active SDK release.
+    # Major bumps must be done as a coordinated SDK upgrade, not piecemeal.
+    ignore:
+      - dependency-name: "expo"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "expo-*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@expo/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-native"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # RevenueCat is parked until build 2 (Path A).
+      - dependency-name: "react-native-purchases"
     groups:
       security-updates:
         applies-to: security-updates


### PR DESCRIPTION
## Summary
Stops Dependabot from opening unsafe PRs that would break the Expo SDK 54 build:
- `expo` / `expo-*` / `@expo/*` major bumps (SDK upgrade, not auto-merge)
- `react` / `react-dom` minor + major (Expo SDK pins react 19.1.0)
- `react-native` major
- `react-native-purchases` (RevenueCat parked until build 2)

PRs already closed: #83 (expo-notifications 0→56), #84 (expo 54→56), #85 (expo-symbols 1→56), #87 (react-native-purchases 9→10).

## Test plan
- [ ] Future Dependabot runs no longer open PRs for ignored bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)