### PR TITLE
ci: broaden Dependabot ignore rules to silence noisy major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,25 @@ updates:
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
       # RevenueCat is parked until build 2 (Path A).
       - dependency-name: "react-native-purchases"
+      # Dev tooling — major bumps need deliberate review/migration.
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint-config-expo"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "tailwindcss"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "prettier-plugin-tailwindcss"
+        update-types: ["version-update:semver-major"]
+      # Sentry SDK majors require migration steps.
+      - dependency-name: "@sentry/react-native"
+        update-types: ["version-update:semver-major"]
+      # Convex SDK and react-navigation: pin to direct minor/patch only.
+      - dependency-name: "convex"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@react-navigation/*"
+        update-types: ["version-update:semver-major"]
     groups:
       security-updates:
         applies-to: security-updates


### PR DESCRIPTION
## Summary
Stops Dependabot from re-opening risky/noisy major version PRs:
- Dev tooling: eslint, eslint-config-expo, typescript, tailwindcss, prettier-plugin-tailwindcss
- Sentry SDK
- Convex backend SDK
- @react-navigation/*

Patches and minors still come through normally for all of these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)