### PR TITLE
chore: bump @react-native-async-storage/async-storage 2.2.0 → 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@expo-google-fonts/gabarito": "^0.4.2",
         "@expo-google-fonts/sanchez": "^0.4.1",
         "@expo/vector-icons": "^15.1.1",
-        "@react-native-async-storage/async-storage": "^2.2.0",
+        "@react-native-async-storage/async-storage": "^3.1.0",
         "@react-native-community/netinfo": "11.4.1",
         "@react-navigation/bottom-tabs": "^7.16.2",
         "@react-navigation/elements": "^2.9.19",
@@ -4294,15 +4294,16 @@
       }
     },
     "node_modules/@react-native-async-storage/async-storage": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
-      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-3.1.0.tgz",
+      "integrity": "sha512-ENwbn3kj/dOapdR3GVgfX5x9f9/rxHnsqol1bUkt26lrv0aAq6UoXnTlv7y2dT7RH0AShh9B1+KAPDVjJXnk0w==",
       "license": "MIT",
       "dependencies": {
-        "merge-options": "^3.0.4"
+        "idb": "8.0.3"
       },
       "peerDependencies": {
-        "react-native": "^0.0.0-0 || >=0.65 <1.0"
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@react-native-community/netinfo": {
@@ -10559,6 +10560,12 @@
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/idb": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+      "license": "ISC"
+    },
     "node_modules/idb-keyval": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
@@ -11055,6 +11062,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -12115,6 +12123,7 @@
       "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
       "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "is-plain-obj": "^2.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@expo-google-fonts/gabarito": "^0.4.2",
     "@expo-google-fonts/sanchez": "^0.4.1",
     "@expo/vector-icons": "^15.1.1",
-    "@react-native-async-storage/async-storage": "^2.2.0",
+    "@react-native-async-storage/async-storage": "^3.1.0",
     "@react-native-community/netinfo": "11.4.1",
     "@react-navigation/bottom-tabs": "^7.16.2",
     "@react-navigation/elements": "^2.9.19",


### PR DESCRIPTION
## Summary
Major version bump. v3 introduces "scoped storages" (new API) but the **default export remains a singleton that uses v2/v1 storage data**, so existing `AsyncStorage.getItem/setItem/removeItem` calls continue to work without migration.

iOS-only — Android requires an extra install step which doesn't affect us (Path A).

### Removed APIs we don't use
- callback-based API (we use async/await everywhere)
- `useAsyncStorage` hook (we don't use it)

### Files using AsyncStorage (no changes needed)
- `contexts/voice-settings-context.tsx`
- `contexts/theme-context.tsx`
- `contexts/skin-tone-context.tsx`
- `contexts/onboarding-context.tsx`
- `app/_layout.tsx`
- `app/(tabs)/_layout.tsx`

### Verified
- `npm ci` passes
- TypeScript reports no new errors
- All existing AsyncStorage calls use the default export which v3 maintains for backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)