### PR TITLE
chore: bump dev dependencies and sentry minor; reformat with new prettier

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -204,13 +204,21 @@ export default function SignIn() {
               />
             </Animated.View>
 
-            <Animated.View entering={FadeInUp.delay(250).duration(400)} className="mb-6 flex-row justify-end">
+            <Animated.View
+              entering={FadeInUp.delay(250).duration(400)}
+              className="mb-6 flex-row justify-end"
+            >
               <Pressable onPress={handleForgotPassword}>
-                <Text className="text-sm" style={{ color: colors.primary }}>Forgot password?</Text>
+                <Text className="text-sm" style={{ color: colors.primary }}>
+                  Forgot password?
+                </Text>
               </Pressable>
             </Animated.View>
 
-            <Animated.View entering={FadeInUp.delay(300).duration(400).springify()} className="mb-4">
+            <Animated.View
+              entering={FadeInUp.delay(300).duration(400).springify()}
+              className="mb-4"
+            >
               <GradientButton
                 title="Sign In"
                 onPress={handleSignIn}
@@ -229,7 +237,10 @@ export default function SignIn() {
               <View className="h-px flex-1 bg-gray-300" />
             </Animated.View>
 
-            <Animated.View entering={FadeInUp.delay(500).duration(400).springify()} className="mb-4">
+            <Animated.View
+              entering={FadeInUp.delay(500).duration(400).springify()}
+              className="mb-4"
+            >
               <GradientButton
                 title="Continue with Google"
                 onPress={handleGoogleSignIn}
@@ -239,7 +250,10 @@ export default function SignIn() {
               />
             </Animated.View>
 
-            <Animated.View entering={FadeInUp.delay(600).duration(400).springify()} className="mb-6">
+            <Animated.View
+              entering={FadeInUp.delay(600).duration(400).springify()}
+              className="mb-6"
+            >
               <GradientButton
                 title="Continue with Apple"
                 onPress={handleAppleSignIn}
@@ -255,7 +269,9 @@ export default function SignIn() {
             >
               <Text className="text-gray-600">Don&apos;t have an account? </Text>
               <Pressable onPress={() => router.replace('/(auth)/sign-up')}>
-                <Text className="font-semibold" style={{ color: colors.primary }}>Sign Up</Text>
+                <Text className="font-semibold" style={{ color: colors.primary }}>
+                  Sign Up
+                </Text>
               </Pressable>
             </Animated.View>
           </>
@@ -273,7 +289,10 @@ export default function SignIn() {
               />
             </Animated.View>
 
-            <Animated.View entering={FadeInUp.delay(100).duration(400).springify()} className="mb-4">
+            <Animated.View
+              entering={FadeInUp.delay(100).duration(400).springify()}
+              className="mb-4"
+            >
               <GradientButton
                 title="Verify Code"
                 onPress={handleVerifyCode}
@@ -283,9 +302,21 @@ export default function SignIn() {
               />
             </Animated.View>
 
-            <Animated.View entering={FadeInUp.delay(200).duration(400)} className="flex-row justify-center">
-              <Pressable onPress={() => { setResetFlow('idle'); setError(''); setCode(''); setNewPassword(''); }}>
-                <Text className="font-semibold" style={{ color: colors.primary }}>Back to Sign In</Text>
+            <Animated.View
+              entering={FadeInUp.delay(200).duration(400)}
+              className="flex-row justify-center"
+            >
+              <Pressable
+                onPress={() => {
+                  setResetFlow('idle');
+                  setError('');
+                  setCode('');
+                  setNewPassword('');
+                }}
+              >
+                <Text className="font-semibold" style={{ color: colors.primary }}>
+                  Back to Sign In
+                </Text>
               </Pressable>
             </Animated.View>
           </>
@@ -303,7 +334,10 @@ export default function SignIn() {
               />
             </Animated.View>
 
-            <Animated.View entering={FadeInUp.delay(100).duration(400).springify()} className="mb-4">
+            <Animated.View
+              entering={FadeInUp.delay(100).duration(400).springify()}
+              className="mb-4"
+            >
               <GradientButton
                 title="Reset Password"
                 onPress={handleResetPassword}

--- a/components/matches/celebration-modal.tsx
+++ b/components/matches/celebration-modal.tsx
@@ -36,28 +36,16 @@ export function CelebrationModal({ visible, nameName, onClose }: CelebrationModa
     <Modal visible={visible} transparent animationType="fade" statusBarTranslucent>
       <Confetti visible={visible} />
       <View style={styles.overlay}>
-        <Animated.View
-          entering={FadeIn.duration(400)}
-          style={styles.content}
-        >
-          <Animated.Text
-            entering={ZoomIn.delay(200).duration(500).springify()}
-            style={styles.name}
-          >
+        <Animated.View entering={FadeIn.duration(400)} style={styles.content}>
+          <Animated.Text entering={ZoomIn.delay(200).duration(500).springify()} style={styles.name}>
             {nameName}
           </Animated.Text>
 
-          <Animated.Text
-            entering={FadeIn.delay(500).duration(400)}
-            style={styles.subtitle}
-          >
+          <Animated.Text entering={FadeIn.delay(500).duration(400)} style={styles.subtitle}>
             You both chose {nameName}
           </Animated.Text>
 
-          <Animated.View
-            entering={FadeIn.delay(800).duration(400)}
-            style={styles.buttons}
-          >
+          <Animated.View entering={FadeIn.delay(800).duration(400)} style={styles.buttons}>
             <Pressable
               style={[styles.shareButton, { backgroundColor: colors.primary }]}
               onPress={handleShare}

--- a/components/matches/decline-sheet.tsx
+++ b/components/matches/decline-sheet.tsx
@@ -47,10 +47,7 @@ export function DeclineSheet({ visible, nameName, onDecline, onClose }: DeclineS
         <Text style={styles.charCount}>{message.length}/200</Text>
 
         <View style={styles.buttons}>
-          <Pressable
-            style={styles.declineButton}
-            onPress={handleDecline}
-          >
+          <Pressable style={styles.declineButton} onPress={handleDecline}>
             <Text style={styles.declineButtonText}>Decline</Text>
           </Pressable>
           <Pressable style={styles.cancelButton} onPress={handleClose}>

--- a/components/matches/match-detail-modal.tsx
+++ b/components/matches/match-detail-modal.tsx
@@ -1,13 +1,5 @@
 import { useState, useEffect } from 'react';
-import {
-  View,
-  Text,
-  Pressable,
-  StyleSheet,
-  ScrollView,
-  TextInput,
-  Alert,
-} from 'react-native';
+import { View, Text, Pressable, StyleSheet, ScrollView, TextInput, Alert } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useMutation } from 'convex/react';
 import { api } from '@/convex/_generated/api';
@@ -142,136 +134,136 @@ export function MatchDetailModal({ visible, match, onClose }: MatchDetailModalPr
       maxHeight="90%"
       style={{ paddingBottom: 34 }}
     >
-          <View style={[styles.handleBar, { backgroundColor: colors.border }]} />
+      <View style={[styles.handleBar, { backgroundColor: colors.border }]} />
 
-          <View style={[styles.header, { borderBottomColor: colors.border }]}>
-            <Text style={styles.headerTitle}>Match Details</Text>
-            <Pressable style={styles.closeButton} onPress={onClose}>
-              <Ionicons name="close" size={24} color="#6B5B7B" />
-            </Pressable>
+      <View style={[styles.header, { borderBottomColor: colors.border }]}>
+        <Text style={styles.headerTitle}>Match Details</Text>
+        <Pressable style={styles.closeButton} onPress={onClose}>
+          <Ionicons name="close" size={24} color="#6B5B7B" />
+        </Pressable>
+      </View>
+
+      <ScrollView
+        style={styles.scrollContent}
+        contentContainerStyle={styles.scrollContainer}
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+      >
+        {/* Name display */}
+        <View style={styles.nameSection}>
+          <View style={[styles.matchBadge, { backgroundColor: colors.primary }]}>
+            <Ionicons name="heart" size={16} color="#fff" />
+            <Text style={styles.matchBadgeText}>{"It's a Match!"}</Text>
           </View>
+          <Text style={styles.name}>{name.name}</Text>
+          <View style={styles.badges}>
+            <GenderBadge gender={name.gender as 'boy' | 'girl' | 'unisex'} />
+            <View style={[styles.originBadge, { backgroundColor: colors.primaryLight }]}>
+              <Text style={[styles.originText, { color: colors.primary }]}>{name.origin}</Text>
+            </View>
+          </View>
+          {name.meaning && <Text style={styles.meaning}>{name.meaning}</Text>}
+        </View>
 
-          <ScrollView
-            style={styles.scrollContent}
-            contentContainerStyle={styles.scrollContainer}
-            showsVerticalScrollIndicator={false}
-            keyboardShouldPersistTaps="handled"
+        {/* Quick actions */}
+        <View style={styles.quickActions}>
+          <Pressable
+            style={[
+              styles.quickAction,
+              { borderColor: colors.border },
+              isFavorite && { borderColor: colors.primary, backgroundColor: colors.secondaryLight },
+            ]}
+            onPress={handleToggleFavorite}
           >
-            {/* Name display */}
-            <View style={styles.nameSection}>
-              <View style={[styles.matchBadge, { backgroundColor: colors.primary }]}>
-                <Ionicons name="heart" size={16} color="#fff" />
-                <Text style={styles.matchBadgeText}>{"It's a Match!"}</Text>
-              </View>
-              <Text style={styles.name}>{name.name}</Text>
-              <View style={styles.badges}>
-                <GenderBadge gender={name.gender as 'boy' | 'girl' | 'unisex'} />
-                <View style={[styles.originBadge, { backgroundColor: colors.primaryLight }]}>
-                  <Text style={[styles.originText, { color: colors.primary }]}>{name.origin}</Text>
-                </View>
-              </View>
-              {name.meaning && <Text style={styles.meaning}>{name.meaning}</Text>}
-            </View>
+            <Ionicons
+              name={isFavorite ? 'star' : 'star-outline'}
+              size={24}
+              color={isFavorite ? colors.primary : '#6B5B7B'}
+            />
+            <Text style={[styles.quickActionText, isFavorite && { color: colors.primary }]}>
+              {isFavorite ? 'Favorited' : 'Favorite'}
+            </Text>
+          </Pressable>
 
-            {/* Quick actions */}
-            <View style={styles.quickActions}>
-              <Pressable
-                style={[
-                  styles.quickAction,
-                  { borderColor: colors.border },
-                  isFavorite && { borderColor: colors.primary, backgroundColor: colors.secondaryLight },
-                ]}
-                onPress={handleToggleFavorite}
-              >
-                <Ionicons
-                  name={isFavorite ? 'star' : 'star-outline'}
-                  size={24}
-                  color={isFavorite ? colors.primary : '#6B5B7B'}
-                />
-                <Text style={[styles.quickActionText, isFavorite && { color: colors.primary }]}>
-                  {isFavorite ? 'Favorited' : 'Favorite'}
-                </Text>
-              </Pressable>
+          <Pressable
+            style={[
+              styles.quickAction,
+              { borderColor: colors.border },
+              isChosen && { borderColor: colors.primary, backgroundColor: colors.primary },
+            ]}
+            onPress={isChosen ? undefined : handleChoose}
+            disabled={isChosen}
+          >
+            <Ionicons
+              name={isChosen ? 'trophy' : 'trophy-outline'}
+              size={24}
+              color={isChosen ? '#fff' : '#6B5B7B'}
+            />
+            <Text style={[styles.quickActionText, isChosen && styles.quickActionTextChosen]}>
+              {isChosen ? 'Chosen!' : 'Choose'}
+            </Text>
+          </Pressable>
+        </View>
 
-              <Pressable
-                style={[
-                  styles.quickAction,
-                  { borderColor: colors.border },
-                  isChosen && { borderColor: colors.primary, backgroundColor: colors.primary },
-                ]}
-                onPress={isChosen ? undefined : handleChoose}
-                disabled={isChosen}
-              >
-                <Ionicons
-                  name={isChosen ? 'trophy' : 'trophy-outline'}
-                  size={24}
-                  color={isChosen ? '#fff' : '#6B5B7B'}
-                />
-                <Text style={[styles.quickActionText, isChosen && styles.quickActionTextChosen]}>
-                  {isChosen ? 'Chosen!' : 'Choose'}
-                </Text>
-              </Pressable>
-            </View>
+        {/* Notes input */}
+        <View style={styles.inputSection}>
+          <Text style={styles.inputLabel}>Notes</Text>
+          <TextInput
+            style={[
+              styles.notesInput,
+              { backgroundColor: colors.surfaceSubtle, borderColor: colors.border },
+            ]}
+            placeholder="Add your thoughts about this name..."
+            placeholderTextColor="#A89BB5"
+            multiline
+            numberOfLines={3}
+            value={notes}
+            onChangeText={setNotes}
+            textAlignVertical="top"
+          />
+        </View>
 
-            {/* Notes input */}
-            <View style={styles.inputSection}>
-              <Text style={styles.inputLabel}>Notes</Text>
-              <TextInput
-                style={[
-                  styles.notesInput,
-                  { backgroundColor: colors.surfaceSubtle, borderColor: colors.border },
-                ]}
-                placeholder="Add your thoughts about this name..."
-                placeholderTextColor="#A89BB5"
-                multiline
-                numberOfLines={3}
-                value={notes}
-                onChangeText={setNotes}
-                textAlignVertical="top"
-              />
-            </View>
+        {/* Rank input */}
+        <View style={styles.inputSection}>
+          <Text style={styles.inputLabel}>Rank</Text>
+          <View style={styles.rankContainer}>
+            <TextInput
+              style={[
+                styles.rankInput,
+                { backgroundColor: colors.surfaceSubtle, borderColor: colors.border },
+              ]}
+              placeholder="#"
+              placeholderTextColor="#A89BB5"
+              keyboardType="number-pad"
+              value={rank}
+              onChangeText={(text) => setRank(text.replace(/[^0-9]/g, ''))}
+              maxLength={2}
+            />
+            <Text style={styles.rankHint}>Set a priority ranking (1 = top choice)</Text>
+          </View>
+        </View>
 
-            {/* Rank input */}
-            <View style={styles.inputSection}>
-              <Text style={styles.inputLabel}>Rank</Text>
-              <View style={styles.rankContainer}>
-                <TextInput
-                  style={[
-                    styles.rankInput,
-                    { backgroundColor: colors.surfaceSubtle, borderColor: colors.border },
-                  ]}
-                  placeholder="#"
-                  placeholderTextColor="#A89BB5"
-                  keyboardType="number-pad"
-                  value={rank}
-                  onChangeText={(text) => setRank(text.replace(/[^0-9]/g, ''))}
-                  maxLength={2}
-                />
-                <Text style={styles.rankHint}>Set a priority ranking (1 = top choice)</Text>
-              </View>
-            </View>
+        {/* Action buttons */}
+        <View style={styles.buttons}>
+          <Pressable
+            style={[
+              styles.saveButton,
+              { backgroundColor: colors.primary },
+              isSaving && styles.buttonDisabled,
+            ]}
+            onPress={handleSave}
+            disabled={isSaving}
+          >
+            <Ionicons name="checkmark" size={20} color="#fff" />
+            <Text style={styles.saveButtonText}>{isSaving ? 'Saving...' : 'Save Changes'}</Text>
+          </Pressable>
 
-            {/* Action buttons */}
-            <View style={styles.buttons}>
-              <Pressable
-                style={[
-                  styles.saveButton,
-                  { backgroundColor: colors.primary },
-                  isSaving && styles.buttonDisabled,
-                ]}
-                onPress={handleSave}
-                disabled={isSaving}
-              >
-                <Ionicons name="checkmark" size={20} color="#fff" />
-                <Text style={styles.saveButtonText}>{isSaving ? 'Saving...' : 'Save Changes'}</Text>
-              </Pressable>
-
-              <Pressable style={styles.removeButton} onPress={handleRemoveMatch}>
-                <Ionicons name="trash-outline" size={20} color="#FF6B6B" />
-                <Text style={styles.removeButtonText}>Remove Match</Text>
-              </Pressable>
-            </View>
-          </ScrollView>
+          <Pressable style={styles.removeButton} onPress={handleRemoveMatch}>
+            <Ionicons name="trash-outline" size={20} color="#FF6B6B" />
+            <Text style={styles.removeButtonText}>Remove Match</Text>
+          </Pressable>
+        </View>
+      </ScrollView>
     </AnimatedBottomSheet>
   );
 }

--- a/components/matches/proposal-banner.tsx
+++ b/components/matches/proposal-banner.tsx
@@ -36,8 +36,7 @@ export function ProposalBanner({
           <Ionicons name="time-outline" size={20} color={colors.primary} />
           <View style={styles.bannerTextContainer}>
             <Text style={[styles.bannerText, { color: colors.tabActive }]}>
-              Waiting for response on{' '}
-              <Text style={styles.bannerNameText}>{nameName}</Text>
+              Waiting for response on <Text style={styles.bannerNameText}>{nameName}</Text>
             </Text>
           </View>
           <Pressable style={styles.withdrawClose} onPress={onWithdraw} hitSlop={10}>
@@ -50,21 +49,15 @@ export function ProposalBanner({
 
   return (
     <View
-      style={[
-        styles.banner,
-        { backgroundColor: colors.primaryLight, borderColor: colors.primary },
-      ]}
+      style={[styles.banner, { backgroundColor: colors.primaryLight, borderColor: colors.primary }]}
     >
       <View style={styles.bannerContent}>
         <Ionicons name="hand-left" size={20} color={colors.primary} />
         <View style={styles.bannerTextContainer}>
           <Text style={[styles.bannerText, { color: colors.tabActive }]}>
-            {proposerName} proposed{' '}
-            <Text style={styles.bannerNameText}>{nameName}</Text>
+            {proposerName} proposed <Text style={styles.bannerNameText}>{nameName}</Text>
           </Text>
-          {message ? (
-            <Text style={styles.bannerMessage}>"{message}"</Text>
-          ) : null}
+          {message ? <Text style={styles.bannerMessage}>"{message}"</Text> : null}
         </View>
       </View>
       <View style={styles.bannerActions}>

--- a/components/matches/propose-sheet.tsx
+++ b/components/matches/propose-sheet.tsx
@@ -36,9 +36,7 @@ export function ProposeSheet({ visible, name, onPropose, onClose }: ProposeSheet
 
         <Text style={styles.title}>Propose This Name?</Text>
         <Text style={styles.name}>{name.name}</Text>
-        <Text style={styles.subtitle}>
-          Your partner will be asked to accept or decline.
-        </Text>
+        <Text style={styles.subtitle}>Your partner will be asked to accept or decline.</Text>
 
         <StyledInput
           value={message}

--- a/components/name-detail/name-detail-modal.tsx
+++ b/components/name-detail/name-detail-modal.tsx
@@ -227,7 +227,13 @@ export function NameDetailModal({
       {/* Header with close button */}
       <View style={styles.header}>
         <View style={styles.headerSpacer} />
-        <Pressable onPress={onClose} style={styles.closeButton} hitSlop={8} accessibilityLabel="Close" accessibilityRole="button">
+        <Pressable
+          onPress={onClose}
+          style={styles.closeButton}
+          hitSlop={8}
+          accessibilityLabel="Close"
+          accessibilityRole="button"
+        >
           <Ionicons name="close" size={24} color="#6B5B7B" />
         </Pressable>
       </View>

--- a/components/onboarding/multiplayer-intro.tsx
+++ b/components/onboarding/multiplayer-intro.tsx
@@ -38,19 +38,19 @@ export function MultiplayerIntro({ isActive }: { isActive: boolean }) {
     const p = progress.value;
     const translateX = interpolate(
       p,
-      [0, 0.10, 0.70, 0.82, 1.0],
+      [0, 0.1, 0.7, 0.82, 1.0],
       [-70, 0, 0, -70, -70],
       Extrapolation.CLAMP,
     );
     const rotate = interpolate(
       p,
-      [0, 0.10, 0.70, 0.82, 1.0],
+      [0, 0.1, 0.7, 0.82, 1.0],
       [-6, 0, 0, -6, -6],
       Extrapolation.CLAMP,
     );
     const borderColor = interpolateColor(
       p,
-      [0, 0.10, 0.18, 0.70, 0.82, 1.0],
+      [0, 0.1, 0.18, 0.7, 0.82, 1.0],
       [colors.border, colors.border, MATCH_GREEN, MATCH_GREEN, colors.border, colors.border],
     );
     return {
@@ -63,19 +63,14 @@ export function MultiplayerIntro({ isActive }: { isActive: boolean }) {
     const p = progress.value;
     const translateX = interpolate(
       p,
-      [0, 0.10, 0.70, 0.82, 1.0],
+      [0, 0.1, 0.7, 0.82, 1.0],
       [70, 0, 0, 70, 70],
       Extrapolation.CLAMP,
     );
-    const rotate = interpolate(
-      p,
-      [0, 0.10, 0.70, 0.82, 1.0],
-      [6, 0, 0, 6, 6],
-      Extrapolation.CLAMP,
-    );
+    const rotate = interpolate(p, [0, 0.1, 0.7, 0.82, 1.0], [6, 0, 0, 6, 6], Extrapolation.CLAMP);
     const borderColor = interpolateColor(
       p,
-      [0, 0.10, 0.18, 0.70, 0.82, 1.0],
+      [0, 0.1, 0.18, 0.7, 0.82, 1.0],
       [colors.border, colors.border, MATCH_GREEN, MATCH_GREEN, colors.border, colors.border],
     );
     return {
@@ -90,13 +85,13 @@ export function MultiplayerIntro({ isActive }: { isActive: boolean }) {
     const p = progress.value;
     const scale = interpolate(
       p,
-      [0, 0.28, 0.32, 0.34, 0.70, 0.78, 1.0],
+      [0, 0.28, 0.32, 0.34, 0.7, 0.78, 1.0],
       [0, 0, 1.08, 1, 1, 0, 0],
       Extrapolation.CLAMP,
     );
     const opacity = interpolate(
       p,
-      [0, 0.28, 0.32, 0.70, 0.78, 1.0],
+      [0, 0.28, 0.32, 0.7, 0.78, 1.0],
       [0, 0, 1, 1, 0, 0],
       Extrapolation.CLAMP,
     );
@@ -148,7 +143,17 @@ export function MultiplayerIntro({ isActive }: { isActive: boolean }) {
         </Animated.View>
 
         {/* Match banner */}
-        <Animated.View style={[styles.matchBanner, { borderColor: colors.primary, shadowColor: colors.primary, backgroundColor: colors.secondaryLight }, bannerStyle]}>
+        <Animated.View
+          style={[
+            styles.matchBanner,
+            {
+              borderColor: colors.primary,
+              shadowColor: colors.primary,
+              backgroundColor: colors.secondaryLight,
+            },
+            bannerStyle,
+          ]}
+        >
           <Text style={styles.matchEmoji}>{'\uD83C\uDF89'}</Text>
           <Text style={[styles.matchText, { color: colors.tabActive }]}>It&apos;s a Match!</Text>
         </Animated.View>

--- a/components/onboarding/swipe-demo.tsx
+++ b/components/onboarding/swipe-demo.tsx
@@ -46,13 +46,13 @@ export function SwipeDemo({ isActive }: { isActive: boolean }) {
     const p = progress.value;
     const translateX = interpolate(
       p,
-      [0, 0.12, 0.24, 0.40, 0.52, 0.64, 1.0],
+      [0, 0.12, 0.24, 0.4, 0.52, 0.64, 1.0],
       [0, 100, 0, 0, -100, 0, 0],
       Extrapolation.CLAMP,
     );
     const rotate = interpolate(
       p,
-      [0, 0.12, 0.24, 0.40, 0.52, 0.64, 1.0],
+      [0, 0.12, 0.24, 0.4, 0.52, 0.64, 1.0],
       [0, 8, 0, 0, -8, 0, 0],
       Extrapolation.CLAMP,
     );
@@ -64,8 +64,8 @@ export function SwipeDemo({ isActive }: { isActive: boolean }) {
   // LIKE stamp opacity and scale
   const likeStampStyle = useAnimatedStyle(() => {
     const p = progress.value;
-    const opacity = interpolate(p, [0.04, 0.08, 0.12, 0.20], [0, 1, 1, 0], Extrapolation.CLAMP);
-    const scale = interpolate(p, [0.04, 0.07, 0.10], [0.6, 1.15, 1], Extrapolation.CLAMP);
+    const opacity = interpolate(p, [0.04, 0.08, 0.12, 0.2], [0, 1, 1, 0], Extrapolation.CLAMP);
+    const scale = interpolate(p, [0.04, 0.07, 0.1], [0.6, 1.15, 1], Extrapolation.CLAMP);
     return {
       opacity,
       transform: [{ rotate: '-12deg' }, { scale }],
@@ -75,8 +75,8 @@ export function SwipeDemo({ isActive }: { isActive: boolean }) {
   // NOPE stamp opacity and scale
   const nopeStampStyle = useAnimatedStyle(() => {
     const p = progress.value;
-    const opacity = interpolate(p, [0.44, 0.48, 0.52, 0.60], [0, 1, 1, 0], Extrapolation.CLAMP);
-    const scale = interpolate(p, [0.44, 0.47, 0.50], [0.6, 1.15, 1], Extrapolation.CLAMP);
+    const opacity = interpolate(p, [0.44, 0.48, 0.52, 0.6], [0, 1, 1, 0], Extrapolation.CLAMP);
+    const scale = interpolate(p, [0.44, 0.47, 0.5], [0.6, 1.15, 1], Extrapolation.CLAMP);
     return {
       opacity,
       transform: [{ rotate: '12deg' }, { scale }],
@@ -116,7 +116,7 @@ export function SwipeDemo({ isActive }: { isActive: boolean }) {
     const p = progress.value;
     const fade = interpolate(
       p,
-      [0, 0.04, 0.12, 0.20, 0.24, 0.40, 0.44, 0.52, 0.60, 0.64, 1.0],
+      [0, 0.04, 0.12, 0.2, 0.24, 0.4, 0.44, 0.52, 0.6, 0.64, 1.0],
       [1, 0.3, 0.3, 0.3, 1, 1, 0.3, 0.3, 0.3, 1, 1],
       Extrapolation.CLAMP,
     );
@@ -168,7 +168,8 @@ export function SwipeDemo({ isActive }: { isActive: boolean }) {
 
             <View style={[styles.meaningBox, { backgroundColor: colors.surfaceSubtle }]}>
               <Text style={styles.meaningText}>
-                {'\u201C'}Dawn{'\u201D'} {'\u2014'} the Roman goddess of sunrise, whose tears became the morning dew
+                {'\u201C'}Dawn{'\u201D'} {'\u2014'} the Roman goddess of sunrise, whose tears became
+                the morning dew
               </Text>
             </View>
 

--- a/components/popularity/popularity-chart.tsx
+++ b/components/popularity/popularity-chart.tsx
@@ -127,15 +127,16 @@ export function PopularityChart({ name, gender }: PopularityChartProps) {
   }
 
   // Use current data, fall back to cached data during transitions
-  const rawData = (popularityData && popularityData.length > 0) ? popularityData : cachedData.current;
+  const rawData = popularityData && popularityData.length > 0 ? popularityData : cachedData.current;
   if (rawData.length === 0) return null;
 
   // Downsample large datasets (All Time) to ~50 points for readable labels
   const MAX_POINTS = 50;
   const step = Math.ceil(rawData.length / MAX_POINTS);
-  const data = rawData.length > MAX_POINTS
-    ? rawData.filter((_, i) => i % step === 0 || i === rawData.length - 1)
-    : rawData;
+  const data =
+    rawData.length > MAX_POINTS
+      ? rawData.filter((_, i) => i % step === 0 || i === rawData.length - 1)
+      : rawData;
 
   // Find max rank for inverting (so rank 1 appears at top)
   const maxRank = Math.max(...data.map((d) => d.rank));
@@ -147,9 +148,7 @@ export function PopularityChart({ name, gender }: PopularityChartProps) {
   const labelInterval = Math.max(1, Math.floor((data.length - 1) / (labelCount - 1)));
   const chartData = data.map((d, index) => ({
     value: maxRank - d.rank + 1,
-    label: index % labelInterval === 0 || index === data.length - 1
-      ? String(d.year)
-      : '',
+    label: index % labelInterval === 0 || index === data.length - 1 ? String(d.year) : '',
   }));
 
   // Calculate spacing based on data length and available width
@@ -181,40 +180,40 @@ export function PopularityChart({ name, gender }: PopularityChartProps) {
           </View>
           <View style={styles.chartWrapper}>
             <LineChart
-            data={chartData}
-            width={chartWidth}
-            height={CHART_HEIGHT}
-            color={GENDER_COLORS[gender].line}
-            thickness={2}
-            curved
-            areaChart
-            startFillColor={GENDER_COLORS[gender].gradient}
-            endFillColor="transparent"
-            startOpacity={0.4}
-            endOpacity={0}
-            initialSpacing={10}
-            endSpacing={10}
-            spacing={spacing}
-            hideDataPoints
-            onPress={handleDataPointPress}
-            yAxisTextStyle={styles.axisLabel}
-            xAxisLabelTextStyle={styles.axisLabel}
-            yAxisThickness={0}
-            xAxisThickness={1}
-            xAxisColor={themeColors.border}
-            labelsExtraHeight={20}
-            rulesColor={themeColors.surfaceSubtle}
-            rulesType="dashed"
-            noOfSections={4}
-            maxValue={maxRank - minRank + 1}
-            formatYLabel={(value: string) => {
-              const numValue = parseFloat(value);
-              const rank = maxRank - numValue + 1;
-              return `#${Math.round(rank)}`;
-            }}
-            disableScroll
-            isAnimated={false}
-          />
+              data={chartData}
+              width={chartWidth}
+              height={CHART_HEIGHT}
+              color={GENDER_COLORS[gender].line}
+              thickness={2}
+              curved
+              areaChart
+              startFillColor={GENDER_COLORS[gender].gradient}
+              endFillColor="transparent"
+              startOpacity={0.4}
+              endOpacity={0}
+              initialSpacing={10}
+              endSpacing={10}
+              spacing={spacing}
+              hideDataPoints
+              onPress={handleDataPointPress}
+              yAxisTextStyle={styles.axisLabel}
+              xAxisLabelTextStyle={styles.axisLabel}
+              yAxisThickness={0}
+              xAxisThickness={1}
+              xAxisColor={themeColors.border}
+              labelsExtraHeight={20}
+              rulesColor={themeColors.surfaceSubtle}
+              rulesType="dashed"
+              noOfSections={4}
+              maxValue={maxRank - minRank + 1}
+              formatYLabel={(value: string) => {
+                const numValue = parseFloat(value);
+                const rank = maxRank - numValue + 1;
+                return `#${Math.round(rank)}`;
+              }}
+              disableScroll
+              isAnimated={false}
+            />
           </View>
         </View>
         {/* X-axis label */}

--- a/components/search/origin-toggle-row.tsx
+++ b/components/search/origin-toggle-row.tsx
@@ -14,16 +14,14 @@ export function OriginToggleRow({ origin, count, isActive, onToggle }: OriginTog
   const { colors } = useTheme();
 
   return (
-    <Pressable
-      onPress={onToggle}
-      style={[
-        styles.row,
-        { shadowColor: colors.secondary },
-      ]}
-    >
+    <Pressable onPress={onToggle} style={[styles.row, { shadowColor: colors.secondary }]}>
       <View style={styles.textContainer}>
-        <Text style={[styles.name, isActive && styles.nameActive]}>{getOriginFlag(origin)} {origin}</Text>
-        <Text style={styles.count}>{count.toLocaleString()} {count === 1 ? 'name' : 'names'}</Text>
+        <Text style={[styles.name, isActive && styles.nameActive]}>
+          {getOriginFlag(origin)} {origin}
+        </Text>
+        <Text style={styles.count}>
+          {count.toLocaleString()} {count === 1 ? 'name' : 'names'}
+        </Text>
       </View>
       <Switch
         value={isActive}

--- a/components/settings/skin-tone-section.tsx
+++ b/components/settings/skin-tone-section.tsx
@@ -68,32 +68,23 @@ export function SkinToneSection() {
   const { colors } = useTheme();
   const [isExpanded, setIsExpanded] = useState(false);
 
-  useFocusEffect(useCallback(() => {
-    return () => setIsExpanded(false);
-  }, []));
+  useFocusEffect(
+    useCallback(() => {
+      return () => setIsExpanded(false);
+    }, []),
+  );
 
   const currentEmoji = getGenderEmoji('neutral', skinTone);
 
   return (
     <View style={styles.container}>
       <Pressable style={styles.headerRow} onPress={() => setIsExpanded(!isExpanded)}>
-        <Ionicons
-          name="hand-left-outline"
-          size={22}
-          color="#6B5B7B"
-          style={{ marginRight: 12 }}
-        />
+        <Ionicons name="hand-left-outline" size={22} color="#6B5B7B" style={{ marginRight: 12 }} />
         <View style={styles.headerContent}>
           <Text style={styles.headerTitle}>Skin Tone</Text>
-          <Text style={styles.headerSubtitle}>
-            {currentEmoji}
-          </Text>
+          <Text style={styles.headerSubtitle}>{currentEmoji}</Text>
         </View>
-        <Ionicons
-          name={isExpanded ? 'chevron-up' : 'chevron-down'}
-          size={22}
-          color="#A89BB5"
-        />
+        <Ionicons name={isExpanded ? 'chevron-up' : 'chevron-down'} size={22} color="#A89BB5" />
       </Pressable>
 
       {isExpanded && (

--- a/components/settings/theme-picker-section.tsx
+++ b/components/settings/theme-picker-section.tsx
@@ -111,16 +111,23 @@ export function ThemePickerSection() {
   const { themeKey, setTheme } = useTheme();
   const [isExpanded, setIsExpanded] = useState(false);
 
-  useFocusEffect(useCallback(() => {
-    return () => setIsExpanded(false);
-  }, []));
+  useFocusEffect(
+    useCallback(() => {
+      return () => setIsExpanded(false);
+    }, []),
+  );
 
   const currentMeta = THEME_META.find((t) => t.key === themeKey)!;
 
   return (
     <View style={styles.container}>
       <Pressable style={styles.headerRow} onPress={() => setIsExpanded(!isExpanded)}>
-        <Ionicons name="color-palette-outline" size={22} color="#6B5B7B" style={{ marginRight: 12 }} />
+        <Ionicons
+          name="color-palette-outline"
+          size={22}
+          color="#6B5B7B"
+          style={{ marginRight: 12 }}
+        />
         <View style={styles.headerContent}>
           <Text style={styles.headerTitle}>Theme</Text>
           <Text style={styles.headerSubtitle}>

--- a/components/settings/voice-settings-section.tsx
+++ b/components/settings/voice-settings-section.tsx
@@ -47,9 +47,11 @@ export function VoiceSettingsSection() {
   const [previewingVoice, setPreviewingVoice] = useState<string | null>(null);
   const [isExpanded, setIsExpanded] = useState(false);
 
-  useFocusEffect(useCallback(() => {
-    return () => setIsExpanded(false);
-  }, []));
+  useFocusEffect(
+    useCallback(() => {
+      return () => setIsExpanded(false);
+    }, []),
+  );
 
   // Fetch available voices on mount
   useEffect(() => {
@@ -139,7 +141,12 @@ export function VoiceSettingsSection() {
     <View style={styles.container}>
       {/* Header row - tappable to expand/collapse */}
       <Pressable style={styles.headerRow} onPress={() => setIsExpanded(!isExpanded)}>
-        <Ionicons name="volume-medium-outline" size={22} color="#6B5B7B" style={{ marginRight: 12 }} />
+        <Ionicons
+          name="volume-medium-outline"
+          size={22}
+          color="#6B5B7B"
+          style={{ marginRight: 12 }}
+        />
         <View style={styles.headerContent}>
           <Text style={styles.headerTitle}>Voice</Text>
           <Text style={styles.headerSubtitle}>{currentVoiceName}</Text>

--- a/components/ui/match-animation.tsx
+++ b/components/ui/match-animation.tsx
@@ -31,19 +31,19 @@ export function MatchAnimation() {
     const p = progress.value;
     const translateX = interpolate(
       p,
-      [0, 0.1, 0.70, 0.82, 1.0],
+      [0, 0.1, 0.7, 0.82, 1.0],
       [-70, 0, 0, -70, -70],
       Extrapolation.CLAMP,
     );
     const rotate = interpolate(
       p,
-      [0, 0.1, 0.70, 0.82, 1.0],
+      [0, 0.1, 0.7, 0.82, 1.0],
       [-6, 0, 0, -6, -6],
       Extrapolation.CLAMP,
     );
     const borderColor = interpolateColor(
       p,
-      [0, 0.10, 0.18, 0.70, 0.82, 1.0],
+      [0, 0.1, 0.18, 0.7, 0.82, 1.0],
       [colors.border, colors.border, MATCH_GREEN, MATCH_GREEN, colors.border, colors.border],
     );
     return { transform: [{ rotate: `${rotate}deg` }, { translateX }], borderColor };
@@ -53,19 +53,14 @@ export function MatchAnimation() {
     const p = progress.value;
     const translateX = interpolate(
       p,
-      [0, 0.1, 0.70, 0.82, 1.0],
+      [0, 0.1, 0.7, 0.82, 1.0],
       [70, 0, 0, 70, 70],
       Extrapolation.CLAMP,
     );
-    const rotate = interpolate(
-      p,
-      [0, 0.1, 0.70, 0.82, 1.0],
-      [6, 0, 0, 6, 6],
-      Extrapolation.CLAMP,
-    );
+    const rotate = interpolate(p, [0, 0.1, 0.7, 0.82, 1.0], [6, 0, 0, 6, 6], Extrapolation.CLAMP);
     const borderColor = interpolateColor(
       p,
-      [0, 0.10, 0.18, 0.70, 0.82, 1.0],
+      [0, 0.1, 0.18, 0.7, 0.82, 1.0],
       [colors.border, colors.border, MATCH_GREEN, MATCH_GREEN, colors.border, colors.border],
     );
     return { transform: [{ rotate: `${rotate}deg` }, { translateX }], borderColor };
@@ -76,13 +71,13 @@ export function MatchAnimation() {
     const p = progress.value;
     const scale = interpolate(
       p,
-      [0, 0.28, 0.32, 0.34, 0.70, 0.78, 1.0],
+      [0, 0.28, 0.32, 0.34, 0.7, 0.78, 1.0],
       [0, 0, 1.08, 1, 1, 0, 0],
       Extrapolation.CLAMP,
     );
     const opacity = interpolate(
       p,
-      [0, 0.28, 0.32, 0.70, 0.78, 1.0],
+      [0, 0.28, 0.32, 0.7, 0.78, 1.0],
       [0, 0, 1, 1, 0, 0],
       Extrapolation.CLAMP,
     );

--- a/components/ui/styled-input.tsx
+++ b/components/ui/styled-input.tsx
@@ -1,4 +1,11 @@
-import { TextInput, StyleSheet, View, Pressable, type TextInputProps, type ViewStyle } from 'react-native';
+import {
+  TextInput,
+  StyleSheet,
+  View,
+  Pressable,
+  type TextInputProps,
+  type ViewStyle,
+} from 'react-native';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@react-navigation/bottom-tabs": "^7.16.2",
         "@react-navigation/elements": "^2.9.19",
         "@react-navigation/native": "^7.2.5",
-        "@sentry/react-native": "~7.2.0",
+        "@sentry/react-native": "~7.13.0",
         "convex": "^1.39.1",
         "expo": "~54.0.34",
         "expo-apple-authentication": "~8.0.8",
@@ -60,15 +60,15 @@
         "react-native-worklets": "0.5.1"
       },
       "devDependencies": {
-        "@anthropic-ai/sdk": "^0.91.1",
+        "@anthropic-ai/sdk": "^0.98.0",
         "@types/react": "~19.1.0",
-        "eslint": "^9.25.0",
+        "eslint": "^9.39.4",
         "eslint-config-expo": "~10.0.0",
         "eslint-config-prettier": "^10.1.8",
-        "eslint-plugin-prettier": "^5.5.4",
-        "prettier": "^3.6.2",
-        "prettier-plugin-tailwindcss": "^0.6.14",
-        "tailwindcss": "^3.4.18",
+        "eslint-plugin-prettier": "^5.5.5",
+        "prettier": "^3.8.3",
+        "prettier-plugin-tailwindcss": "^0.8.0",
+        "tailwindcss": "^3.4.19",
         "typescript": "~5.9.2"
       }
     },
@@ -106,13 +106,14 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "version": "0.98.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.98.0.tgz",
+      "integrity": "sha512-N7aXtCvC5g6T1Y4V29lJjceu/zTkVkIZF0jdBvagr0TRFHuKeImffalGWEfqZKrvjH+IQbzJWw6TmSmUzrlMgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -2482,37 +2483,37 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
-      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.0.tgz",
-      "integrity": "sha512-WUFvV4WoIwW8Bv0KeKCIIEgdSiFOsulyN0xrMu+7z43q/hkOLXjvb5u7UC9jDxvRzcrbEmuZBX5yJZz1741jog==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.16.0"
+        "@eslint/core": "^0.17.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.16.0.tgz",
-      "integrity": "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2523,20 +2524,20 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -2547,9 +2548,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.37.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.37.0.tgz",
-      "integrity": "sha512-jaS+NJ+hximswBG6pjNX0uEJZkrT0zwpVi3BA3vX22aFGjJjmgSTSmPpZCRKmoBL5VY/M6p0xsSJx7rk7sy5gg==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2560,9 +2561,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2570,13 +2571,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.0.tgz",
-      "integrity": "sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.16.0",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -4752,86 +4753,86 @@
       }
     },
     "node_modules/@sentry-internal/browser-utils": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.12.0.tgz",
-      "integrity": "sha512-dozbx389jhKynj0d657FsgbBVOar7pX3mb6GjqCxslXF0VKpZH2Xks0U32RgDY/nK27O+o095IWz7YvjVmPkDw==",
+      "version": "10.38.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.38.0.tgz",
+      "integrity": "sha512-UOJtYmdcxHCcV0NPfXFff/a95iXl/E0EhuQ1y0uE0BuZDMupWSF5t2BgC4HaE5Aw3RTjDF3XkSHWoIF6ohy7eA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.12.0"
+        "@sentry/core": "10.38.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.12.0.tgz",
-      "integrity": "sha512-0+7ceO6yQPPqfxRc9ue/xoPHKcnB917ezPaehGQNfAFNQB9PNTG1y55+8mRu0Fw+ANbZeCt/HyoCmXuRdxmkpg==",
+      "version": "10.38.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.38.0.tgz",
+      "integrity": "sha512-JXneg9zRftyfy1Fyfc39bBlF/Qd8g4UDublFFkVvdc1S6JQPlK+P6q22DKz3Pc8w3ySby+xlIq/eTu9Pzqi4KA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.12.0"
+        "@sentry/core": "10.38.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.12.0.tgz",
-      "integrity": "sha512-/1093gSNGN5KlOBsuyAl33JkzGiG38kCnxswQLZWpPpR6LBbR1Ddb18HjhDpoQNNEZybJBgJC3a5NKl43C2TSQ==",
+      "version": "10.38.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.38.0.tgz",
+      "integrity": "sha512-YWIkL6/dnaiQyFiZXJ/nN+NXGv/15z45ia86bE/TMq01CubX/DUOilgsFz0pk2v/pg3tp/U2MskLO9Hz0cnqeg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.12.0",
-        "@sentry/core": "10.12.0"
+        "@sentry-internal/browser-utils": "10.38.0",
+        "@sentry/core": "10.38.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.12.0.tgz",
-      "integrity": "sha512-W/z1/+69i3INNfPjD1KuinSNaRQaApjzwb37IFmiyF440F93hxmEYgXHk3poOlYYaigl2JMYbysGPWOiXnqUXA==",
+      "version": "10.38.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.38.0.tgz",
+      "integrity": "sha512-OXWM9jEqNYh4VTvrMu7v+z1anz+QKQ/fZXIZdsO7JTT2lGNZe58UUMeoq386M+Saxen8F9SUH7yTORy/8KI5qw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/replay": "10.12.0",
-        "@sentry/core": "10.12.0"
+        "@sentry-internal/replay": "10.38.0",
+        "@sentry/core": "10.38.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/babel-plugin-component-annotate": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-4.3.0.tgz",
-      "integrity": "sha512-OuxqBprXRyhe8Pkfyz/4yHQJc5c3lm+TmYWSSx8u48g5yKewSQDOxkiLU5pAk3WnbLPy8XwU/PN+2BG0YFU9Nw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-4.9.1.tgz",
+      "integrity": "sha512-0gEoi2Lb54MFYPOmdTfxlNKxI7kCOvNV7gP8lxMXJ7nCazF5OqOOZIVshfWjDLrc0QrSV6XdVvwPV9GDn4wBMg==",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.12.0.tgz",
-      "integrity": "sha512-lKyaB2NFmr7SxPjmMTLLhQ7xfxaY3kdkMhpzuRI5qwOngtKt4+FtvNYHRuz+PTtEFv4OaHhNNbRn6r91gWguQg==",
+      "version": "10.38.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.38.0.tgz",
+      "integrity": "sha512-3phzp1YX4wcQr9mocGWKbjv0jwtuoDBv7+Y6Yfrys/kwyaL84mDLjjQhRf4gL5SX7JdYkhBp4WaiNlR0UC4kTA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.12.0",
-        "@sentry-internal/feedback": "10.12.0",
-        "@sentry-internal/replay": "10.12.0",
-        "@sentry-internal/replay-canvas": "10.12.0",
-        "@sentry/core": "10.12.0"
+        "@sentry-internal/browser-utils": "10.38.0",
+        "@sentry-internal/feedback": "10.38.0",
+        "@sentry-internal/replay": "10.38.0",
+        "@sentry-internal/replay-canvas": "10.38.0",
+        "@sentry/core": "10.38.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/cli": {
-      "version": "2.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.55.0.tgz",
-      "integrity": "sha512-cynvcIM2xL8ddwELyFRSpZQw4UtFZzoM2rId2l9vg7+wDREPDocMJB9lEQpBIo3eqhp9JswqUT037yjO6iJ5Sw==",
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.4.tgz",
+      "integrity": "sha512-ArDrpuS8JtDYEvwGleVE+FgR+qHaOp77IgdGSacz6SZy6Lv90uX0Nu4UrHCQJz8/xwIcNxSqnN22lq0dH4IqTg==",
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
+      "license": "FSL-1.1-MIT",
       "dependencies": {
         "https-proxy-agent": "^5.0.0",
         "node-fetch": "^2.6.7",
@@ -4846,21 +4847,21 @@
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@sentry/cli-darwin": "2.55.0",
-        "@sentry/cli-linux-arm": "2.55.0",
-        "@sentry/cli-linux-arm64": "2.55.0",
-        "@sentry/cli-linux-i686": "2.55.0",
-        "@sentry/cli-linux-x64": "2.55.0",
-        "@sentry/cli-win32-arm64": "2.55.0",
-        "@sentry/cli-win32-i686": "2.55.0",
-        "@sentry/cli-win32-x64": "2.55.0"
+        "@sentry/cli-darwin": "2.58.4",
+        "@sentry/cli-linux-arm": "2.58.4",
+        "@sentry/cli-linux-arm64": "2.58.4",
+        "@sentry/cli-linux-i686": "2.58.4",
+        "@sentry/cli-linux-x64": "2.58.4",
+        "@sentry/cli-win32-arm64": "2.58.4",
+        "@sentry/cli-win32-i686": "2.58.4",
+        "@sentry/cli-win32-x64": "2.58.4"
       }
     },
     "node_modules/@sentry/cli-darwin": {
-      "version": "2.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.55.0.tgz",
-      "integrity": "sha512-jGHE7SHHzqXUmnsmRLgorVH6nmMmTjQQXdPZbSL5tRtH8d3OIYrVNr5D72DSgD26XAPBDMV0ibqOQ9NKoiSpfA==",
-      "license": "BSD-3-Clause",
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.4.tgz",
+      "integrity": "sha512-kbTD+P4X8O+nsNwPxCywtj3q22ecyRHWff98rdcmtRrvwz8CKi/T4Jxn/fnn2i4VEchy08OWBuZAqaA5Kh2hRQ==",
+      "license": "FSL-1.1-MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -4870,13 +4871,13 @@
       }
     },
     "node_modules/@sentry/cli-linux-arm": {
-      "version": "2.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.55.0.tgz",
-      "integrity": "sha512-ATjU0PsiWADSPLF/kZroLZ7FPKd5W9TDWHVkKNwIUNTei702LFgTjNeRwOIzTgSvG3yTmVEqtwFQfFN/7hnVXQ==",
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.4.tgz",
+      "integrity": "sha512-rdQ8beTwnN48hv7iV7e7ZKucPec5NJkRdrrycMJMZlzGBPi56LqnclgsHySJ6Kfq506A2MNuQnKGaf/sBC9REA==",
       "cpu": [
         "arm"
       ],
-      "license": "BSD-3-Clause",
+      "license": "FSL-1.1-MIT",
       "optional": true,
       "os": [
         "linux",
@@ -4888,13 +4889,13 @@
       }
     },
     "node_modules/@sentry/cli-linux-arm64": {
-      "version": "2.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.55.0.tgz",
-      "integrity": "sha512-jNB/0/gFcOuDCaY/TqeuEpsy/k52dwyk1SOV3s1ku4DUsln6govTppeAGRewY3T1Rj9B2vgIWTrnB8KVh9+Rgg==",
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.4.tgz",
+      "integrity": "sha512-0g0KwsOozkLtzN8/0+oMZoOuQ0o7W6O+hx+ydVU1bktaMGKEJLMAWxOQNjsh1TcBbNIXVOKM/I8l0ROhaAb8Ig==",
       "cpu": [
         "arm64"
       ],
-      "license": "BSD-3-Clause",
+      "license": "FSL-1.1-MIT",
       "optional": true,
       "os": [
         "linux",
@@ -4906,14 +4907,14 @@
       }
     },
     "node_modules/@sentry/cli-linux-i686": {
-      "version": "2.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.55.0.tgz",
-      "integrity": "sha512-8LZjo6PncTM6bWdaggscNOi5r7F/fqRREsCwvd51dcjGj7Kp1plqo9feEzYQ+jq+KUzVCiWfHrUjddFmYyZJrg==",
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.4.tgz",
+      "integrity": "sha512-NseoIQAFtkziHyjZNPTu1Gm1opeQHt7Wm1LbLrGWVIRvUOzlslO9/8i6wETUZ6TjlQxBVRgd3Q0lRBG2A8rFYA==",
       "cpu": [
         "x86",
         "ia32"
       ],
-      "license": "BSD-3-Clause",
+      "license": "FSL-1.1-MIT",
       "optional": true,
       "os": [
         "linux",
@@ -4925,13 +4926,13 @@
       }
     },
     "node_modules/@sentry/cli-linux-x64": {
-      "version": "2.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.55.0.tgz",
-      "integrity": "sha512-5LUVvq74Yj2cZZy5g5o/54dcWEaX4rf3myTHy73AKhRj1PABtOkfexOLbF9xSrZy95WXWaXyeH+k5n5z/vtHfA==",
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.4.tgz",
+      "integrity": "sha512-d3Arz+OO/wJYTqCYlSN3Ktm+W8rynQ/IMtSZLK8nu0ryh5mJOh+9XlXY6oDXw4YlsM8qCRrNquR8iEI1Y/IH+Q==",
       "cpu": [
         "x64"
       ],
-      "license": "BSD-3-Clause",
+      "license": "FSL-1.1-MIT",
       "optional": true,
       "os": [
         "linux",
@@ -4943,13 +4944,13 @@
       }
     },
     "node_modules/@sentry/cli-win32-arm64": {
-      "version": "2.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.55.0.tgz",
-      "integrity": "sha512-cWIQdzm1pfLwPARsV6dUb8TVd6Y3V1A2VWxjTons3Ift6GvtVmiAe0OWL8t2Yt95i8v61kTD/6Tq21OAaogqzA==",
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.4.tgz",
+      "integrity": "sha512-bqYrF43+jXdDBh0f8HIJU3tbvlOFtGyRjHB8AoRuMQv9TEDUfENZyCelhdjA+KwDKYl48R1Yasb4EHNzsoO83w==",
       "cpu": [
         "arm64"
       ],
-      "license": "BSD-3-Clause",
+      "license": "FSL-1.1-MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4959,14 +4960,14 @@
       }
     },
     "node_modules/@sentry/cli-win32-i686": {
-      "version": "2.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.55.0.tgz",
-      "integrity": "sha512-ldepCn2t9r4I0wvgk7NRaA7coJyy4rTQAzM66u9j5nTEsUldf66xym6esd5ZZRAaJUjffqvHqUIr/lrieTIrVg==",
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.4.tgz",
+      "integrity": "sha512-3triFD6jyvhVcXOmGyttf+deKZcC1tURdhnmDUIBkiDPJKGT/N5xa4qAtHJlAB/h8L9jgYih9bvJnvvFVM7yug==",
       "cpu": [
         "x86",
         "ia32"
       ],
-      "license": "BSD-3-Clause",
+      "license": "FSL-1.1-MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4976,13 +4977,13 @@
       }
     },
     "node_modules/@sentry/cli-win32-x64": {
-      "version": "2.55.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.55.0.tgz",
-      "integrity": "sha512-4hPc/I/9tXx+HLTdTGwlagtAfDSIa2AoTUP30tl32NAYQhx9a6niUbPAemK2qfxesiufJ7D2djX83rCw6WnJVA==",
+      "version": "2.58.4",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.4.tgz",
+      "integrity": "sha512-cSzN4PjM1RsCZ4pxMjI0VI7yNCkxiJ5jmWncyiwHXGiXrV1eXYdQ3n1LhUYLZ91CafyprR0OhDcE+RVZ26Qb5w==",
       "cpu": [
         "x64"
       ],
-      "license": "BSD-3-Clause",
+      "license": "FSL-1.1-MIT",
       "optional": true,
       "os": [
         "win32"
@@ -5017,23 +5018,22 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.12.0.tgz",
-      "integrity": "sha512-Jrf0Yo7DvmI/ZQcvBnA0xKNAFkJlVC/fMlvcin+5IrFNRcqOToZ2vtF+XqTgjRZymXQNE8s1QTD7IomPHk0TAw==",
+      "version": "10.38.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.38.0.tgz",
+      "integrity": "sha512-1pubWDZE5y5HZEPMAZERP4fVl2NH3Ihp1A+vMoVkb3Qc66Diqj1WierAnStlZP7tCx0TBa0dK85GTW/ZFYyB9g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/react": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.12.0.tgz",
-      "integrity": "sha512-TpqgdoYbkf5JynmmW2oQhHQ/h5w+XPYk0cEb/UrsGlvJvnBSR+5tgh0AqxCSi3gvtp82rAXI5w1TyRPBbhLDBw==",
+      "version": "10.38.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.38.0.tgz",
+      "integrity": "sha512-3UiKo6QsqTyPGUt0XWRY9KLaxc/cs6Kz4vlldBSOXEL6qPDL/EfpwNJT61osRo81VFWu8pKu7ZY2bvLPryrnBQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.12.0",
-        "@sentry/core": "10.12.0",
-        "hoist-non-react-statics": "^3.3.2"
+        "@sentry/browser": "10.38.0",
+        "@sentry/core": "10.38.0"
       },
       "engines": {
         "node": ">=18"
@@ -5043,17 +5043,17 @@
       }
     },
     "node_modules/@sentry/react-native": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-7.2.0.tgz",
-      "integrity": "sha512-rjqYgEjntPz1sPysud78wi4B9ui7LBVPsG6qr8s/htLMYho9GPGFA5dF+eqsQWqMX8NDReAxNkLTC4+gCNklLQ==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-7.13.0.tgz",
+      "integrity": "sha512-pKY+rln3CEnhnG21eUXcl/yeG5fkNruqXXjEikE5FjsyLmJi2POAGwT4tlupyHtG3fQT5mp06QI7bQdpAuH4Xw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/babel-plugin-component-annotate": "4.3.0",
-        "@sentry/browser": "10.12.0",
-        "@sentry/cli": "2.55.0",
-        "@sentry/core": "10.12.0",
-        "@sentry/react": "10.12.0",
-        "@sentry/types": "10.12.0"
+        "@sentry/babel-plugin-component-annotate": "4.9.1",
+        "@sentry/browser": "10.38.0",
+        "@sentry/cli": "2.58.4",
+        "@sentry/core": "10.38.0",
+        "@sentry/react": "10.38.0",
+        "@sentry/types": "10.38.0"
       },
       "bin": {
         "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
@@ -5070,12 +5070,12 @@
       }
     },
     "node_modules/@sentry/types": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-10.12.0.tgz",
-      "integrity": "sha512-sKGj3l3V8ZKISh2Tu88bHfnm5ztkRtSLdmpZ6TmCeJdSM9pV+RRd6CMJ0RnSEXmYHselPNUod521t2NQFd4W1w==",
+      "version": "10.38.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-10.38.0.tgz",
+      "integrity": "sha512-DoeyTv/TvnoVDhHgdyv/wehieAKdyjLjEMtPOqqq/AjkP02BxeC0JYUrrWKOjV0wdLq5ZP8jKcCX8GN7awZonQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.12.0"
+        "@sentry/core": "10.38.0"
       },
       "engines": {
         "node": ">=18"
@@ -5473,6 +5473,13 @@
         "@solana/wallet-adapter-base": "*",
         "react": "*"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@stripe/stripe-js": {
       "version": "5.6.0",
@@ -6429,9 +6436,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8530,26 +8537,25 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.37.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.37.0.tgz",
-      "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.0",
-        "@eslint/config-helpers": "^0.4.0",
-        "@eslint/core": "^0.16.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.37.0",
-        "@eslint/plugin-kit": "^0.4.0",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
@@ -8568,7 +8574,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -8787,14 +8793,14 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz",
-      "integrity": "sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==",
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
+      "integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "prettier-linter-helpers": "^1.0.0",
-        "synckit": "^0.11.7"
+        "prettier-linter-helpers": "^1.0.1",
+        "synckit": "^0.11.12"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -9837,6 +9843,13 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.2",
@@ -12502,9 +12515,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -13592,9 +13605,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -13607,9 +13620,9 @@
       }
     },
     "node_modules/prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
+      "integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13620,13 +13633,13 @@
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {
-      "version": "0.6.14",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.14.tgz",
-      "integrity": "sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.8.0.tgz",
+      "integrity": "sha512-V8ITGH87yuBDF6JpEZTOVlUz/saAwqb8f3HRgUj8Lh+tGCcrmorhsLpYqzygwFwK0PE2Ib6Mv3M7T/uE2tZV1g==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14.21.3"
+        "node": ">=20.19"
       },
       "peerDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "*",
@@ -13639,14 +13652,12 @@
         "prettier": "^3.0",
         "prettier-plugin-astro": "*",
         "prettier-plugin-css-order": "*",
-        "prettier-plugin-import-sort": "*",
         "prettier-plugin-jsdoc": "*",
         "prettier-plugin-marko": "*",
         "prettier-plugin-multiline-arrays": "*",
         "prettier-plugin-organize-attributes": "*",
         "prettier-plugin-organize-imports": "*",
         "prettier-plugin-sort-imports": "*",
-        "prettier-plugin-style-order": "*",
         "prettier-plugin-svelte": "*"
       },
       "peerDependenciesMeta": {
@@ -13677,9 +13688,6 @@
         "prettier-plugin-css-order": {
           "optional": true
         },
-        "prettier-plugin-import-sort": {
-          "optional": true
-        },
         "prettier-plugin-jsdoc": {
           "optional": true
         },
@@ -13696,9 +13704,6 @@
           "optional": true
         },
         "prettier-plugin-sort-imports": {
-          "optional": true
-        },
-        "prettier-plugin-style-order": {
           "optional": true
         },
         "prettier-plugin-svelte": {
@@ -15684,6 +15689,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -15999,9 +16015,9 @@
       }
     },
     "node_modules/synckit": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
-      "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
+      "version": "0.11.12",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16021,9 +16037,9 @@
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
-      "version": "3.4.18",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
-      "integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@react-navigation/bottom-tabs": "^7.16.2",
     "@react-navigation/elements": "^2.9.19",
     "@react-navigation/native": "^7.2.5",
-    "@sentry/react-native": "~7.2.0",
+    "@sentry/react-native": "~7.13.0",
     "convex": "^1.39.1",
     "expo": "~54.0.34",
     "expo-apple-authentication": "~8.0.8",
@@ -69,15 +69,15 @@
     "react-native-worklets": "0.5.1"
   },
   "devDependencies": {
-    "@anthropic-ai/sdk": "^0.91.1",
+    "@anthropic-ai/sdk": "^0.98.0",
     "@types/react": "~19.1.0",
-    "eslint": "^9.25.0",
+    "eslint": "^9.39.4",
     "eslint-config-expo": "~10.0.0",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-prettier": "^5.5.4",
-    "prettier": "^3.6.2",
-    "prettier-plugin-tailwindcss": "^0.6.14",
-    "tailwindcss": "^3.4.18",
+    "eslint-plugin-prettier": "^5.5.5",
+    "prettier": "^3.8.3",
+    "prettier-plugin-tailwindcss": "^0.8.0",
+    "tailwindcss": "^3.4.19",
     "typescript": "~5.9.2"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
### Dev tooling bumps
- `@anthropic-ai/sdk` 0.91.1 → 0.98.0 (dev-only, used in `enrich-names` script)
- `eslint` 9.37 → 9.39.4
- `eslint-plugin-prettier` 5.5.4 → 5.5.5
- `prettier` 3.6.2 → 3.8.3 (different default formatting)
- `prettier-plugin-tailwindcss` 0.6 → 0.8
- `tailwindcss` 3.4.18 → 3.4.19

### Production minor
- `@sentry/react-native` 7.2.0 → 7.13.0 (no breaking changes in 7.x)

### Reformatting
New Prettier 3.8 defaults caused 16 source files to need reformatting. Net change reduces ESLint error count from 240 to 4 (4 pre-existing unescaped-quote errors in `decline-sheet.tsx` and `proposal-banner.tsx` — unrelated to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)