### PR TITLE
feat: use native Sign in with Apple via useSignInWithApple

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -1,4 +1,4 @@
-import { useSignIn, useSSO } from '@clerk/clerk-expo';
+import { useSignIn, useSignInWithApple, useSSO } from '@clerk/clerk-expo';
 import { useRouter } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
 import { useCallback, useState } from 'react';
@@ -21,6 +21,7 @@ function getClerkError(err: unknown, fallback: string): string {
 export default function SignIn() {
   const { signIn, setActive, isLoaded } = useSignIn();
   const { startSSOFlow } = useSSO();
+  const { startAppleAuthenticationFlow } = useSignInWithApple();
   const router = useRouter();
 
   const { colors } = useTheme();
@@ -145,20 +146,21 @@ export default function SignIn() {
     setError('');
 
     try {
-      const { createdSessionId, setActive: ssoSetActive } = await startSSOFlow({
-        strategy: 'oauth_apple',
-      });
+      const { createdSessionId, setActive: appleSetActive } =
+        await startAppleAuthenticationFlow();
 
-      if (createdSessionId && ssoSetActive) {
-        await ssoSetActive({ session: createdSessionId });
+      if (createdSessionId && appleSetActive) {
+        await appleSetActive({ session: createdSessionId });
         router.replace('/');
       }
     } catch (err: unknown) {
+      const appleError = err as { code?: string };
+      if (appleError.code === 'ERR_REQUEST_CANCELED') return;
       setError(getClerkError(err, 'Apple sign in failed'));
     } finally {
       setIsLoading(false);
     }
-  }, [startSSOFlow, router]);
+  }, [startAppleAuthenticationFlow, router]);
 
   return (
     <GradientBackground variant="auth">

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -1,4 +1,4 @@
-import { useSignUp, useSSO } from '@clerk/clerk-expo';
+import { useSignInWithApple, useSignUp, useSSO } from '@clerk/clerk-expo';
 import { useRouter } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
 import { useCallback, useState } from 'react';
@@ -17,6 +17,7 @@ WebBrowser.maybeCompleteAuthSession();
 export default function SignUp() {
   const { signUp, setActive, isLoaded } = useSignUp();
   const { startSSOFlow } = useSSO();
+  const { startAppleAuthenticationFlow } = useSignInWithApple();
   const router = useRouter();
 
   const { colors } = useTheme();
@@ -98,22 +99,23 @@ export default function SignUp() {
     setError('');
 
     try {
-      const { createdSessionId, setActive: ssoSetActive } = await startSSOFlow({
-        strategy: 'oauth_apple',
-      });
+      const { createdSessionId, setActive: appleSetActive } =
+        await startAppleAuthenticationFlow();
 
-      if (createdSessionId && ssoSetActive) {
-        await ssoSetActive({ session: createdSessionId });
+      if (createdSessionId && appleSetActive) {
+        await appleSetActive({ session: createdSessionId });
         trackEvent(Events.SIGN_UP, { method: 'apple' });
         router.replace('/');
       }
     } catch (err: unknown) {
+      const appleError = err as { code?: string };
+      if (appleError.code === 'ERR_REQUEST_CANCELED') return;
       const clerkError = err as { errors?: { message: string }[] };
       setError(clerkError.errors?.[0]?.message || 'Apple sign up failed');
     } finally {
       setIsLoading(false);
     }
-  }, [startSSOFlow, router]);
+  }, [startAppleAuthenticationFlow, router]);
 
   if (pendingVerification) {
     return (


### PR DESCRIPTION
## Summary
Replaces Clerk's web-routed `startSSOFlow({ strategy: 'oauth_apple' })` with the native `useSignInWithApple` hook. Eliminates the double-modal UX where a web sheet would slide up before the native Apple sheet appeared on top of it.

The `useSignInWithApple` hook wraps `expo-apple-authentication` and handles the ID token exchange with Clerk's backend automatically. Same Clerk session creation flow on success.

### Changes
- `app/(auth)/sign-up.tsx` — `handleAppleSignUp` now uses `startAppleAuthenticationFlow()`
- `app/(auth)/sign-in.tsx` — `handleAppleSignIn` now uses `startAppleAuthenticationFlow()`
- Both: silently swallow `ERR_REQUEST_CANCELED` when user dismisses the native sheet (not a real error)

Google sign-in untouched (still uses `useSSO`) — there's no native Google Sign-In flow comparable to Apple's.

## Test plan
- [ ] Tap "Continue with Apple" on sign-in / sign-up screens
- [ ] Confirm only the native Apple sheet appears (no web-browser slide-up underneath)
- [ ] Complete sign-up flow → land on dashboard, Convex user created
- [ ] Sign out, sign back in with Apple → land on dashboard
- [ ] Cancel the native Apple sheet → no error banner shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)