### PR TITLE
ci: add development-device profile for physical iPhone testing

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -37,4 +37,4 @@ jobs:
         run: npm ci
 
       - name: Build development client
-        run: eas build --platform ios --profile development --non-interactive --no-wait
+        run: eas build --platform ios --profile development-device --non-interactive --no-wait

--- a/eas.json
+++ b/eas.json
@@ -14,6 +14,16 @@
         "simulator": true
       }
     },
+    "development-device": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "env": {
+        "APP_ENV": "development"
+      },
+      "ios": {
+        "simulator": false
+      }
+    },
     "preview": {
       "distribution": "internal",
       "env": {


### PR DESCRIPTION
## Summary
The existing `development` profile in `eas.json` had `simulator: true`, so EAS builds produced a `.tar.gz` for the iOS Simulator only — not installable on physical devices. CI's dev builds were therefore not actually usable for on-device testing.

This adds a parallel `development-device` profile with `simulator: false` that produces an installable `.ipa` for registered iOS devices. CI now builds this variant so each merge to master produces a binary you can install on your iPhone via QR / share link.

The original `development` profile is kept for local simulator iteration:
```
eas build --profile development
```

## Test plan
- [ ] Merge → `dev-build.yml` re-triggers and produces an `.ipa` (not `.tar.gz`)
- [ ] Build installs on registered iPhone via QR scan
- [ ] App connects to local Metro and Apple Sign-In native flow works

🤖 Generated with [Claude Code](https://claude.com/claude-code)