### PR TITLE
ci: add preview-build workflow for installable on-device builds

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,0 +1,44 @@
+name: Preview build
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or commit SHA to build (defaults to master)"
+        required: false
+        default: "master"
+
+jobs:
+  build:
+    name: Build preview client (iOS)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for EXPO_TOKEN
+        run: |
+          if [ -z "${{ secrets.EXPO_TOKEN }}" ]; then
+            echo "EXPO_TOKEN is not set. Add it at https://github.com/${{ github.repository }}/settings/secrets/actions"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build preview
+        run: eas build --platform ios --profile preview --non-interactive --no-wait


### PR DESCRIPTION
## Summary
Manual `workflow_dispatch` workflow that builds the `preview` profile from `eas.json`. Produces an installable `.ipa` for registered iOS devices — no TestFlight submission, no Apple review.

### Use cases
- Share a fixed snapshot with a tester / yourself for QA
- On-device testing without running Metro
- Preview PR work before merging (optional `ref` input lets you build any branch / tag / SHA)

### Caveats
- First invocation will fail in non-interactive mode — needs an initial interactive `eas build --profile preview` to bootstrap credentials (same dance as production / development-device)

🤖 Generated with [Claude Code](https://claude.com/claude-code)