### PR TITLE
chore: install expo-auth-session as a peer dep of @clerk/clerk-expo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "convex": "^1.39.1",
         "expo": "~54.0.34",
         "expo-apple-authentication": "~8.0.8",
+        "expo-auth-session": "~7.0.11",
         "expo-blur": "~15.0.8",
         "expo-clipboard": "~8.0.8",
         "expo-constants": "~18.0.10",
@@ -9112,6 +9113,24 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-auth-session": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/expo-auth-session/-/expo-auth-session-7.0.11.tgz",
+      "integrity": "sha512-AhWtt/m9rb1Po77X/VBFbeE6UTgbm2vXP2iCblUSRsHCw2qD6lO0ulKUB8Xyxy9FtoI9yrNQ1iwCNgIIgo8VYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-application": "~7.0.8",
+        "expo-constants": "~18.0.13",
+        "expo-crypto": "~15.0.9",
+        "expo-linking": "~8.0.12",
+        "expo-web-browser": "~15.0.11",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-blur": {
       "version": "15.0.8",
       "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-15.0.8.tgz",
@@ -9146,6 +9165,18 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-crypto": {
+      "version": "15.0.9",
+      "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-15.0.9.tgz",
+      "integrity": "sha512-SNWKa2fXx7v9gkp1h/7nqXY5XN7qgNDn3yRc2aO0gWGbeMbvob/haMxxsPFe9f51aqH5NjNCqHf2kvLhvAd8KQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-dev-client": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "convex": "^1.39.1",
     "expo": "~54.0.34",
     "expo-apple-authentication": "~8.0.8",
+    "expo-auth-session": "~7.0.11",
     "expo-blur": "~15.0.8",
     "expo-clipboard": "~8.0.8",
     "expo-constants": "~18.0.10",


### PR DESCRIPTION
## Summary
Fixes preview/production bundle failure:
```
Unable to resolve module expo-auth-session from
node_modules/@clerk/clerk-expo/dist/hooks/useOAuth.js
```

`@clerk/clerk-expo` 2.19.x imports `expo-auth-session` from inside its OAuth hook but doesn't list it as a direct dependency — it expects the host project to install it.

### Why this didn't show up earlier
Dev builds bundle JS *at runtime via Metro*, which is lenient about lazy resolution. Preview/production bundle JS *at build time* via `expo export:embed`, which is strict — every transitive `require` must resolve.

Same pattern as `expo-dev-client` (#76).

## Test plan
- [ ] Re-run preview build — should now bundle successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)