### PR TITLE
revert: async-storage 3.1.0 → 2.2.0 (preview crash)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@expo-google-fonts/gabarito": "^0.4.2",
         "@expo-google-fonts/sanchez": "^0.4.1",
         "@expo/vector-icons": "^15.1.1",
-        "@react-native-async-storage/async-storage": "^3.1.0",
+        "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-community/netinfo": "11.4.1",
         "@react-navigation/bottom-tabs": "^7.16.2",
         "@react-navigation/elements": "^2.9.19",
@@ -4296,16 +4296,15 @@
       }
     },
     "node_modules/@react-native-async-storage/async-storage": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-3.1.0.tgz",
-      "integrity": "sha512-ENwbn3kj/dOapdR3GVgfX5x9f9/rxHnsqol1bUkt26lrv0aAq6UoXnTlv7y2dT7RH0AShh9B1+KAPDVjJXnk0w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
       "license": "MIT",
       "dependencies": {
-        "idb": "8.0.3"
+        "merge-options": "^3.0.4"
       },
       "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native-community/netinfo": {
@@ -10612,12 +10611,6 @@
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/idb": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
-      "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
-      "license": "ISC"
-    },
     "node_modules/idb-keyval": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
@@ -11114,7 +11107,6 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -12175,7 +12167,6 @@
       "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
       "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "is-plain-obj": "^2.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@expo-google-fonts/gabarito": "^0.4.2",
     "@expo-google-fonts/sanchez": "^0.4.1",
     "@expo/vector-icons": "^15.1.1",
-    "@react-native-async-storage/async-storage": "^3.1.0",
+    "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/netinfo": "11.4.1",
     "@react-navigation/bottom-tabs": "^7.16.2",
     "@react-navigation/elements": "^2.9.19",


### PR DESCRIPTION
## Summary
Reverts #103. Preview build (master HEAD up to #115) crashes immediately on cold start on real devices. Crash report shows:

- Faulting thread: `com.meta.react.turbomodulemanager.queue`
- ~0.6s after launch
- `objc_exception_rethrow` during `ObjCTurboModule::performVoidMethodInvocation`

That pattern matches a native module throwing on first JS call. Async-storage v3 has documented native bridge changes ("scoped storages", reworked init), and is called from multiple contexts in `app/_layout.tsx` on first render — exactly when this crash fires.

Sentry didn't catch the crash because Sentry's init runs after the bridge is up, but the crash beats it to the punch.

If this fixes the cold-start crash, async-storage 3 needs proper migration (separate PR). For now staying on 2.x keeps everything else current.

## Test plan
- [ ] Re-run preview build
- [ ] Install on iPhone, confirm cold start no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)