### PR TITLE
feat: full Sentry + PostHog instrumentation across the app

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -1,4 +1,5 @@
 import { useSignIn, useSignInWithApple, useSSO } from '@clerk/clerk-expo';
+import * as Sentry from '@sentry/react-native';
 import { useRouter } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
 import { useCallback, useState } from 'react';
@@ -10,6 +11,7 @@ import { GradientButton } from '@/components/ui/gradient-button';
 import { StyledInput } from '@/components/ui/styled-input';
 import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
+import { Events, trackEvent } from '@/lib/analytics';
 
 WebBrowser.maybeCompleteAuthSession();
 
@@ -47,10 +49,14 @@ export default function SignIn() {
 
       if (result.status === 'complete') {
         await setActive({ session: result.createdSessionId });
+        trackEvent(Events.SIGN_IN, { method: 'email' });
         router.replace('/');
       }
     } catch (err: unknown) {
-      setError(getClerkError(err, 'Sign in failed'));
+      const message = getClerkError(err, 'Sign in failed');
+      setError(message);
+      Sentry.captureException(err, { tags: { flow: 'sign_in', method: 'email' } });
+      trackEvent(Events.SIGN_IN_FAILED, { method: 'email', reason: message });
     } finally {
       setIsLoading(false);
     }
@@ -74,6 +80,7 @@ export default function SignIn() {
       setResetFlow('code');
     } catch (err: unknown) {
       setError(getClerkError(err, 'Failed to send reset code'));
+      Sentry.captureException(err, { tags: { flow: 'forgot_password' } });
     } finally {
       setIsLoading(false);
     }
@@ -96,6 +103,7 @@ export default function SignIn() {
       }
     } catch (err: unknown) {
       setError(getClerkError(err, 'Invalid code'));
+      Sentry.captureException(err, { tags: { flow: 'reset_password_verify' } });
     } finally {
       setIsLoading(false);
     }
@@ -116,6 +124,7 @@ export default function SignIn() {
       }
     } catch (err: unknown) {
       setError(getClerkError(err, 'Failed to reset password'));
+      Sentry.captureException(err, { tags: { flow: 'reset_password' } });
     } finally {
       setIsLoading(false);
     }
@@ -132,10 +141,14 @@ export default function SignIn() {
 
       if (createdSessionId && ssoSetActive) {
         await ssoSetActive({ session: createdSessionId });
+        trackEvent(Events.SIGN_IN, { method: 'google' });
         router.replace('/');
       }
     } catch (err: unknown) {
-      setError(getClerkError(err, 'Google sign in failed'));
+      const message = getClerkError(err, 'Google sign in failed');
+      setError(message);
+      Sentry.captureException(err, { tags: { flow: 'sign_in', method: 'google' } });
+      trackEvent(Events.SIGN_IN_FAILED, { method: 'google', reason: message });
     } finally {
       setIsLoading(false);
     }
@@ -146,17 +159,20 @@ export default function SignIn() {
     setError('');
 
     try {
-      const { createdSessionId, setActive: appleSetActive } =
-        await startAppleAuthenticationFlow();
+      const { createdSessionId, setActive: appleSetActive } = await startAppleAuthenticationFlow();
 
       if (createdSessionId && appleSetActive) {
         await appleSetActive({ session: createdSessionId });
+        trackEvent(Events.SIGN_IN, { method: 'apple' });
         router.replace('/');
       }
     } catch (err: unknown) {
       const appleError = err as { code?: string };
       if (appleError.code === 'ERR_REQUEST_CANCELED') return;
-      setError(getClerkError(err, 'Apple sign in failed'));
+      const message = getClerkError(err, 'Apple sign in failed');
+      setError(message);
+      Sentry.captureException(err, { tags: { flow: 'sign_in', method: 'apple' } });
+      trackEvent(Events.SIGN_IN_FAILED, { method: 'apple', reason: message });
     } finally {
       setIsLoading(false);
     }

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -1,4 +1,5 @@
 import { useSignInWithApple, useSignUp, useSSO } from '@clerk/clerk-expo';
+import * as Sentry from '@sentry/react-native';
 import { useRouter } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
 import { useCallback, useState } from 'react';
@@ -11,6 +12,11 @@ import { StyledInput } from '@/components/ui/styled-input';
 import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { trackEvent, Events } from '@/lib/analytics';
+
+function getClerkError(err: unknown, fallback: string): string {
+  const clerkError = err as { errors?: { message: string }[] };
+  return clerkError.errors?.[0]?.message || fallback;
+}
 
 WebBrowser.maybeCompleteAuthSession();
 
@@ -43,8 +49,10 @@ export default function SignUp() {
       await signUp.prepareEmailAddressVerification({ strategy: 'email_code' });
       setPendingVerification(true);
     } catch (err: unknown) {
-      const clerkError = err as { errors?: { message: string }[] };
-      setError(clerkError.errors?.[0]?.message || 'Sign up failed');
+      const message = getClerkError(err, 'Sign up failed');
+      setError(message);
+      Sentry.captureException(err, { tags: { flow: 'sign_up', method: 'email' } });
+      trackEvent(Events.SIGN_UP_FAILED, { method: 'email', reason: message });
     } finally {
       setIsLoading(false);
     }
@@ -65,8 +73,10 @@ export default function SignUp() {
         router.replace('/');
       }
     } catch (err: unknown) {
-      const clerkError = err as { errors?: { message: string }[] };
-      setError(clerkError.errors?.[0]?.message || 'Verification failed');
+      const message = getClerkError(err, 'Verification failed');
+      setError(message);
+      Sentry.captureException(err, { tags: { flow: 'sign_up_verify', method: 'email' } });
+      trackEvent(Events.SIGN_UP_FAILED, { method: 'email', reason: message });
     } finally {
       setIsLoading(false);
     }
@@ -87,8 +97,10 @@ export default function SignUp() {
         router.replace('/');
       }
     } catch (err: unknown) {
-      const clerkError = err as { errors?: { message: string }[] };
-      setError(clerkError.errors?.[0]?.message || 'Google sign up failed');
+      const message = getClerkError(err, 'Google sign up failed');
+      setError(message);
+      Sentry.captureException(err, { tags: { flow: 'sign_up', method: 'google' } });
+      trackEvent(Events.SIGN_UP_FAILED, { method: 'google', reason: message });
     } finally {
       setIsLoading(false);
     }
@@ -99,8 +111,7 @@ export default function SignUp() {
     setError('');
 
     try {
-      const { createdSessionId, setActive: appleSetActive } =
-        await startAppleAuthenticationFlow();
+      const { createdSessionId, setActive: appleSetActive } = await startAppleAuthenticationFlow();
 
       if (createdSessionId && appleSetActive) {
         await appleSetActive({ session: createdSessionId });
@@ -110,8 +121,10 @@ export default function SignUp() {
     } catch (err: unknown) {
       const appleError = err as { code?: string };
       if (appleError.code === 'ERR_REQUEST_CANCELED') return;
-      const clerkError = err as { errors?: { message: string }[] };
-      setError(clerkError.errors?.[0]?.message || 'Apple sign up failed');
+      const message = getClerkError(err, 'Apple sign up failed');
+      setError(message);
+      Sentry.captureException(err, { tags: { flow: 'sign_up', method: 'apple' } });
+      trackEvent(Events.SIGN_UP_FAILED, { method: 'apple', reason: message });
     } finally {
       setIsLoading(false);
     }

--- a/app/(tabs)/explore/filters.tsx
+++ b/app/(tabs)/explore/filters.tsx
@@ -12,6 +12,7 @@ import { GradientBackground } from '@/components/ui/gradient-background';
 import { SlotCounter } from '@/components/ui/slot-counter';
 import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
+import { Events, trackEvent } from '@/lib/analytics';
 
 type GenderFilter = 'boy' | 'girl' | 'both';
 
@@ -44,6 +45,11 @@ export default function Filters() {
     async (gender: GenderFilter, origin: string[] | null) => {
       try {
         await updateFilters({ genderFilter: gender, originFilter: origin ?? [] });
+        trackEvent(Events.FILTERS_CHANGED, {
+          gender_filter: gender,
+          origin_count: origin?.length ?? 0,
+          all_origins: origin === null,
+        });
       } catch (error) {
         Sentry.captureException(error);
         Alert.alert('Error', 'Failed to save filters. Please try again.');

--- a/app/(tabs)/matches.tsx
+++ b/app/(tabs)/matches.tsx
@@ -10,7 +10,7 @@ import { api } from '@/convex/_generated/api';
 import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { useEffectivePremium } from '@/hooks/use-effective-premium';
-import { trackScreen } from '@/lib/analytics';
+import { Events, trackEvent, trackScreen } from '@/lib/analytics';
 import { usePurchases } from '@/hooks/use-purchases';
 import { Paywall } from '@/components/paywall';
 import {
@@ -135,6 +135,7 @@ export default function Matches() {
           matchId: proposeTarget._id,
           message,
         });
+        trackEvent(Events.PROPOSAL_SENT);
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
         setProposeTarget(null);
       } catch (error) {
@@ -152,6 +153,7 @@ export default function Matches() {
         matchId: pendingProposal._id,
         accept: true,
       });
+      trackEvent(Events.PROPOSAL_ACCEPTED);
       setCelebrationName(pendingProposal.name?.name ?? '');
       setShowCelebration(true);
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
@@ -170,6 +172,7 @@ export default function Matches() {
           accept: false,
           message,
         });
+        trackEvent(Events.PROPOSAL_DECLINED);
         setShowDeclineSheet(false);
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
       } catch (error) {
@@ -192,6 +195,7 @@ export default function Matches() {
             onPress: async () => {
               try {
                 await withdrawProposalMutation({ matchId });
+                trackEvent(Events.PROPOSAL_WITHDRAWN);
                 Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
               } catch (error) {
                 Sentry.captureException(error);

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -5,7 +5,7 @@ import * as Sentry from '@sentry/react-native';
 import * as Clipboard from 'expo-clipboard';
 import { useCallback, useRef, useState } from 'react';
 import { useFocusEffect } from 'expo-router';
-import { trackScreen } from '@/lib/analytics';
+import { Events, resetAnalytics, trackEvent, trackScreen } from '@/lib/analytics';
 import {
   Alert,
   Pressable,
@@ -123,7 +123,10 @@ export default function Profile() {
   const handleSignOut = useCallback(async () => {
     setIsLoading(true);
     try {
+      trackEvent(Events.SIGNED_OUT);
       await signOut();
+      Sentry.setUser(null);
+      resetAnalytics();
     } finally {
       setIsLoading(false);
     }
@@ -142,7 +145,10 @@ export default function Profile() {
             setIsLoading(true);
             try {
               await deleteAccount();
+              trackEvent(Events.ACCOUNT_DELETED);
               await signOut();
+              Sentry.setUser(null);
+              resetAnalytics();
             } catch (error) {
               Sentry.captureException(error);
               Alert.alert('Error', 'Failed to delete account. Please try again.');
@@ -158,6 +164,7 @@ export default function Profile() {
   const handleCopyCode = useCallback(async () => {
     if (partnerInfo?.shareCode) {
       await Clipboard.setStringAsync(partnerInfo.shareCode);
+      trackEvent(Events.PARTNER_CODE_COPIED);
       Alert.alert('Copied', 'Share code copied to clipboard!');
     }
   }, [partnerInfo?.shareCode]);
@@ -168,6 +175,7 @@ export default function Profile() {
         await Share.share({
           message: `Join me on Bambino! Use my partner code: ${partnerInfo.shareCode}`,
         });
+        trackEvent(Events.PARTNER_CODE_SHARED);
       } catch (error) {
         Sentry.captureException(error);
       }
@@ -247,6 +255,7 @@ export default function Profile() {
           onPress: async () => {
             try {
               await unlinkPartner();
+              trackEvent(Events.PARTNER_UNLINKED);
             } catch (error) {
               Sentry.captureException(error);
               Alert.alert('Error', 'Failed to unlink partner. Please try again.');

--- a/components/matches/match-detail-modal.tsx
+++ b/components/matches/match-detail-modal.tsx
@@ -10,6 +10,7 @@ import { GenderBadge } from '@/components/name-detail/gender-badge';
 import * as Haptics from 'expo-haptics';
 import * as Sentry from '@sentry/react-native';
 import { AnimatedBottomSheet } from '@/components/ui/animated-bottom-sheet';
+import { Events, trackEvent } from '@/lib/analytics';
 
 interface MatchDetailModalProps {
   visible: boolean;
@@ -43,6 +44,13 @@ export function MatchDetailModal({ visible, match, onClose }: MatchDetailModalPr
     }
   }, [match]);
 
+  // Fire match_viewed when the modal opens with a match
+  useEffect(() => {
+    if (visible && match) {
+      trackEvent(Events.MATCH_VIEWED, { match_id: match._id });
+    }
+  }, [visible, match]);
+
   if (!match) return null;
 
   const { name, isFavorite, isChosen } = match;
@@ -71,6 +79,7 @@ export function MatchDetailModal({ visible, match, onClose }: MatchDetailModalPr
         matchId: match._id,
         isFavorite: !isFavorite,
       });
+      trackEvent(Events.MATCH_FAVORITED, { favorited: !isFavorite });
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     } catch (error) {
       Sentry.captureException(error);
@@ -91,6 +100,7 @@ export function MatchDetailModal({ visible, match, onClose }: MatchDetailModalPr
                 matchId: match._id,
                 isChosen: true,
               });
+              trackEvent(Events.NAME_CHOSEN);
               Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
               onClose();
             } catch (error) {
@@ -115,6 +125,7 @@ export function MatchDetailModal({ visible, match, onClose }: MatchDetailModalPr
           onPress: async () => {
             try {
               await deleteMatch({ matchId: match._id });
+              trackEvent(Events.MATCH_REMOVED);
               Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
               onClose();
             } catch (error) {

--- a/components/onboarding/onboarding-screens.tsx
+++ b/components/onboarding/onboarding-screens.tsx
@@ -1,8 +1,9 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { View, Text, Pressable, StyleSheet, FlatList, Dimensions } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
+import { Events, trackEvent } from '@/lib/analytics';
 import { WelcomeSplash } from './welcome-splash';
 import { SwipeDemo } from './swipe-demo';
 import { MultiplayerIntro } from './multiplayer-intro';
@@ -26,11 +27,19 @@ export function OnboardingScreens({ onComplete }: OnboardingScreensProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const flatListRef = useRef<FlatList>(null);
 
+  // Fire onboarding_started once when the carousel mounts
+  useEffect(() => {
+    trackEvent(Events.ONBOARDING_STARTED);
+  }, []);
+
   const handleNext = useCallback(() => {
     if (currentIndex < TOTAL_SCREENS - 1) {
-      flatListRef.current?.scrollToIndex({ index: currentIndex + 1 });
-      setCurrentIndex(currentIndex + 1);
+      const nextIndex = currentIndex + 1;
+      flatListRef.current?.scrollToIndex({ index: nextIndex });
+      setCurrentIndex(nextIndex);
+      trackEvent(Events.ONBOARDING_SLIDE_ADVANCED, { slide_index: nextIndex });
     } else {
+      trackEvent(Events.ONBOARDING_COMPLETED);
       onComplete();
     }
   }, [currentIndex, onComplete]);

--- a/components/partner/partner-link-modal.tsx
+++ b/components/partner/partner-link-modal.tsx
@@ -15,8 +15,9 @@ import { api } from '@/convex/_generated/api';
 import { Fonts } from '@/constants/theme';
 import { LoadingIndicator } from '@/components/ui/loading-indicator';
 import { Paywall } from '@/components/paywall';
+import * as Sentry from '@sentry/react-native';
 import { useTheme } from '@/contexts/theme-context';
-import { trackEvent } from '@/lib/analytics';
+import { Events, trackEvent } from '@/lib/analytics';
 import { AnimatedBottomSheet } from '@/components/ui/animated-bottom-sheet';
 import { StyledInput } from '@/components/ui/styled-input';
 import { NameConfirmationModal } from './name-confirmation-modal';
@@ -129,10 +130,11 @@ export function PartnerLinkModal({ visible, onClose }: PartnerLinkModalProps) {
         return;
       }
 
-      trackEvent('partner_linked');
+      trackEvent(Events.PARTNER_LINKED);
       handleClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to link partner');
+      Sentry.captureException(err, { tags: { flow: 'partner_link' } });
       setIsLinking(false);
     }
   };

--- a/components/paywall.tsx
+++ b/components/paywall.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { View, Text, Pressable, StyleSheet, Alert } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { usePurchases } from '@/hooks/use-purchases';
@@ -34,13 +34,20 @@ export function Paywall({ visible, onClose, trigger = 'swipe_limit' }: PaywallPr
   const hasPackages = packages.length > 0;
   const price = packages[0]?.product.priceString ?? '$4.99';
 
+  useEffect(() => {
+    if (visible) trackEvent(Events.PAYWALL_SHOWN, { trigger });
+  }, [visible, trigger]);
+
   const handlePurchase = async () => {
     setIsPurchasing(true);
+    trackEvent(Events.PURCHASE_ATTEMPTED, { trigger });
     try {
       const success = await purchasePremium();
       if (success) {
         trackEvent(Events.PURCHASE_COMPLETED, { trigger });
         onClose();
+      } else {
+        trackEvent(Events.PURCHASE_FAILED, { trigger, reason: 'cancelled_or_failed' });
       }
     } finally {
       setIsPurchasing(false);
@@ -52,6 +59,7 @@ export function Paywall({ visible, onClose, trigger = 'swipe_limit' }: PaywallPr
     try {
       const success = await restorePurchases();
       if (success) {
+        trackEvent(Events.PURCHASE_RESTORED);
         onClose();
         Alert.alert('Restored', 'Your premium purchase has been restored!');
       } else {

--- a/components/settings/feedback-section.tsx
+++ b/components/settings/feedback-section.tsx
@@ -3,6 +3,7 @@ import { View, Text, Pressable, TextInput, StyleSheet } from 'react-native';
 import { useFocusEffect } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useAction } from 'convex/react';
+import * as Sentry from '@sentry/react-native';
 import { api } from '@/convex/_generated/api';
 import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
@@ -52,8 +53,9 @@ export function FeedbackSection() {
         setCategory(null);
         setMessage('');
       }, 2000);
-    } catch {
+    } catch (err) {
       setErrorMessage('Something went wrong. Try again.');
+      Sentry.captureException(err, { tags: { flow: 'feedback_submit' } });
     } finally {
       setIsSubmitting(false);
     }

--- a/components/settings/skin-tone-section.tsx
+++ b/components/settings/skin-tone-section.tsx
@@ -14,6 +14,7 @@ import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { useSkinTone } from '@/contexts/skin-tone-context';
 import { SKIN_TONE_OPTIONS, getGenderEmoji, type SkinToneKey } from '@/constants/skin-tone';
+import { Events, trackEvent } from '@/lib/analytics';
 
 const SPRING_CONFIG = { damping: 20, stiffness: 200 };
 const COLOR_TIMING = { duration: 350, easing: Easing.out(Easing.cubic) };
@@ -95,7 +96,12 @@ export function SkinToneSection() {
                 key={option.key}
                 toneKey={option.key}
                 isSelected={skinTone === option.key}
-                onSelect={() => setSkinTone(option.key)}
+                onSelect={() => {
+                  if (skinTone !== option.key) {
+                    trackEvent(Events.SKIN_TONE_CHANGED, { tone: option.key });
+                  }
+                  setSkinTone(option.key);
+                }}
                 primaryColor={colors.primary}
               />
             ))}

--- a/components/settings/theme-picker-section.tsx
+++ b/components/settings/theme-picker-section.tsx
@@ -13,6 +13,7 @@ import Animated, {
 import { Ionicons } from '@expo/vector-icons';
 import { Fonts, THEME_META, CANDY_THEMES, type ThemeKey } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
+import { Events, trackEvent } from '@/lib/analytics';
 
 const SPRING_CONFIG = { damping: 20, stiffness: 200 };
 const COLOR_TIMING = { duration: 350, easing: Easing.out(Easing.cubic) };
@@ -145,7 +146,12 @@ export function ThemePickerSection() {
                 key={key}
                 themeKey={key}
                 isSelected={themeKey === key}
-                onSelect={() => setTheme(key)}
+                onSelect={() => {
+                  if (themeKey !== key) {
+                    trackEvent(Events.THEME_CHANGED, { from: themeKey, to: key });
+                  }
+                  setTheme(key);
+                }}
               />
             ))}
           </View>

--- a/components/settings/voice-settings-section.tsx
+++ b/components/settings/voice-settings-section.tsx
@@ -8,6 +8,7 @@ import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { LoadingIndicator } from '@/components/ui/loading-indicator';
 import * as Sentry from '@sentry/react-native';
+import { Events, trackEvent } from '@/lib/analytics';
 
 interface Voice {
   identifier: string;
@@ -86,6 +87,7 @@ export function VoiceSettingsSection() {
   const handleSelectVoice = useCallback(
     async (identifier: string | null) => {
       await setVoiceIdentifier(identifier);
+      trackEvent(Events.VOICE_CHANGED, { voice_id: identifier ?? 'system_default' });
       setIsExpanded(false);
     },
     [setVoiceIdentifier],

--- a/hooks/use-push-registration.ts
+++ b/hooks/use-push-registration.ts
@@ -8,6 +8,7 @@ import { Platform } from 'react-native';
 import * as Sentry from '@sentry/react-native';
 
 import { api } from '@/convex/_generated/api';
+import { Events, trackEvent } from '@/lib/analytics';
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -41,8 +42,12 @@ export function usePushRegistration() {
         let finalStatus = existingStatus;
 
         if (existingStatus !== 'granted') {
+          trackEvent(Events.PUSH_PERMISSION_REQUESTED);
           const { status } = await Notifications.requestPermissionsAsync();
           finalStatus = status;
+          trackEvent(
+            status === 'granted' ? Events.PUSH_PERMISSION_GRANTED : Events.PUSH_PERMISSION_DENIED,
+          );
         }
 
         if (finalStatus !== 'granted') {

--- a/hooks/use-store-user.ts
+++ b/hooks/use-store-user.ts
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import * as Sentry from '@sentry/react-native';
 
 import { api } from '@/convex/_generated/api';
+import { identifyUser } from '@/lib/analytics';
 
 export function useStoreUser() {
   const { isSignedIn, user } = useUser();
@@ -14,11 +15,20 @@ export function useStoreUser() {
       return;
     }
 
+    const email = user.primaryEmailAddress?.emailAddress ?? '';
+    const name = user.fullName ?? undefined;
+
+    Sentry.setUser({ id: user.id, email });
+    identifyUser(user.id, {
+      ...(email ? { email } : {}),
+      ...(name ? { name } : {}),
+    });
+
     const syncUser = async () => {
       try {
         await createOrUpdateUser({
-          email: user.primaryEmailAddress?.emailAddress ?? '',
-          name: user.fullName ?? undefined,
+          email,
+          name,
           imageUrl: user.imageUrl ?? undefined,
         });
       } catch (error) {

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -32,15 +32,54 @@ export function resetAnalytics() {
   posthog?.reset();
 }
 
-// Key event names
+// Event taxonomy. Naming convention: object_past-tense-verb, snake_case.
 export const Events = {
-  SIGN_UP: 'sign_up',
+  // Auth & identity
   SIGN_IN: 'sign_in',
-  SEARCH_CREATED: 'search_created',
+  SIGN_IN_FAILED: 'sign_in_failed',
+  SIGN_UP: 'sign_up',
+  SIGN_UP_FAILED: 'sign_up_failed',
+  SIGNED_OUT: 'signed_out',
+  ACCOUNT_DELETED: 'account_deleted',
+
+  // Onboarding
+  ONBOARDING_STARTED: 'onboarding_started',
+  ONBOARDING_SLIDE_ADVANCED: 'onboarding_slide_advanced',
+  ONBOARDING_COMPLETED: 'onboarding_completed',
+
+  // Swipe & matches
   NAME_SWIPED: 'name_swiped',
   MATCH_FOUND: 'match_found',
-  PURCHASE_COMPLETED: 'purchase_completed',
-  PURCHASE_RESTORED: 'purchase_restored',
+  MATCH_VIEWED: 'match_viewed',
+  MATCH_FAVORITED: 'match_favorited',
+  NAME_CHOSEN: 'name_chosen',
+  MATCH_REMOVED: 'match_removed',
+  PROPOSAL_SENT: 'proposal_sent',
+  PROPOSAL_ACCEPTED: 'proposal_accepted',
+  PROPOSAL_DECLINED: 'proposal_declined',
+  PROPOSAL_WITHDRAWN: 'proposal_withdrawn',
+
+  // Partner
+  PARTNER_CODE_COPIED: 'partner_code_copied',
+  PARTNER_CODE_SHARED: 'partner_code_shared',
   PARTNER_LINKED: 'partner_linked',
-  ACCOUNT_DELETED: 'account_deleted',
+  PARTNER_UNLINKED: 'partner_unlinked',
+
+  // Settings
+  THEME_CHANGED: 'theme_changed',
+  SKIN_TONE_CHANGED: 'skin_tone_changed',
+  VOICE_CHANGED: 'voice_changed',
+  FILTERS_CHANGED: 'filters_changed',
+
+  // Paywall & purchases
+  PAYWALL_SHOWN: 'paywall_shown',
+  PURCHASE_ATTEMPTED: 'purchase_attempted',
+  PURCHASE_COMPLETED: 'purchase_completed',
+  PURCHASE_FAILED: 'purchase_failed',
+  PURCHASE_RESTORED: 'purchase_restored',
+
+  // Notifications
+  PUSH_PERMISSION_REQUESTED: 'push_permission_requested',
+  PUSH_PERMISSION_GRANTED: 'push_permission_granted',
+  PUSH_PERMISSION_DENIED: 'push_permission_denied',
 } as const;


### PR DESCRIPTION
## Summary
- Audited every catch block, mutation site, and user-action entry point across the app, then closed every gap I found.
- Adds `Sentry.captureException` to all 6 auth catch blocks (sign-in, sign-up, forgot-password, reset, Google SSO, Apple SSO) — these previously swallowed errors silently, which is why the recent Apple Sign-In failure didn't appear in Sentry.
- Wires user identity: `Sentry.setUser` + `identifyUser` on sign-in (in `useStoreUser`), `Sentry.setUser(null)` + `resetAnalytics` on sign-out and account deletion.
- Expands the PostHog event taxonomy from 7 events to ~30 — auth (incl. failure events for funnels), onboarding, partner flows, settings (theme/skin-tone/voice/filters), matches (viewed/favorited/chosen/removed), proposals (sent/accepted/declined/withdrawn), paywall (shown/attempted/failed/restored), push permission (requested/granted/denied).
- Adds Sentry capture to two more silent catches: feedback submission and partner link failure.
- Drops the dead `SEARCH_CREATED` event left over from the global-list refactor; replaces a string literal `'partner_linked'` with `Events.PARTNER_LINKED`.

## Why
The Apple Sign-In failure on the latest preview build had no Sentry trace and no PostHog event, leaving us blind. The audit found that gap is systemic: Sentry has decent coverage everywhere except auth, and PostHog is barely instrumented (no `identifyUser`, no `resetAnalytics`, no funnels).

## Event taxonomy
See `lib/analytics.ts` `Events` enum. Naming is `object_past-tense-verb`, snake_case, consistent with the existing convention.

## Test plan
- [ ] Trigger a deliberate sign-in failure (wrong password) → confirm error shows in Sentry with `flow:sign_in, method:email` tags + `sign_in_failed` event in PostHog
- [ ] Trigger Apple Sign-In on the new preview build → confirm the unauthorized-request error now reaches Sentry
- [ ] Sign in successfully → confirm `Sentry.setUser` set in next captured error, and PostHog events identified to the user
- [ ] Sign out → confirm subsequent events are anonymous (resetAnalytics worked)
- [ ] Tap through paywall, restore purchase, switch theme/skin-tone/voice/filters → confirm corresponding events arrive in PostHog
- [ ] Onboarding flow → confirm `onboarding_started`, slide-advance events, and `onboarding_completed` arrive
- [ ] Push permission prompt → confirm `push_permission_requested` + granted/denied event arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)