### PR TITLE
ci: add Convex prod deploy workflow (manual dispatch)

### DIFF
--- a/.github/workflows/convex-deploy.yml
+++ b/.github/workflows/convex-deploy.yml
@@ -1,0 +1,45 @@
+name: Convex deploy (prod)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or commit SHA to deploy (defaults to master)"
+        required: false
+        default: "master"
+
+jobs:
+  deploy:
+    name: Deploy Convex backend to prod
+    runs-on: ubuntu-latest
+    # Production environment: requires CONVEX_DEPLOY_KEY secret.
+    # Configure under Settings → Secrets and variables → Actions.
+    environment: production
+    steps:
+      - name: Check for CONVEX_DEPLOY_KEY
+        run: |
+          if [ -z "${{ secrets.CONVEX_DEPLOY_KEY }}" ]; then
+            echo "CONVEX_DEPLOY_KEY is not set. Generate one in the Convex dashboard"
+            echo "(Settings → Deploy Keys → Generate prod deploy key) and add it at"
+            echo "https://github.com/${{ github.repository }}/settings/secrets/actions"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Deploy Convex backend
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+        run: npx convex deploy


### PR DESCRIPTION
## Summary
- New workflow at `.github/workflows/convex-deploy.yml`. Trigger: `workflow_dispatch` only — no push trigger.
- Uses `CONVEX_DEPLOY_KEY` secret to deploy `convex/` to prod via `npx convex deploy`.
- Bound to a `production` GitHub environment so optional required-reviewer rules can be layered in via the UI without code changes.
- Accepts a `ref` input (defaults to master) so you can deploy from any branch/tag — useful for hotfixes.

## Why
Right now Convex prod deploys are manual from your laptop. Putting it behind a workflow:
- One-click from the Actions tab; no need to remember the command
- Deploys from a clean checkout, not whatever's lying around locally
- Centralizes the deploy key in GitHub secrets rather than your shell
- Prepares the path for tag-triggered or auto-on-master deploys later, once we have a staging deployment in front of prod

Manual dispatch is the right starting point: lower blast radius than auto-on-master while you're prepping for App Review and don't have a staging Convex deployment yet.

## Setup before first use
1. Convex dashboard → Settings → Deploy Keys → Generate prod deploy key
2. Add as `CONVEX_DEPLOY_KEY` in GitHub repo secrets (Settings → Secrets and variables → Actions)
3. (Optional) Settings → Environments → production → add required reviewers

## Test plan
- [ ] Add the `CONVEX_DEPLOY_KEY` secret
- [ ] Run the workflow from the Actions tab on master
- [ ] Confirm `npx convex deploy` succeeds and the new `seedAppReviewDemo` function appears in prod
- [ ] Run `npx convex run admin:seedAppReviewDemo --prod ...` and confirm the demo accounts get populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)