### PR TITLE
fix: set demo user names in seedAppReviewDemo

### DIFF
--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -196,17 +196,20 @@ export const seedAppReviewDemo = internalMutation({
 
     const now = Date.now();
 
-    // 1. Link as partners
-    await ctx.db.patch(reviewer._id, { partnerId: partner._id, updatedAt: now });
-    await ctx.db.patch(partner._id, { partnerId: reviewer._id, updatedAt: now });
-
-    // Confirm names so the partner-action gate doesn't pop the modal for the reviewer
-    if (reviewer.nameConfirmed !== true) {
-      await ctx.db.patch(reviewer._id, { nameConfirmed: true });
-    }
-    if (partner.nameConfirmed !== true) {
-      await ctx.db.patch(partner._id, { nameConfirmed: true });
-    }
+    // 1. Link as partners + set display names so neither side sees the
+    //    "Bambino User" fallback in the partner section.
+    await ctx.db.patch(reviewer._id, {
+      partnerId: partner._id,
+      name: 'Bambino User',
+      nameConfirmed: true,
+      updatedAt: now,
+    });
+    await ctx.db.patch(partner._id, {
+      partnerId: reviewer._id,
+      name: 'Bambino Partner',
+      nameConfirmed: true,
+      updatedAt: now,
+    });
 
     // 2. Pick popular names from the seeded names table.
     // Mutual likes (both like → match): 8 names


### PR DESCRIPTION
## Summary
- The seed marked `nameConfirmed: true` to skip the name-confirmation modal during App Review, but never set the actual `name` field. Result: the partner section shows the "Bambino User" fallback.
- Now sets `name = "Bambino User"` for the reviewer and `name = "Bambino Partner"` for the linked account.

## Test plan
- [ ] Merge → re-run the convex-deploy workflow to push the updated function
- [ ] Re-run `npx convex run admin:seedAppReviewDemo --prod ...` (idempotent)
- [ ] Sign in as appreview@bambinobaby.xyz → confirm Profile shows partner as "Bambino Partner"

🤖 Generated with [Claude Code](https://claude.com/claude-code)