### PR TITLE
feat: grant premium to demo accounts in seedAppReviewDemo

### DIFF
--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -196,18 +196,26 @@ export const seedAppReviewDemo = internalMutation({
 
     const now = Date.now();
 
-    // 1. Link as partners + set display names so neither side sees the
-    //    "Bambino User" fallback in the partner section.
+    // 1. Link as partners, set display names, and grant premium so the
+    //    reviewer can access Matches and unlimited swipes without
+    //    going through IAP. (Premium on either side is shared with the
+    //    partner via getEffectivePremiumStatus.)
     await ctx.db.patch(reviewer._id, {
       partnerId: partner._id,
       name: 'Bambino User',
       nameConfirmed: true,
+      isPremium: true,
+      purchasedAt: now,
+      premiumRevokedAt: undefined,
       updatedAt: now,
     });
     await ctx.db.patch(partner._id, {
       partnerId: reviewer._id,
       name: 'Bambino Partner',
       nameConfirmed: true,
+      isPremium: true,
+      purchasedAt: now,
+      premiumRevokedAt: undefined,
       updatedAt: now,
     });
 


### PR DESCRIPTION
## Summary
The Matches tab + unlimited swipes are premium features. The reviewer hit the paywall instead of seeing matches — defeating the point of the seed. Set `isPremium: true` on both seeded users so the reviewer experiences the full app without needing to go through IAP.

## Why
App Review reviewers typically don't run IAP. They look for "the app's main features work." If they see a paywall they think the app is broken or hostile and either reject or give a low rating. Granting premium to the demo account is the standard pattern.

## Test plan
- [ ] Merge → re-run convex-deploy workflow
- [ ] Re-run `npx convex run admin:seedAppReviewDemo --prod ...` (idempotent — patches the existing users)
- [ ] Sign in as appreview@bambinobaby.xyz → confirm Matches tab loads (no paywall) and shows 8 matches

## Note for App Review
The App Review notes will explain the demo account has been granted premium for evaluation purposes; reviewers can still verify the IAP flow via Apple's sandbox if they want to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)