### PR TITLE
chore: use realistic names (Sam / Alex) for demo accounts

### DIFF
--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -202,7 +202,7 @@ export const seedAppReviewDemo = internalMutation({
     //    partner via getEffectivePremiumStatus.)
     await ctx.db.patch(reviewer._id, {
       partnerId: partner._id,
-      name: 'Bambino User',
+      name: 'Sam',
       nameConfirmed: true,
       isPremium: true,
       purchasedAt: now,
@@ -211,7 +211,7 @@ export const seedAppReviewDemo = internalMutation({
     });
     await ctx.db.patch(partner._id, {
       partnerId: reviewer._id,
-      name: 'Bambino Partner',
+      name: 'Alex',
       nameConfirmed: true,
       isPremium: true,
       purchasedAt: now,


### PR DESCRIPTION
## Summary
Renames the seeded demo accounts from "Bambino User" / "Bambino Partner" to "Sam" / "Alex" so the data looks like a real couple to App Review rather than placeholder text.

## Test plan
- [ ] Merge → re-run convex-deploy workflow
- [ ] Re-run `npx convex run admin:seedAppReviewDemo --prod ...` (idempotent)
- [ ] Sign in as appreview@bambinobaby.xyz → confirm Profile shows partner name "Alex"

🤖 Generated with [Claude Code](https://claude.com/claude-code)