### PR TITLE
fix: add --prod flag to update-ranks script

### DIFF
--- a/scripts/update-ranks.ts
+++ b/scripts/update-ranks.ts
@@ -20,8 +20,11 @@ function runWithRetry(command: string): string {
 async function updateRanks() {
   const yearArg = process.argv.find((a) => a.startsWith('--year='));
   const year = yearArg ? parseInt(yearArg.split('=')[1], 10) : 2023;
+  const prod = process.argv.includes('--prod');
+  const deploymentFlag = prod ? ' --prod' : '';
+  const target = prod ? 'PRODUCTION' : 'dev';
 
-  console.log(`Updating names with current rank for ${year}...`);
+  console.log(`Updating names with current rank for ${year} on ${target}...`);
 
   let totalUpdated = 0;
   let totalProcessed = 0;
@@ -36,7 +39,7 @@ async function updateRanks() {
 
     try {
       const output = runWithRetry(
-        `npx convex run popularity:updateNamesWithCurrentRank '${JSON.stringify(argsObj)}'`,
+        `npx convex run popularity:updateNamesWithCurrentRank${deploymentFlag} '${JSON.stringify(argsObj)}'`,
       );
       const result = JSON.parse(output.trim());
       totalUpdated += result.updated;


### PR DESCRIPTION
## Summary
`scripts/update-ranks.ts` always targeted the dev Convex deployment, leaving production names with empty `currentRank` values. Adds `--prod` flag support to align with other seed scripts (`seed:names`, `seed:popularity`).

Audit findings (task #22):
- Prod: 0 / 1000 names with currentRank in first page (= ~0% coverage overall)
- Dev: 884 / 1000 names with currentRank in first page (~88% coverage)

Popularity data itself is fully seeded on both — only the `currentRank` patch step has been missed on prod.

## Test plan
- [ ] Merge
- [ ] Run `npm run update-ranks -- --prod` from laptop
- [ ] Run `npx convex run admin:auditNamesPage --prod '{}'` and confirm `withRank` is now ~1000 / 1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)