### PR TITLE
feat: backfill currentRank from most-recent-year fallback

### DIFF
--- a/convex/popularity.ts
+++ b/convex/popularity.ts
@@ -111,6 +111,105 @@ export const updateNamesWithCurrentRank = internalMutation({
   },
 });
 
+// Backfill currentRank for names that have no rank yet — uses each name's
+// most recent year of popularity data as a fallback. Run AFTER
+// updateNamesWithCurrentRank for the target year, so this only touches
+// names that didn't have a record in that year (e.g. names popular in
+// 1950 but no longer in the SSA top list).
+//
+// Records primaryGender for neutral names based on which gender's record
+// is more recent (or higher-ranked if tied on year).
+export const backfillCurrentRankFromMostRecent = internalMutation({
+  args: {
+    limit: v.optional(v.number()),
+    cursor: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const pageSize = args.limit ?? 500;
+    const result = await ctx.db
+      .query('names')
+      .paginate({ numItems: pageSize, cursor: (args.cursor as string | null) ?? null });
+
+    let updated = 0;
+    let alreadyRanked = 0;
+    let stillRankless = 0;
+
+    for (const name of result.page) {
+      if (name.currentRank !== undefined && name.currentRank !== null) {
+        alreadyRanked++;
+        continue;
+      }
+
+      async function mostRecentForGender(g: 'M' | 'F') {
+        const records = await ctx.db
+          .query('namePopularity')
+          .withIndex('by_name_gender', (q) => q.eq('name', name.name).eq('gender', g))
+          .collect();
+        if (records.length === 0) return null;
+        // Pick highest year; tiebreaker = lower rank (more popular).
+        return records.reduce((best, r) => {
+          if (r.year > best.year) return r;
+          if (r.year === best.year && r.rank < best.rank) return r;
+          return best;
+        });
+      }
+
+      if (name.gender === 'neutral') {
+        const mr = await mostRecentForGender('M');
+        const fr = await mostRecentForGender('F');
+        if (!mr && !fr) {
+          stillRankless++;
+          continue;
+        }
+        // Prefer the gender with the more recent record, then better rank
+        let chosen: { rank: number; year: number } | null = null;
+        let chosenGender: 'male' | 'female' = 'male';
+        if (mr && fr) {
+          if (mr.year > fr.year || (mr.year === fr.year && mr.rank <= fr.rank)) {
+            chosen = mr;
+            chosenGender = 'male';
+          } else {
+            chosen = fr;
+            chosenGender = 'female';
+          }
+        } else if (mr) {
+          chosen = mr;
+          chosenGender = 'male';
+        } else if (fr) {
+          chosen = fr;
+          chosenGender = 'female';
+        }
+        if (chosen) {
+          await ctx.db.patch(name._id, {
+            currentRank: chosen.rank,
+            primaryGender: chosenGender,
+          });
+          updated++;
+        }
+        continue;
+      }
+
+      const ssaGender = name.gender === 'male' ? 'M' : 'F';
+      const fallback = await mostRecentForGender(ssaGender);
+      if (fallback) {
+        await ctx.db.patch(name._id, { currentRank: fallback.rank });
+        updated++;
+      } else {
+        stillRankless++;
+      }
+    }
+
+    return {
+      processed: result.page.length,
+      updated,
+      alreadyRanked,
+      stillRankless,
+      isDone: result.isDone,
+      continueCursor: result.continueCursor,
+    };
+  },
+});
+
 export const getNamePopularity = query({
   args: {
     name: v.string(),

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "process:ssa": "npx tsx scripts/process-ssa-data.ts",
     "seed:popularity": "npx tsx scripts/seed-popularity.ts",
     "update:ranks": "npx tsx scripts/update-ranks.ts",
+    "backfill:ranks": "npx tsx scripts/backfill-ranks.ts",
     "extract-names": "npx tsx scripts/extract-ssa-names.ts",
     "enrich-names": "npx tsx scripts/enrich-names.ts"
   },

--- a/scripts/backfill-ranks.ts
+++ b/scripts/backfill-ranks.ts
@@ -1,0 +1,67 @@
+import { execSync } from 'child_process';
+
+const MAX_RETRIES = 5;
+const BASE_DELAY_MS = 2000;
+
+function runWithRetry(command: string): string {
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      return execSync(command, { encoding: 'utf-8', cwd: process.cwd() });
+    } catch (error) {
+      if (attempt === MAX_RETRIES) throw error;
+      const delay = BASE_DELAY_MS * Math.pow(2, attempt - 1);
+      console.log(`  Failed (attempt ${attempt}/${MAX_RETRIES}), retrying in ${delay / 1000}s...`);
+      execSync(`sleep ${delay / 1000}`);
+    }
+  }
+  throw new Error('Unreachable');
+}
+
+async function backfillRanks() {
+  const prod = process.argv.includes('--prod');
+  const deploymentFlag = prod ? ' --prod' : '';
+  const target = prod ? 'PRODUCTION' : 'dev';
+
+  console.log(`Backfilling missing currentRank values from most recent year on ${target}...`);
+
+  let totalUpdated = 0;
+  let totalAlreadyRanked = 0;
+  let totalStillRankless = 0;
+  let totalProcessed = 0;
+  let cursor: string | undefined;
+  let page = 1;
+
+  while (true) {
+    const argsObj: Record<string, unknown> = { limit: 500 };
+    if (cursor) argsObj.cursor = cursor;
+
+    console.log(`Processing page ${page}...`);
+
+    try {
+      const output = runWithRetry(
+        `npx convex run popularity:backfillCurrentRankFromMostRecent${deploymentFlag} '${JSON.stringify(argsObj)}'`,
+      );
+      const result = JSON.parse(output.trim());
+      totalUpdated += result.updated;
+      totalAlreadyRanked += result.alreadyRanked;
+      totalStillRankless += result.stillRankless;
+      totalProcessed += result.processed;
+      console.log(
+        `  Page ${page}: backfilled ${result.updated}, already ranked ${result.alreadyRanked}, no popularity data ${result.stillRankless}`,
+      );
+
+      if (result.isDone) break;
+      cursor = result.continueCursor;
+      page++;
+    } catch (error) {
+      console.error('Error during backfill:', error);
+      process.exit(1);
+    }
+  }
+
+  console.log(
+    `\nDone! Processed ${totalProcessed} names: backfilled ${totalUpdated}, already ranked ${totalAlreadyRanked}, no popularity data ${totalStillRankless}.`,
+  );
+}
+
+backfillRanks();


### PR DESCRIPTION
## Summary
After running `update:ranks` against prod for 2023, 26% of names (3K of 11.4K) still have no currentRank because they don't appear in the 2023 SSA top list. Many are historically popular names that fell out of fashion. Falls back to the most recent year they DO have data so they get a meaningful rank.

Adds:
- `popularity:backfillCurrentRankFromMostRecent` — paginated mutation, only touches names with no rank yet, uses most recent popularity record (highest year, lower rank as tiebreaker). For neutral names, picks the gender with the more recent record and also patches primaryGender.
- `scripts/backfill-ranks.ts` + `npm run backfill:ranks` — wrapper, same pattern as `update:ranks`, supports `--prod`.

## Test plan
- [ ] Merge → run convex-deploy workflow
- [ ] `npm run backfill:ranks -- --prod`
- [ ] Confirm `withRank` count is now ~11400+ (close to total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)