### PR TITLE
fix: auto-expand popularity chart when default window empty

### DIFF
--- a/components/popularity/popularity-chart.tsx
+++ b/components/popularity/popularity-chart.tsx
@@ -43,6 +43,15 @@ export function PopularityChart({ name, gender }: PopularityChartProps) {
   const chartOpacity = useRef(new Animated.Value(1)).current;
   const isFirstLoad = useRef(true);
   const cachedData = useRef<{ year: number; rank: number; count: number }[]>([]);
+  // Tracks whether we've auto-widened the range for this name because the
+  // narrower default returned no data. Prevents fighting the user if they
+  // later choose a narrow range manually.
+  const hasAutoExpanded = useRef(false);
+
+  // Reset auto-expand state when the name changes
+  useEffect(() => {
+    hasAutoExpanded.current = false;
+  }, [name]);
 
   const startYear = getStartYear(yearRange);
 
@@ -52,6 +61,20 @@ export function PopularityChart({ name, gender }: PopularityChartProps) {
     startYear,
     endYear: END_YEAR,
   });
+
+  // If the default narrow window returned nothing, auto-widen to 'all' once
+  // so names whose data ends before the 50-year window still show a chart.
+  useEffect(() => {
+    if (
+      !hasAutoExpanded.current &&
+      popularityData !== undefined &&
+      popularityData.length === 0 &&
+      yearRange !== 'all'
+    ) {
+      hasAutoExpanded.current = true;
+      setYearRange('all');
+    }
+  }, [popularityData, yearRange]);
 
   // Cache the latest valid data so we can keep rendering during transitions
   if (popularityData !== undefined && popularityData.length > 0) {
@@ -155,9 +178,21 @@ export function PopularityChart({ name, gender }: PopularityChartProps) {
   const chartWidth = 280;
   const spacing = chartData.length > 1 ? chartWidth / (chartData.length - 1) : chartWidth;
 
+  // If we auto-expanded because the narrow window was empty, surface a
+  // subtitle so the user understands why they're seeing older data.
+  const latestDataYear = data[data.length - 1]?.year;
+  const showAutoExpandSubtitle =
+    hasAutoExpanded.current &&
+    yearRange === 'all' &&
+    latestDataYear !== undefined &&
+    latestDataYear < END_YEAR - 19;
+
   return (
     <View style={[styles.container, { backgroundColor: themeColors.surfaceSubtle }]}>
       <Text style={styles.title}>Popularity Over Time</Text>
+      {showAutoExpandSubtitle ? (
+        <Text style={styles.subtitle}>Most recent data: {latestDataYear}</Text>
+      ) : null}
 
       <YearRangeSelector selected={yearRange} onSelect={setYearRange} />
 
@@ -236,6 +271,12 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
     letterSpacing: 0.8,
     textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 11,
+    color: '#A89BB5',
+    textAlign: 'center',
+    marginTop: -8,
   },
   chartArea: {
     height: CHART_HEIGHT + 70,

--- a/components/popularity/sparkline-chart.tsx
+++ b/components/popularity/sparkline-chart.tsx
@@ -26,11 +26,13 @@ const START_YEAR = END_YEAR - YEARS_TO_SHOW + 1;
 
 export function SparklineChart({ name, gender }: SparklineChartProps) {
   const { colors } = useTheme();
+  // Fetch all popularity data, then prefer the last 20 years client-side.
+  // For names whose data ends before the recent window (e.g. 1950s only),
+  // fall back to using all data so the sparkline isn't blank. Slightly more
+  // data over the wire, but avoids a follow-up query / loading flicker.
   const popularityData = useQuery(api.popularity.getNamePopularity, {
     name,
     gender,
-    startYear: START_YEAR,
-    endYear: END_YEAR,
   });
 
   // Don't render for neutral gender
@@ -56,13 +58,17 @@ export function SparklineChart({ name, gender }: SparklineChartProps) {
     );
   }
 
+  // Prefer last 20 years if any data lands there; otherwise show full history.
+  const recent = popularityData.filter((d) => d.year >= START_YEAR);
+  const seriesSource = recent.length > 0 ? recent : popularityData;
+
   const lineColor = GENDER_COLORS[gender];
 
   // Find max rank for inverting (so rank 1 appears at top)
-  const maxRank = Math.max(...popularityData.map((d) => d.rank));
+  const maxRank = Math.max(...seriesSource.map((d) => d.rank));
 
   // Transform data - invert rank so lower rank appears higher
-  const chartData = popularityData.map((d) => ({
+  const chartData = seriesSource.map((d) => ({
     value: maxRank - d.rank + 1,
   }));
 


### PR DESCRIPTION
## Summary
After the `backfillCurrentRankFromMostRecent` change in #127, names whose most recent SSA data is from e.g. the 1950s now have a `currentRank` — but the chart's default window was the last 50 years (1974+), so the chart was blank for these names.

Two fixes, one per chart component:

**PopularityChart** (full chart, name detail modal): if the default `'50'` window returns zero records, auto-switch to `'all'` on first render. Surface a small subtitle "Most recent data: <year>" so users understand why they're seeing older data. A ref tracks whether we already auto-expanded so we don't fight the user if they manually pick a narrow range later. Reset on name change.

**SparklineChart** (small chart on swipe card): query without `startYear`, prefer the last-20-year window client-side, fall back to the full series if that window is empty. Single query, no flicker, **no subtitle** — sparkline stays compact (per Daisy's request).

## Test plan
- [ ] Sign in to the app on the seeded demo account
- [ ] Find a long-tail name (e.g. via the swipe queue — the seed includes 'Aaron'/'Adam'/'Adrian' which have older popularity peaks)
- [ ] Swipe card sparkline should show a real trend line, not "No trend data"
- [ ] Tap into the name detail modal — popularity chart auto-expands to 'all' and shows subtitle "Most recent data: <year>"
- [ ] Manually switch the range to '50' — chart shows empty state, doesn't auto-expand again
- [ ] Switch to a name with full recent data (e.g. Olivia) — default '50' range works as before, no subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)