### PR TITLE
chore: drop iPad support for v1 launch

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,7 +9,7 @@
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {
-      "supportsTablet": true,
+      "supportsTablet": false,
       "bundleIdentifier": "xyz.bambinobaby.app",
       "usesAppleSignIn": true,
       "infoPlist": {


### PR DESCRIPTION
## Summary
Sets `ios.supportsTablet: false` in `app.json`. Phone-only for v1.

## Why
- We've only designed and tested for iPhone
- App Store Connect requires iPad screenshots for any app that declares iPad support
- Reviewers test what's declared — declaring iPad means they look for layout/touch-target issues we haven't validated
- Easy to add back later once we've actually built the iPad experience

## Test plan
- [ ] Merge → kick off a new preview build (the existing in-flight build #128 is already on master without this change, so this needs a fresh build)
- [ ] Confirm on App Store Connect that the device targets show iPhone only

🤖 Generated with [Claude Code](https://claude.com/claude-code)