### PR TITLE
chore: make dev-build manual-only to stop burning EAS credits

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,10 +1,17 @@
 name: Development build
 
+# Manual dispatch only. The `development-device` profile produces a dev
+# client used for connecting Metro to a physical iPhone — you only need
+# a fresh one when native config changes (app.json plugins, new native
+# deps, etc.). JS-only changes don't require a rebuild. Auto-on-master
+# was burning EAS build credits on every merge.
 on:
-  push:
-    branches:
-      - master
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or commit SHA to build (defaults to master)"
+        required: false
+        default: "master"
 
 jobs:
   build:
@@ -20,6 +27,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
The `development-device` build was firing on every push to master, producing a dev client (~\$0.50-1 of EAS credit each) for every merge — even when the change was JS-only and didn't need a native rebuild. Hit ~\$38 of \$45 monthly allowance with most burn coming from this auto-trigger during a multi-PR session.

Switches dev-build.yml to `workflow_dispatch` only, matching `preview-build.yml`. Adds a `ref` input so you can target a non-default branch/tag.

## When to actually trigger this manually
- Native config changed: `app.json` plugins, `ios.infoPlist` entries, bundle ID, etc.
- New native dependency added (anything with iOS pod install)
- Expo SDK / React Native bumped
- Apple capabilities (Sign in with Apple, push notifications) added/changed

## When NOT needed
- JS/TS changes only (components, hooks, contexts)
- Convex backend changes
- CSS / styling
- These are picked up by Metro reload or via OTA updates if you ever set those up

🤖 Generated with [Claude Code](https://claude.com/claude-code)