### PR TITLE
docs: align privacy policy and terms of service with App Store nutrition labels

### DIFF
--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,0 +1,92 @@
+# Bambino Privacy Policy
+
+Last updated: 2026-05-27
+
+## Introduction
+
+Bambino ("we", "our", or "us") operates the Bambino mobile application ("the App"). This Privacy Policy explains what information we collect, how we use it, who we share it with, and your rights regarding your data. By using Bambino you agree to the practices described below.
+
+Contact: hello@bambinobaby.xyz
+
+## What we collect
+
+**Account information** (required to use the App)
+
+- Email address — used for sign-in, email verification, password reset, and account recovery
+- Display name — optional; shown to you and to your linked partner
+- Profile photo — optional; shown to you and to your linked partner
+- A unique user ID assigned by our authentication provider
+
+**Activity within the App**
+
+- Your name selections (like, reject, hide) so we can build your liked list and detect matches with your partner
+- Filters you set (gender, name origin)
+- Match notes, name proposals, and proposal decline messages — visible only to you and your linked partner
+- Theme, skin tone, and voice preferences
+
+**Diagnostic and analytics data**
+
+- Crash reports, performance traces, and contextual breadcrumbs sent to our error-monitoring provider (Sentry) so we can fix bugs and improve reliability. These reports include your user ID so we can correlate errors with the affected user.
+- Product-interaction events sent to our analytics provider (PostHog) — for example: sign-in, name swiped, match found, theme changed. These events are linked to your user ID so we can build per-user usage funnels and understand how features are adopted.
+
+**Customer support content**
+
+- If you submit feedback through the in-app form, we receive your message along with your name and email so we can respond.
+
+**What we don't collect**
+
+- We don't access your contacts, location, microphone, camera (except if you explicitly pick a photo), health data, or browsing history outside the App.
+- We don't use IDFA, advertising identifiers, or any cross-app tracking.
+- We don't sell or rent your personal information.
+
+## How we use your information
+
+- To provide the App: matching with your partner, syncing your selections across devices, sending push notifications about activity from your partner.
+- To authenticate you and recover your account if you forget your password.
+- To improve the App: understand which features are used, identify and fix bugs and crashes, and prioritize improvements.
+- To support you: respond to feedback you submit through the App.
+
+## Who we share data with
+
+Bambino is built on a small set of third-party providers. Your data is shared only with the providers necessary to run the App, each of whom acts as a data processor on our behalf:
+
+- **Clerk** — handles sign-in, email verification, password reset, and Sign in with Apple / Google. Receives your email, password (hashed by Clerk), and display name.
+- **Convex** — our application database. Stores your account record, selections, matches, partner link, and preferences.
+- **Sentry** — error and performance monitoring. Receives crash reports, performance traces, and diagnostic breadcrumbs along with your user ID.
+- **PostHog** — product analytics. Receives interaction events along with your user ID, email, and name.
+- **Apple Push Notification service** — delivers push notifications about activity from your partner. Receives a device push token only.
+- **RevenueCat** (when in-app purchases are enabled) — manages premium subscriptions/purchases. Receives your user ID for receipt validation.
+- **Slack (internal)** — when you submit feedback through the in-app form, the message, your name, and your email are posted to our internal Slack workspace so we can respond.
+
+We don't share your personal information with third-party advertisers or data brokers, and we don't permit any of the above providers to do so.
+
+## How long we keep your data
+
+- Your account and all associated data (selections, matches, partner link, preferences) are kept until you delete the account.
+- Diagnostic events (Sentry) are retained for 90 days.
+- Analytics events (PostHog) are retained for 12 months.
+
+## Your rights
+
+- **Access** your data — contact us and we'll send you a copy
+- **Delete** your account and all associated data — Profile → Delete Account in the App, or contact us
+- **Export** your data — contact us
+- **Correct** your data — most fields are editable directly in the App (Profile screen, settings); for anything else contact us
+
+To exercise any of these rights, email hello@bambinobaby.xyz.
+
+## Security
+
+Data is stored encrypted in transit (TLS) and at rest. Authentication uses industry-standard token-based sign-in via Clerk. Match data, selections, notes, and proposals are only visible to you and your linked partner.
+
+## Children's privacy
+
+Bambino is intended for adult users (typically expecting or prospective parents). We do not knowingly collect personal information from children under 13. If you believe a child has provided us with personal information, contact us and we'll delete it.
+
+## Changes to this policy
+
+We may update this policy from time to time. The "Last updated" date at the top of this page reflects the most recent change. For significant changes we'll surface a notice within the App.
+
+## Contact us
+
+Questions about this policy or your data: hello@bambinobaby.xyz

--- a/docs/terms-of-service.md
+++ b/docs/terms-of-service.md
@@ -1,0 +1,208 @@
+# Bambino Terms of Service
+
+Last updated: 2026-05-27
+
+## 1. Introduction
+
+Welcome to Bambino. These Terms of Service ("Terms") govern your use of the Bambino mobile application ("the App") operated by Bambino ("we", "our", or "us").
+
+By downloading, installing, or using the App, you agree to be bound by these Terms. If you do not agree to these Terms, do not use the App.
+
+These Terms are in addition to Apple's Licensed Application End User License Agreement (the "Apple EULA") for apps distributed through the App Store. In the event of any conflict between these Terms and the Apple EULA, these Terms govern your relationship with us, and the Apple EULA governs your relationship with Apple.
+
+Contact: hello@bambinobaby.xyz
+
+## 2. Eligibility and accounts
+
+### 2.1 Age
+
+You must be at least 18 years old to use the App. The App is intended for adult users (typically expecting or prospective parents) and is not directed to children. We do not knowingly collect information from anyone under 13.
+
+### 2.2 Account creation
+
+To use the App you must create an account. You agree to:
+
+- Provide accurate, current, and complete information when creating your account
+- Maintain the security of your account credentials
+- Not create multiple accounts representing the same person
+- Notify us promptly of any unauthorized access
+
+You are responsible for all activity that occurs under your account.
+
+### 2.3 Sign-in providers
+
+We support sign-in via email and password, Sign in with Apple, and Continue with Google. By signing in via Apple or Google you also agree to those providers' terms.
+
+## 3. The Service
+
+### 3.1 What Bambino provides
+
+Bambino is a baby-name discovery app that allows partners to:
+
+- Browse and swipe on baby names
+- Filter names by gender, origin, and other attributes
+- View historical name popularity trends
+- Link with a partner via a 6-character share code
+- See mutually liked names ("matches")
+- Propose a name as the final choice and receive an accept/decline response from the partner
+- Save match notes, mark favorites, and rank choices
+
+### 3.2 Name data
+
+Name data, including popularity statistics, is sourced from publicly available records such as the U.S. Social Security Administration. We do not guarantee the completeness or accuracy of this data and present it for informational purposes only.
+
+### 3.3 Availability
+
+We strive to keep the App available but do not guarantee uninterrupted access. We may temporarily suspend the App for maintenance, updates, or in response to security or operational issues. We are not liable for any inability to use the App during such periods.
+
+### 3.4 Updates
+
+We may release updates to the App, which may add, remove, or change features. Continued use of the App after an update constitutes acceptance of the changes.
+
+## 4. Acceptable use
+
+You agree not to:
+
+- Use the App for any unlawful, harmful, harassing, defamatory, or fraudulent purpose
+- Submit user-generated content (match notes, name proposals, decline messages, feedback) that is illegal, harassing, hateful, threatening, sexually explicit, or that infringes on the rights of others
+- Use the App to send spam or unsolicited communications to your partner or anyone else
+- Attempt to access another user's account, data, or partner connection without authorization
+- Use automated systems, scrapers, or bots to interact with the App
+- Reverse-engineer, decompile, disassemble, or otherwise attempt to derive the source code of the App
+- Circumvent or attempt to circumvent any access controls, premium features, or rate limits
+- Use the App in any manner that could damage, disable, overburden, or impair our infrastructure
+- Resell, redistribute, or sublicense the App or any part of it
+
+We may suspend or terminate accounts that violate this section without notice.
+
+## 5. User-generated content
+
+### 5.1 Your content
+
+The App lets you and your linked partner create content visible only to the two of you, including:
+
+- Notes you add to matched names
+- Name proposals and proposal decline messages
+- Feedback you submit through the in-app form
+
+You retain ownership of this content. By using the App you grant us a limited, worldwide, non-exclusive, royalty-free license to host, store, transmit, and display this content as needed to provide the App to you and your partner.
+
+### 5.2 Our right to remove
+
+We may remove user-generated content that violates these Terms, that we are required to remove by law, or that is reported to us as infringing or abusive. We don't actively monitor user-generated content but reserve the right to do so.
+
+### 5.3 Reporting concerns
+
+To report content that violates these Terms or that you believe infringes your rights, contact us at hello@bambinobaby.xyz.
+
+## 6. In-app purchases and premium
+
+### 6.1 Premium features
+
+Some features (including unlimited swipes, the Matches list, and partner linking) require a one-time premium purchase made through Apple's in-app purchase system.
+
+### 6.2 Pricing and billing
+
+Prices are set in your local currency by Apple at the time of purchase. Payment is charged to your Apple ID account at the time of confirmation. Prices may change; we'll notify you within the App before any change takes effect.
+
+### 6.3 Refunds
+
+All in-app purchases are processed by Apple. Refund requests must be submitted through Apple at https://reportaproblem.apple.com or via your Apple device's purchase history. We do not directly process refunds for App Store purchases.
+
+### 6.4 Premium and partner accounts
+
+When two accounts are linked as partners and one has premium, premium features are shared between both partners while the link is active. If the premium-holding account unlinks, downgrades, or refunds, the partner's access ends.
+
+## 7. Privacy
+
+Our collection and use of your personal information is described in our Privacy Policy: https://bambino-baby.notion.site/325d3b58308281158ce6c6cbdd562734
+
+By using the App you agree to that Privacy Policy.
+
+## 8. Intellectual property
+
+### 8.1 Our content
+
+The App, including its design, code, features, original content (excluding user-generated content and publicly sourced name data), and the "Bambino" name and branding, is owned by us and protected by applicable copyright, trademark, and other intellectual property laws. We grant you a limited, non-transferable, non-exclusive, revocable license to use the App for your personal, non-commercial use in accordance with these Terms.
+
+### 8.2 Apple's rights
+
+You acknowledge that the Apple EULA grants Apple certain rights and remedies as a third-party beneficiary of these Terms with respect to the App distributed via the App Store.
+
+### 8.3 Copyright complaints
+
+If you believe content within the App infringes your copyright, contact us at hello@bambinobaby.xyz with: a description of the work, a description of where it appears in the App, your contact information, and a statement that you have a good-faith belief the use is unauthorized.
+
+## 9. Termination
+
+### 9.1 By you
+
+You may delete your account at any time via Profile → Delete Account in the App, or by contacting us. Account deletion permanently removes your account and all associated data.
+
+### 9.2 By us
+
+We may suspend or terminate your access if you violate these Terms, if required by law, or if continued service to you would expose us to legal or operational risk.
+
+### 9.3 Effect of termination
+
+Upon termination, your right to use the App ceases. Sections of these Terms that by their nature should survive termination (intellectual property, limitation of liability, governing law, dispute resolution) survive termination.
+
+## 10. Disclaimers
+
+The App is provided "as is" and "as available" without warranties of any kind, express or implied, including without limitation warranties of merchantability, fitness for a particular purpose, and non-infringement.
+
+We do not warrant that:
+
+- The App will be error-free or uninterrupted
+- Defects will be corrected
+- The App is free of viruses or other harmful components
+- Name data, popularity rankings, or any other information provided is accurate or complete
+
+To the fullest extent permitted by law, we disclaim all such warranties.
+
+## 11. Limitation of liability
+
+To the maximum extent permitted by applicable law:
+
+- We are not liable for any indirect, incidental, special, consequential, or punitive damages arising from your use of the App, including loss of data, loss of profits, or emotional distress
+- Our total cumulative liability for any claim arising from your use of the App shall not exceed the greater of: (a) the amount you have paid us in the 12 months preceding the claim, or (b) CAD $50
+
+Some jurisdictions don't allow exclusion or limitation of certain damages. In those jurisdictions, our liability is limited to the maximum extent permitted by law.
+
+## 12. Indemnification
+
+You agree to indemnify and hold us harmless from any claims, damages, losses, liabilities, and expenses (including reasonable legal fees) arising from your violation of these Terms, your misuse of the App, or your user-generated content.
+
+## 13. Governing law and dispute resolution
+
+These Terms are governed by the laws of the Province of British Columbia and the federal laws of Canada applicable in British Columbia, without regard to conflict-of-laws principles.
+
+Any dispute arising from these Terms or your use of the App will be resolved in the courts of British Columbia, Canada, and you consent to the exclusive jurisdiction of those courts.
+
+If you reside outside Canada, mandatory consumer-protection laws of your jurisdiction may also apply.
+
+## 14. Changes to these Terms
+
+We may update these Terms from time to time. The "Last updated" date at the top of this page reflects the most recent change. For significant changes we'll surface a notice within the App. Continued use of the App after a change constitutes acceptance of the updated Terms.
+
+## 15. Miscellaneous
+
+### 15.1 Entire agreement
+
+These Terms, together with the Privacy Policy and the Apple EULA, constitute the entire agreement between you and us regarding the App.
+
+### 15.2 Severability
+
+If any provision of these Terms is found unenforceable, the remaining provisions remain in full effect.
+
+### 15.3 No waiver
+
+Our failure to enforce any right or provision of these Terms is not a waiver of that right.
+
+### 15.4 Assignment
+
+You may not assign these Terms without our written consent. We may assign these Terms in connection with a merger, acquisition, or sale of assets.
+
+## 16. Contact
+
+Questions about these Terms: hello@bambinobaby.xyz


### PR DESCRIPTION
## Summary
Adds source-of-truth versions of the privacy policy and terms of service in the repo, aligned with the privacy nutrition labels we just published in App Store Connect. The Notion-hosted versions have been updated to match.

## Why
The previous Notion pages had inaccuracies vs. what we declare in the App Store privacy labels:
- Missing Sentry (we declared Crash Data, Performance Data, Other Diagnostic Data)
- PostHog claim was wrong: "Analytics data does not include your personal information" — but PostHog identifies users by Clerk user ID and is linked to identity per the labels
- Missing profile photo collection
- Missing feedback / customer support data
- Missing match notes / proposal messages / decline messages (User Content)
- ToS missing IAP / refunds / Apple EULA cross-reference (required for App Store distribution)

Apple's review process specifically compares declared labels against the linked privacy policy. Mismatches cause rejection.

## What's in the docs
- `docs/privacy-policy.md` — covers all 11 declared data types, 7 third-party processors (Clerk, Convex, Sentry, PostHog, APNs, RevenueCat, Slack), retention windows, user rights
- `docs/terms-of-service.md` — adds IAP/refund handling, Apple EULA cross-reference, UGC section for match notes / proposals / feedback, governing law set to British Columbia, Canada (matching dev jurisdiction)

## Future work
Tracked separately as task #21: replace these Notion-hosted pages with a real bambinobaby.xyz site rendered from these markdown files. Until then the canonical text lives in the repo and the published copies live in Notion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)