### PR TITLE
docs: add support page text

### DIFF
--- a/docs/support.md
+++ b/docs/support.md
@@ -1,0 +1,58 @@
+# Bambino Support
+
+Need help with Bambino? You're in the right place.
+
+For anything not covered below, email us at **hello@bambinobaby.xyz**. We try to respond within a couple of business days.
+
+## Frequently asked questions
+
+### How does the partner matching work?
+
+Each partner swipes through baby names independently. When you both like the same name, it shows up in your **Matches** tab. To link with your partner, share the 6-character code shown on your Profile screen. They enter it on their device under Profile → Link Partner.
+
+### Can I change my partner?
+
+Yes. On the Profile screen, tap **Unlink Partner** to disconnect from your current partner. You can then link with a new partner using their share code. Your existing matches and likes are kept.
+
+### Why am I seeing names I don't like?
+
+The swipe queue surfaces popular names first, then progressively less common ones as you swipe. You can narrow the pool by adjusting filters (gender, origin) on the Filters screen.
+
+### How do I propose a name as our final pick?
+
+In the **Matches** tab, tap a match to open its detail view, then tap **Choose This Name**. Your partner gets a notification and can accept or decline. If they accept, the name is marked as your final choice.
+
+### Why isn't my popularity chart showing data?
+
+Some less-common names only have historical data (e.g. names popular in the 1950s but rare today). The chart automatically expands to show whatever data is available. If a name has no SSA records at all, no chart will appear.
+
+### How do I unlock Premium?
+
+Premium unlocks unlimited swipes, the Matches feature, and partner linking. Tap any Premium prompt in the app and follow the in-app purchase flow. Premium is a one-time purchase — no subscription, no recurring fees. Premium is shared between linked partners.
+
+### Can I get a refund for Premium?
+
+Refunds for in-app purchases are handled by Apple. Visit [reportaproblem.apple.com](https://reportaproblem.apple.com/) or open the App Store → tap your profile picture → Purchase History.
+
+### How do I delete my account?
+
+Profile tab → **Delete Account**. This permanently removes your account and all associated data (selections, matches, partner link, settings). This action cannot be undone.
+
+### Is my data private?
+
+Yes. The only people who can see your liked names, matches, notes, and proposals are you and your linked partner. We don't sell data, don't show ads, and don't track you across other apps. See our [Privacy Policy](https://bambino-baby.notion.site/325d3b58308281158ce6c6cbdd562734) for details.
+
+### How do I report a bug or request a feature?
+
+Profile tab → **Share Feedback** has a built-in form for bug reports, feature requests, and general feedback. Or email us directly at hello@bambinobaby.xyz.
+
+## Still need help?
+
+Email **hello@bambinobaby.xyz** with:
+
+- A description of what you were trying to do
+- What happened instead (or what you expected to happen)
+- Your iPhone model and iOS version (Settings → General → About)
+- A screenshot if relevant
+
+We'll get back to you as soon as we can.


### PR DESCRIPTION
## Summary
Adds `docs/support.md`, the source-of-truth text for the Bambino Support page now hosted at https://bambino-baby.notion.site/support and used as the App Store Connect "Support URL" for App Review.

Covers FAQs for partner matching, premium / refunds, account deletion, privacy, and bug reporting. Same contact email (hello@bambinobaby.xyz) as the privacy policy and ToS.

Once bambinobaby.xyz is live (task #21), this file will be the source the marketing site renders from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)