### PR TITLE
fix: refetch RevenueCat offerings on every hook mount

### DIFF
--- a/hooks/use-purchases.ts
+++ b/hooks/use-purchases.ts
@@ -18,17 +18,16 @@ export function usePurchases() {
 
   useEffect(() => {
     async function init() {
-      if (!REVENUECAT_API_KEY || isConfigured) {
+      if (!REVENUECAT_API_KEY) {
         setIsLoading(false);
         return;
       }
 
       try {
-        if (__DEV__) {
-          Purchases.setLogLevel(LOG_LEVEL.DEBUG);
-        }
-
-        if (Platform.OS === 'ios') {
+        if (!isConfigured && Platform.OS === 'ios') {
+          if (__DEV__) {
+            Purchases.setLogLevel(LOG_LEVEL.DEBUG);
+          }
           Purchases.configure({ apiKey: REVENUECAT_API_KEY });
           isConfigured = true;
         }


### PR DESCRIPTION
## Summary
- Module-level `isConfigured` was short-circuiting init for any `usePurchases` hook instance that wasn't first to mount, leaving their local `packages` state empty.
- When `matches.tsx` mounted before the paywall (default tab order can vary), the paywall received `isLoading=false` and `packages=[]`, rendering "Unable to load pricing" instead of the purchase button.
- Now only the `Purchases.configure()` call is gated on `isConfigured`. `getCustomerInfo` and `getOfferings` run on every hook mount — both are cheap (RC caches them internally).

## Test plan
- [x] Paywall opens with real price ($4.99) after navigating Matches → Profile → trigger paywall
- [x] Paywall opens with real price after going Explore → swipe limit → paywall
- [x] StoreKit purchase sheet opens on tap
- [x] Cancelling the StoreKit sheet returns to paywall without crashing
- [ ] Verify in TestFlight build with sandbox tester before App Review submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)