### PR TITLE
fix: drop --what-to-test from production build workflow

### DIFF
--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -1,12 +1,11 @@
 name: Production build + TestFlight submit
 
+# Manual dispatch only. Builds the production profile and submits the
+# resulting build to TestFlight. Add release notes manually in App Store
+# Connect after submission — the `--what-to-test` flag requires the EAS
+# Enterprise plan, so we don't pass it here.
 on:
-  workflow_dispatch:
-    inputs:
-      what_to_test:
-        description: "What to test (shown in TestFlight release notes)"
-        required: false
-        default: ""
+  workflow_dispatch: {}
 
 jobs:
   build-and-submit:
@@ -44,9 +43,4 @@ jobs:
         run: eas build --platform ios --profile production --non-interactive --wait
 
       - name: Submit to TestFlight
-        run: |
-          if [ -n "${{ github.event.inputs.what_to_test }}" ]; then
-            eas submit --platform ios --latest --non-interactive --what-to-test "${{ github.event.inputs.what_to_test }}"
-          else
-            eas submit --platform ios --latest --non-interactive
-          fi
+        run: eas submit --platform ios --latest --non-interactive


### PR DESCRIPTION
## Summary
- The `--what-to-test` (a.k.a. `changelog`) flag on `eas submit` is gated behind the EAS Enterprise plan.
- On a standard plan it errors out: *"Changelog submission is currently available for Enterprise plan only."*
- Passing it caused our first production-build run to fail at the submit step (build itself succeeded — the binary is already on EAS servers).

## Fix
- Removed the `what_to_test` workflow input.
- Submit step now runs `eas submit --platform ios --latest --non-interactive` unconditionally.
- Release notes for testers/reviewers should be added manually in App Store Connect after submission.

## Test plan
- [x] Triggered the original workflow → build OK, submit failed with Enterprise-plan error
- [x] Submit succeeded after running `eas submit` locally without `--what-to-test`
- [ ] Next production run (post-merge) should succeed end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)