### PR TITLE
feat: premium purchase celebration + consistent button spinners

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -30,6 +30,7 @@ export default function SignIn() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [loadingMethod, setLoadingMethod] = useState<'email' | 'google' | 'apple' | null>(null);
   const [error, setError] = useState('');
   const [resetFlow, setResetFlow] = useState<'idle' | 'code' | 'new-password'>('idle');
   const [code, setCode] = useState('');
@@ -39,6 +40,7 @@ export default function SignIn() {
     if (!isLoaded) return;
 
     setIsLoading(true);
+    setLoadingMethod('email');
     setError('');
 
     try {
@@ -59,6 +61,7 @@ export default function SignIn() {
       trackEvent(Events.SIGN_IN_FAILED, { method: 'email', reason: message });
     } finally {
       setIsLoading(false);
+      setLoadingMethod(null);
     }
   }, [isLoaded, signIn, email, password, setActive, router]);
 
@@ -132,6 +135,7 @@ export default function SignIn() {
 
   const handleGoogleSignIn = useCallback(async () => {
     setIsLoading(true);
+    setLoadingMethod('google');
     setError('');
 
     try {
@@ -151,11 +155,13 @@ export default function SignIn() {
       trackEvent(Events.SIGN_IN_FAILED, { method: 'google', reason: message });
     } finally {
       setIsLoading(false);
+      setLoadingMethod(null);
     }
   }, [startSSOFlow, router]);
 
   const handleAppleSignIn = useCallback(async () => {
     setIsLoading(true);
+    setLoadingMethod('apple');
     setError('');
 
     try {
@@ -175,6 +181,7 @@ export default function SignIn() {
       trackEvent(Events.SIGN_IN_FAILED, { method: 'apple', reason: message });
     } finally {
       setIsLoading(false);
+      setLoadingMethod(null);
     }
   }, [startAppleAuthenticationFlow, router]);
 
@@ -241,7 +248,7 @@ export default function SignIn() {
                 title="Sign In"
                 onPress={handleSignIn}
                 variant="primary"
-                loading={isLoading}
+                loading={loadingMethod === 'email'}
                 disabled={isLoading}
               />
             </Animated.View>
@@ -264,6 +271,7 @@ export default function SignIn() {
                 onPress={handleGoogleSignIn}
                 variant="secondary"
                 icon="logo-google"
+                loading={loadingMethod === 'google'}
                 disabled={isLoading}
               />
             </Animated.View>
@@ -277,6 +285,7 @@ export default function SignIn() {
                 onPress={handleAppleSignIn}
                 variant="secondary"
                 icon="logo-apple"
+                loading={loadingMethod === 'apple'}
                 disabled={isLoading}
               />
             </Animated.View>

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -32,12 +32,14 @@ export default function SignUp() {
   const [code, setCode] = useState('');
   const [pendingVerification, setPendingVerification] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [loadingMethod, setLoadingMethod] = useState<'email' | 'google' | 'apple' | null>(null);
   const [error, setError] = useState('');
 
   const handleSignUp = useCallback(async () => {
     if (!isLoaded) return;
 
     setIsLoading(true);
+    setLoadingMethod('email');
     setError('');
 
     try {
@@ -55,6 +57,7 @@ export default function SignUp() {
       trackEvent(Events.SIGN_UP_FAILED, { method: 'email', reason: message });
     } finally {
       setIsLoading(false);
+      setLoadingMethod(null);
     }
   }, [isLoaded, signUp, email, password]);
 
@@ -84,6 +87,7 @@ export default function SignUp() {
 
   const handleGoogleSignUp = useCallback(async () => {
     setIsLoading(true);
+    setLoadingMethod('google');
     setError('');
 
     try {
@@ -103,11 +107,13 @@ export default function SignUp() {
       trackEvent(Events.SIGN_UP_FAILED, { method: 'google', reason: message });
     } finally {
       setIsLoading(false);
+      setLoadingMethod(null);
     }
   }, [startSSOFlow, router]);
 
   const handleAppleSignUp = useCallback(async () => {
     setIsLoading(true);
+    setLoadingMethod('apple');
     setError('');
 
     try {
@@ -127,6 +133,7 @@ export default function SignUp() {
       trackEvent(Events.SIGN_UP_FAILED, { method: 'apple', reason: message });
     } finally {
       setIsLoading(false);
+      setLoadingMethod(null);
     }
   }, [startAppleAuthenticationFlow, router]);
 
@@ -247,7 +254,7 @@ export default function SignUp() {
             title="Sign Up"
             onPress={handleSignUp}
             variant="primary"
-            loading={isLoading}
+            loading={loadingMethod === 'email'}
             disabled={isLoading}
           />
         </Animated.View>
@@ -267,6 +274,7 @@ export default function SignUp() {
             onPress={handleGoogleSignUp}
             variant="secondary"
             icon="logo-google"
+            loading={loadingMethod === 'google'}
             disabled={isLoading}
           />
         </Animated.View>
@@ -277,6 +285,7 @@ export default function SignUp() {
             onPress={handleAppleSignUp}
             variant="secondary"
             icon="logo-apple"
+            loading={loadingMethod === 'apple'}
             disabled={isLoading}
           />
         </Animated.View>

--- a/app/(tabs)/matches.tsx
+++ b/app/(tabs)/matches.tsx
@@ -1,5 +1,14 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { View, Text, StyleSheet, FlatList, Pressable, Share, Alert } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  Pressable,
+  Share,
+  Alert,
+  ActivityIndicator,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Animated, { FadeInDown, FadeInUp } from 'react-native-reanimated';
 import { useQuery, useMutation } from 'convex/react';
@@ -64,6 +73,7 @@ export default function Matches() {
   const [selectedMatch, setSelectedMatch] = useState<MatchWithName | null>(null);
   const [showPaywall, setShowPaywall] = useState(false);
   const [proposeTarget, setProposeTarget] = useState<MatchWithName | null>(null);
+  const [isRestoring, setIsRestoring] = useState(false);
   const [showDeclineSheet, setShowDeclineSheet] = useState(false);
   const [showCelebration, setShowCelebration] = useState(false);
   const [celebrationName, setCelebrationName] = useState('');
@@ -296,19 +306,29 @@ export default function Matches() {
                 </Pressable>
                 <Pressable
                   style={styles.restoreButton}
+                  disabled={isRestoring}
                   onPress={async () => {
-                    const success = await restorePurchases();
-                    if (success) {
-                      Alert.alert('Restored', 'Your premium purchase has been restored!');
-                    } else {
-                      Alert.alert(
-                        'No Purchase Found',
-                        'No previous purchase was found to restore.',
-                      );
+                    setIsRestoring(true);
+                    try {
+                      const success = await restorePurchases();
+                      if (success) {
+                        Alert.alert('Restored', 'Your premium purchase has been restored!');
+                      } else {
+                        Alert.alert(
+                          'No Purchase Found',
+                          'No previous purchase was found to restore.',
+                        );
+                      }
+                    } finally {
+                      setIsRestoring(false);
                     }
                   }}
                 >
-                  <Text style={styles.restoreButtonText}>Restore Purchase</Text>
+                  {isRestoring ? (
+                    <ActivityIndicator size="small" color={colors.primary} />
+                  ) : (
+                    <Text style={styles.restoreButtonText}>Restore Purchase</Text>
+                  )}
                 </Pressable>
               </View>
             )}

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -103,6 +103,7 @@ export default function Profile() {
   const partnerInfo = useQuery(api.partners.getPartnerInfo);
   const convexUser = useQuery(api.users.getCurrentUser);
   const [isLoading, setIsLoading] = useState(false);
+  const [isUnlinking, setIsUnlinking] = useState(false);
   const [showPaywall, setShowPaywall] = useState(false);
   const [showPartnerModal, setShowPartnerModal] = useState(false);
   const [showNameConfirmation, setShowNameConfirmation] = useState(false);
@@ -253,12 +254,15 @@ export default function Profile() {
           text: 'Unlink',
           style: 'destructive',
           onPress: async () => {
+            setIsUnlinking(true);
             try {
               await unlinkPartner();
               trackEvent(Events.PARTNER_UNLINKED);
             } catch (error) {
               Sentry.captureException(error);
               Alert.alert('Error', 'Failed to unlink partner. Please try again.');
+            } finally {
+              setIsUnlinking(false);
             }
           },
         },
@@ -402,9 +406,19 @@ export default function Profile() {
                     </Text>
                   </View>
                 </View>
-                <Pressable style={styles.unlinkButton} onPress={handleUnlinkPartner}>
-                  <Ionicons name="close-circle-outline" size={18} color="#ef4444" />
-                  <Text style={styles.unlinkButtonText}>Unlink Partner</Text>
+                <Pressable
+                  style={styles.unlinkButton}
+                  onPress={handleUnlinkPartner}
+                  disabled={isUnlinking}
+                >
+                  {isUnlinking ? (
+                    <ActivityIndicator size="small" color="#ef4444" />
+                  ) : (
+                    <>
+                      <Ionicons name="close-circle-outline" size={18} color="#ef4444" />
+                      <Text style={styles.unlinkButtonText}>Unlink Partner</Text>
+                    </>
+                  )}
                 </Pressable>
               </View>
             ) : (
@@ -538,7 +552,11 @@ export default function Profile() {
           onPress={handleDeleteAccount}
           disabled={isLoading}
         >
-          <Text style={styles.deleteAccountText}>Delete Account</Text>
+          {isLoading ? (
+            <ActivityIndicator size="small" color="#ef4444" />
+          ) : (
+            <Text style={styles.deleteAccountText}>Delete Account</Text>
+          )}
         </Pressable>
 
         <Paywall

--- a/components/matches/celebration-modal.tsx
+++ b/components/matches/celebration-modal.tsx
@@ -8,11 +8,34 @@ import * as Haptics from 'expo-haptics';
 
 interface CelebrationModalProps {
   visible: boolean;
-  nameName: string;
   onClose: () => void;
+  /** Match-acceptance API: when set (and `title` is not), the headline shows the name and subtitle defaults to "You both chose {nameName}". */
+  nameName?: string;
+  /** Generalized headline. Falls back to `nameName` for the match-acceptance flow. */
+  title?: string;
+  /** Generalized subtitle. Falls back to `You both chose ${nameName}`. */
+  subtitle?: string;
+  /** Primary CTA label. Defaults to "Share with Family" (which triggers Share). */
+  primaryButtonLabel?: string;
+  /** Primary CTA handler. Defaults to opening the system share sheet for the chosen name. */
+  onPrimaryPress?: () => void;
+  /** Secondary CTA label. Defaults to "Done". */
+  secondaryButtonLabel?: string;
+  /** Hide the share button styling/Share-sheet default, e.g. for the Premium celebration. */
+  hideShare?: boolean;
 }
 
-export function CelebrationModal({ visible, nameName, onClose }: CelebrationModalProps) {
+export function CelebrationModal({
+  visible,
+  onClose,
+  nameName,
+  title,
+  subtitle,
+  primaryButtonLabel,
+  onPrimaryPress,
+  secondaryButtonLabel = 'Done',
+  hideShare = false,
+}: CelebrationModalProps) {
   const { colors } = useTheme();
 
   useEffect(() => {
@@ -22,6 +45,7 @@ export function CelebrationModal({ visible, nameName, onClose }: CelebrationModa
   }, [visible]);
 
   const handleShare = async () => {
+    if (!nameName) return;
     try {
       await Share.share({
         message: `We've chosen a name! ${nameName}\n\nDiscovered together on Bambino`,
@@ -32,28 +56,37 @@ export function CelebrationModal({ visible, nameName, onClose }: CelebrationModa
     }
   };
 
+  const headline = title ?? nameName ?? '';
+  const subtitleText = subtitle ?? (nameName ? `You both chose ${nameName}` : '');
+  const resolvedPrimaryLabel = primaryButtonLabel ?? (hideShare ? 'Continue' : 'Share with Family');
+  const resolvedPrimaryPress = onPrimaryPress ?? (hideShare ? onClose : handleShare);
+
   return (
     <Modal visible={visible} transparent animationType="fade" statusBarTranslucent>
       <Confetti visible={visible} />
       <View style={styles.overlay}>
         <Animated.View entering={FadeIn.duration(400)} style={styles.content}>
           <Animated.Text entering={ZoomIn.delay(200).duration(500).springify()} style={styles.name}>
-            {nameName}
+            {headline}
           </Animated.Text>
 
-          <Animated.Text entering={FadeIn.delay(500).duration(400)} style={styles.subtitle}>
-            You both chose {nameName}
-          </Animated.Text>
+          {subtitleText.length > 0 && (
+            <Animated.Text entering={FadeIn.delay(500).duration(400)} style={styles.subtitle}>
+              {subtitleText}
+            </Animated.Text>
+          )}
 
           <Animated.View entering={FadeIn.delay(800).duration(400)} style={styles.buttons}>
             <Pressable
               style={[styles.shareButton, { backgroundColor: colors.primary }]}
-              onPress={handleShare}
+              onPress={resolvedPrimaryPress}
             >
-              <Text style={styles.shareButtonText}>Share with Family</Text>
+              <Text style={styles.shareButtonText}>{resolvedPrimaryLabel}</Text>
             </Pressable>
             <Pressable style={styles.doneButton} onPress={onClose}>
-              <Text style={[styles.doneButtonText, { color: colors.primary }]}>Done</Text>
+              <Text style={[styles.doneButtonText, { color: colors.primary }]}>
+                {secondaryButtonLabel}
+              </Text>
             </Pressable>
           </Animated.View>
         </Animated.View>

--- a/components/matches/decline-sheet.tsx
+++ b/components/matches/decline-sheet.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { ActivityIndicator, View, Text, Pressable, StyleSheet } from 'react-native';
 import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { AnimatedBottomSheet } from '@/components/ui/animated-bottom-sheet';
@@ -15,13 +15,20 @@ interface DeclineSheetProps {
 export function DeclineSheet({ visible, nameName, onDecline, onClose }: DeclineSheetProps) {
   const { colors } = useTheme();
   const [message, setMessage] = useState('');
+  const [isDeclining, setIsDeclining] = useState(false);
 
-  const handleDecline = () => {
-    onDecline(message.trim() || undefined);
-    setMessage('');
+  const handleDecline = async () => {
+    setIsDeclining(true);
+    try {
+      await onDecline(message.trim() || undefined);
+      setMessage('');
+    } finally {
+      setIsDeclining(false);
+    }
   };
 
   const handleClose = () => {
+    if (isDeclining) return;
     setMessage('');
     onClose();
   };
@@ -47,10 +54,14 @@ export function DeclineSheet({ visible, nameName, onDecline, onClose }: DeclineS
         <Text style={styles.charCount}>{message.length}/200</Text>
 
         <View style={styles.buttons}>
-          <Pressable style={styles.declineButton} onPress={handleDecline}>
-            <Text style={styles.declineButtonText}>Decline</Text>
+          <Pressable style={styles.declineButton} onPress={handleDecline} disabled={isDeclining}>
+            {isDeclining ? (
+              <ActivityIndicator size="small" color="#6B5B7B" />
+            ) : (
+              <Text style={styles.declineButtonText}>Decline</Text>
+            )}
           </Pressable>
-          <Pressable style={styles.cancelButton} onPress={handleClose}>
+          <Pressable style={styles.cancelButton} onPress={handleClose} disabled={isDeclining}>
             <Text style={[styles.cancelButtonText, { color: colors.primary }]}>Cancel</Text>
           </Pressable>
         </View>

--- a/components/matches/propose-sheet.tsx
+++ b/components/matches/propose-sheet.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { ActivityIndicator, View, Text, Pressable, StyleSheet } from 'react-native';
 import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { AnimatedBottomSheet } from '@/components/ui/animated-bottom-sheet';
@@ -16,13 +16,20 @@ interface ProposeSheetProps {
 export function ProposeSheet({ visible, name, onPropose, onClose }: ProposeSheetProps) {
   const { colors } = useTheme();
   const [message, setMessage] = useState('');
+  const [isProposing, setIsProposing] = useState(false);
 
-  const handlePropose = () => {
-    onPropose(message.trim() || undefined);
-    setMessage('');
+  const handlePropose = async () => {
+    setIsProposing(true);
+    try {
+      await onPropose(message.trim() || undefined);
+      setMessage('');
+    } finally {
+      setIsProposing(false);
+    }
   };
 
   const handleClose = () => {
+    if (isProposing) return;
     setMessage('');
     onClose();
   };
@@ -52,10 +59,15 @@ export function ProposeSheet({ visible, name, onPropose, onClose }: ProposeSheet
           <Pressable
             style={[styles.proposeButton, { backgroundColor: colors.primary }]}
             onPress={handlePropose}
+            disabled={isProposing}
           >
-            <Text style={styles.proposeButtonText}>Propose</Text>
+            {isProposing ? (
+              <ActivityIndicator size="small" color="#fff" />
+            ) : (
+              <Text style={styles.proposeButtonText}>Propose</Text>
+            )}
           </Pressable>
-          <Pressable style={styles.cancelButton} onPress={handleClose}>
+          <Pressable style={styles.cancelButton} onPress={handleClose} disabled={isProposing}>
             <Text style={[styles.cancelButtonText, { color: colors.primary }]}>Cancel</Text>
           </Pressable>
         </View>

--- a/components/partner/partner-link-modal.tsx
+++ b/components/partner/partner-link-modal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import {
+  ActivityIndicator,
   View,
   Text,
   TextInput,
@@ -13,7 +14,6 @@ import { useQuery, useMutation } from 'convex/react';
 import { Image } from 'expo-image';
 import { api } from '@/convex/_generated/api';
 import { Fonts } from '@/constants/theme';
-import { LoadingIndicator } from '@/components/ui/loading-indicator';
 import { Paywall } from '@/components/paywall';
 import * as Sentry from '@sentry/react-native';
 import { useTheme } from '@/contexts/theme-context';
@@ -206,7 +206,7 @@ export function PartnerLinkModal({ visible, onClose }: PartnerLinkModalProps) {
               disabled={isLookingUp || code.length !== 6}
             >
               {isLookingUp ? (
-                <LoadingIndicator size="small" />
+                <ActivityIndicator size="small" color="#fff" />
               ) : (
                 <Text style={styles.primaryButtonText}>Find Partner</Text>
               )}
@@ -251,7 +251,7 @@ export function PartnerLinkModal({ visible, onClose }: PartnerLinkModalProps) {
                 disabled={isLinking}
               >
                 {isLinking ? (
-                  <LoadingIndicator size="small" />
+                  <ActivityIndicator size="small" color="#fff" />
                 ) : (
                   <Text style={styles.primaryButtonText}>Link Partner</Text>
                 )}

--- a/components/paywall.tsx
+++ b/components/paywall.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
-import { View, Text, Pressable, StyleSheet, Alert } from 'react-native';
+import { ActivityIndicator, View, Text, Pressable, StyleSheet, Alert } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { usePurchases } from '@/hooks/use-purchases';
 import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { AnimatedBottomSheet } from '@/components/ui/animated-bottom-sheet';
 import { GradientButton } from '@/components/ui/gradient-button';
+import { CelebrationModal } from '@/components/matches/celebration-modal';
 import { trackEvent, Events } from '@/lib/analytics';
 
 interface PaywallProps {
@@ -30,6 +31,8 @@ export function Paywall({ visible, onClose, trigger = 'swipe_limit' }: PaywallPr
   const { colors } = useTheme();
   const { packages, purchasePremium, restorePurchases, isLoading } = usePurchases();
   const [isPurchasing, setIsPurchasing] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(false);
+  const [showCelebration, setShowCelebration] = useState(false);
 
   const hasPackages = packages.length > 0;
   const price = packages[0]?.product.priceString ?? '$4.99';
@@ -45,7 +48,7 @@ export function Paywall({ visible, onClose, trigger = 'swipe_limit' }: PaywallPr
       const success = await purchasePremium();
       if (success) {
         trackEvent(Events.PURCHASE_COMPLETED, { trigger });
-        onClose();
+        setShowCelebration(true);
       } else {
         trackEvent(Events.PURCHASE_FAILED, { trigger, reason: 'cancelled_or_failed' });
       }
@@ -54,8 +57,13 @@ export function Paywall({ visible, onClose, trigger = 'swipe_limit' }: PaywallPr
     }
   };
 
+  const handleCelebrationClose = () => {
+    setShowCelebration(false);
+    onClose();
+  };
+
   const handleRestore = async () => {
-    setIsPurchasing(true);
+    setIsRestoring(true);
     try {
       const success = await restorePurchases();
       if (success) {
@@ -66,90 +74,106 @@ export function Paywall({ visible, onClose, trigger = 'swipe_limit' }: PaywallPr
         Alert.alert('No Purchase Found', 'No previous purchase was found to restore.');
       }
     } finally {
-      setIsPurchasing(false);
+      setIsRestoring(false);
     }
   };
 
   return (
-    <AnimatedBottomSheet
-      visible={visible}
-      onClose={onClose}
-      style={{ paddingHorizontal: 24, paddingTop: 16, paddingBottom: 40 }}
-    >
-      {/* Close button */}
-      <Pressable
-        style={styles.closeButton}
-        onPress={onClose}
-        accessibilityLabel="Close"
-        accessibilityRole="button"
+    <>
+      <AnimatedBottomSheet
+        visible={visible && !showCelebration}
+        onClose={onClose}
+        style={{ paddingHorizontal: 24, paddingTop: 16, paddingBottom: 40 }}
       >
-        <Ionicons name="close" size={24} color="#6B5B7B" />
-      </Pressable>
+        {/* Close button */}
+        <Pressable
+          style={styles.closeButton}
+          onPress={onClose}
+          accessibilityLabel="Close"
+          accessibilityRole="button"
+        >
+          <Ionicons name="close" size={24} color="#6B5B7B" />
+        </Pressable>
 
-      {/* Header */}
-      <View style={styles.header}>
-        <View style={[styles.iconBadge, { backgroundColor: colors.secondaryLight }]}>
-          <Ionicons name="star" size={32} color={colors.primary} />
-        </View>
-        <Text style={styles.title}>Bambino Premium</Text>
-        <Text style={styles.subtitle}>{TRIGGER_MESSAGES[trigger]}</Text>
-      </View>
-
-      {/* Comparison */}
-      <View style={[styles.comparison, { backgroundColor: colors.primaryLight }]}>
-        <View style={styles.comparisonRow}>
-          <Text style={styles.comparisonLabel} />
-          <Text style={styles.comparisonHeaderFree}>Free</Text>
-          <View style={[styles.premiumPill, { backgroundColor: colors.primary }]}>
-            <Text style={styles.premiumPillText}>Premium</Text>
+        {/* Header */}
+        <View style={styles.header}>
+          <View style={[styles.iconBadge, { backgroundColor: colors.secondaryLight }]}>
+            <Ionicons name="star" size={32} color={colors.primary} />
           </View>
+          <Text style={styles.title}>Bambino Premium</Text>
+          <Text style={styles.subtitle}>{TRIGGER_MESSAGES[trigger]}</Text>
         </View>
-        {COMPARISON_ROWS.map((row, index) => (
-          <View key={row.label}>
-            {index > 0 && <View style={styles.rowSeparator} />}
-            <View style={styles.comparisonRow}>
-              <Text style={styles.comparisonLabel}>{row.label}</Text>
-              <Text style={styles.comparisonValue}>{row.free}</Text>
-              <Text style={[styles.comparisonValuePremium, { color: colors.primary }]}>
-                {row.premium}
-              </Text>
+
+        {/* Comparison */}
+        <View style={[styles.comparison, { backgroundColor: colors.primaryLight }]}>
+          <View style={styles.comparisonRow}>
+            <Text style={styles.comparisonLabel} />
+            <Text style={styles.comparisonHeaderFree}>Free</Text>
+            <View style={[styles.premiumPill, { backgroundColor: colors.primary }]}>
+              <Text style={styles.premiumPillText}>Premium</Text>
             </View>
           </View>
-        ))}
-      </View>
+          {COMPARISON_ROWS.map((row, index) => (
+            <View key={row.label}>
+              {index > 0 && <View style={styles.rowSeparator} />}
+              <View style={styles.comparisonRow}>
+                <Text style={styles.comparisonLabel}>{row.label}</Text>
+                <Text style={styles.comparisonValue}>{row.free}</Text>
+                <Text style={[styles.comparisonValuePremium, { color: colors.primary }]}>
+                  {row.premium}
+                </Text>
+              </View>
+            </View>
+          ))}
+        </View>
 
-      {/* Purchase button */}
-      <View style={{ marginBottom: 8 }}>
-        {!hasPackages && !isLoading ? (
-          <View style={styles.errorState}>
-            <Text style={styles.errorText}>Unable to load pricing. Check your connection.</Text>
-            <Pressable onPress={onClose}>
-              <Text style={[styles.restoreButtonText, { color: colors.primary }]}>Dismiss</Text>
-            </Pressable>
-          </View>
-        ) : (
-          <GradientButton
-            title={`Unlock Premium - ${price}`}
-            onPress={handlePurchase}
-            loading={isPurchasing}
-            disabled={isPurchasing || isLoading}
-          />
-        )}
-      </View>
+        {/* Purchase button */}
+        <View style={{ marginBottom: 8 }}>
+          {!hasPackages && !isLoading ? (
+            <View style={styles.errorState}>
+              <Text style={styles.errorText}>Unable to load pricing. Check your connection.</Text>
+              <Pressable onPress={onClose}>
+                <Text style={[styles.restoreButtonText, { color: colors.primary }]}>Dismiss</Text>
+              </Pressable>
+            </View>
+          ) : (
+            <GradientButton
+              title={`Unlock Premium - ${price}`}
+              onPress={handlePurchase}
+              loading={isPurchasing}
+              disabled={isPurchasing || isLoading}
+            />
+          )}
+        </View>
 
-      <Text style={styles.oneTime}>One-time purchase. No subscription.</Text>
+        <Text style={styles.oneTime}>One-time purchase. No subscription.</Text>
 
-      {/* Restore */}
-      <Pressable
-        style={styles.restoreButton}
-        onPress={handleRestore}
-        disabled={isPurchasing}
-        accessibilityLabel="Restore previous purchase"
-        accessibilityRole="button"
-      >
-        <Text style={styles.restoreButtonText}>Restore Purchase</Text>
-      </Pressable>
-    </AnimatedBottomSheet>
+        {/* Restore */}
+        <Pressable
+          style={styles.restoreButton}
+          onPress={handleRestore}
+          disabled={isPurchasing || isRestoring}
+          accessibilityLabel="Restore previous purchase"
+          accessibilityRole="button"
+        >
+          {isRestoring ? (
+            <ActivityIndicator size="small" color="#6B5B7B" />
+          ) : (
+            <Text style={styles.restoreButtonText}>Restore Purchase</Text>
+          )}
+        </Pressable>
+      </AnimatedBottomSheet>
+
+      <CelebrationModal
+        visible={showCelebration}
+        onClose={handleCelebrationClose}
+        title="Bambino Premium"
+        subtitle="Welcome to Bambino Premium! 🎉"
+        primaryButtonLabel="Start Exploring"
+        onPrimaryPress={handleCelebrationClose}
+        hideShare
+      />
+    </>
   );
 }
 

--- a/components/ui/gradient-button.tsx
+++ b/components/ui/gradient-button.tsx
@@ -1,10 +1,9 @@
-import { Pressable, Text, View, StyleSheet } from 'react-native';
+import { ActivityIndicator, Pressable, Text, View, StyleSheet } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import Animated, { useSharedValue, useAnimatedStyle, withSpring } from 'react-native-reanimated';
 import { Ionicons } from '@expo/vector-icons';
 import { Fonts, Gradients as DefaultGradients } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
-import { LoadingIndicator } from './loading-indicator';
 
 type ButtonVariant = 'primary' | 'secondary' | 'danger';
 
@@ -57,7 +56,7 @@ export function GradientButton({
         disabled={disabled || loading}
       >
         {loading ? (
-          <LoadingIndicator size="small" />
+          <ActivityIndicator size="small" color={colors.primary} />
         ) : (
           <View style={styles.contentRow}>
             {icon && <Ionicons name={icon} size={20} color={colors.primary} />}
@@ -83,7 +82,7 @@ export function GradientButton({
     >
       <LinearGradient colors={[...gradientColors]} style={[styles.gradient, { shadowColor }]}>
         {loading ? (
-          <LoadingIndicator size="small" />
+          <ActivityIndicator size="small" color="#ffffff" />
         ) : (
           <View style={styles.contentRow}>
             {icon && <Ionicons name={icon} size={20} color="#fff" />}


### PR DESCRIPTION
## Summary

After the first sandbox IAP purchase on TestFlight build 7, two bits of polish:

- **Janky paywall dismiss → celebratory moment.** Generalize the existing `CelebrationModal` (used for proposal acceptance) with optional `title`/`subtitle`/`primaryButtonLabel`/`onPrimaryPress`/`hideShare` props, then trigger it on a successful Premium purchase. Confetti, success haptic, "Welcome to Bambino Premium! 🎉", and a single "Start Exploring" CTA that dismisses both the celebration and the paywall sheet underneath.
- **Consistent button loading states.** Replace the faded "bambino" wordmark inside `GradientButton`'s loading slot with a native `ActivityIndicator`. Add `isLoading` state + inline `ActivityIndicator` to bespoke async `Pressable`s that previously had no spinner: Restore Purchase (paywall + matches), Delete Account, Unlink Partner, Propose, Decline. Swap the same wordmark for `ActivityIndicator` in `partner-link-modal` buttons (component is still used for full-screen content placeholders elsewhere).
- **Per-method auth spinners.** Sign-in / sign-up screens now track `loadingMethod: 'email' | 'google' | 'apple'` so tapping Continue with Apple doesn't show spinners across all three sign-in buttons.

## Test plan

- [x] Fresh free account → exhaust 25 swipes → Unlock Premium → StoreKit confirms → celebration sheet appears with confetti, success haptic, "Welcome to Bambino Premium! 🎉" → "Start Exploring" dismisses both sheets cleanly. Premium is active.
- [x] Sam ↔ Alex demo accounts: existing proposal-accept celebration unchanged (name headline, "Share with Family" + "Done", share works).
- [x] Sweep test of migrated buttons under slow network: each shows a spinner while pending, disables to prevent double-tap, returns to idle. No "bambino" wordmark anywhere inside a button.
- [x] Sign Out: spinner appears, no faded bambino text.
- [x] Restore Purchase from a free account with no prior purchase: spinner, then "No Purchase Found" alert.
- [ ] Production build pickup happens with the next EAS production build (not cut as part of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)