### PR TITLE
ci: add manual Convex dev deploy workflow

### DIFF
--- a/.github/workflows/convex-deploy-dev.yml
+++ b/.github/workflows/convex-deploy-dev.yml
@@ -1,0 +1,53 @@
+name: Convex deploy (dev)
+
+# Pushes the current branch's convex/ schema and functions to the dev
+# deployment. Useful when you've made a schema change and want to
+# validate migrations or new functions on dev before promoting to prod.
+# Defaults to master so it tracks the same source of truth as the prod
+# workflow, but accepts any branch via the `ref` input.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or commit SHA to deploy (defaults to master)"
+        required: false
+        default: "master"
+
+jobs:
+  deploy:
+    name: Deploy Convex backend to dev
+    runs-on: ubuntu-latest
+    # `development` environment requires CONVEX_DEPLOY_KEY_DEV secret —
+    # the dev-deployment key from the Convex dashboard. Different key
+    # than the prod workflow uses; do not reuse the prod key.
+    environment: development
+    steps:
+      - name: Check for CONVEX_DEPLOY_KEY_DEV
+        run: |
+          if [ -z "${{ secrets.CONVEX_DEPLOY_KEY_DEV }}" ]; then
+            echo "CONVEX_DEPLOY_KEY_DEV is not set. Generate one in the Convex dashboard"
+            echo "(Settings → Deploy Keys → Generate dev deploy key) and add it under the"
+            echo "'development' GitHub Environment at"
+            echo "https://github.com/${{ github.repository }}/settings/environments"
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Deploy Convex backend (dev)
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY_DEV }}
+        run: npx convex deploy


### PR DESCRIPTION
## Summary
- Mirrors \`convex-deploy.yml\` but targets the dev deployment.
- Uses a separate \`CONVEX_DEPLOY_KEY_DEV\` secret (do not reuse the prod key).
- Manual dispatch with optional \`ref\` input — defaults to master.

## Why
- Schema/function changes need to land on the dev deployment before we can run paginated migration scripts (e.g. \`populate:origin-stats\`) against dev.
- Without this, you have to run \`npx convex dev\` locally each time, which doesn't fit the CI-driven flow we use for prod.

## Setup before first run
1. Generate a dev deploy key in the Convex dashboard (Settings → Deploy Keys → Generate development deploy key).
2. Create a GitHub \"development\" Environment under repo Settings.
3. Add \`CONVEX_DEPLOY_KEY_DEV\` as a secret on that environment.

## Test plan
- [ ] Set up the secret as above, trigger the workflow against master, confirm dev Convex deployment receives the new schema + functions
- [ ] Re-run \`npm run populate:origin-stats\` against dev and confirm it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)