### PR TITLE
fix: include build number in Sentry release for per-build tagging

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -29,10 +29,21 @@ import { LoadingScreen } from '@/components/ui/loading-screen';
 import { OfflineBanner } from '@/components/ui/offline-banner';
 import { initAnalytics } from '@/lib/analytics';
 
+// Sentry release uniquely identifies a single build, not the marketing
+// version. EAS auto-increments ios.buildNumber on every production build,
+// so combining it with version gives "1.0.0+8", "1.0.0+9", etc. — letting
+// "Resolved in next release" actually distinguish between builds and
+// catch regressions that come back in a later build.
+const sentryVersion = Constants.expoConfig?.version ?? '1.0.0';
+const sentryBuildNumber = Constants.expoConfig?.ios?.buildNumber;
+const sentryRelease = sentryBuildNumber
+  ? `${sentryVersion}+${sentryBuildNumber}`
+  : sentryVersion;
+
 Sentry.init({
   dsn: process.env.EXPO_PUBLIC_SENTRY_DSN,
   enabled: !__DEV__,
-  release: Constants.expoConfig?.version ?? '1.0.0',
+  release: sentryRelease,
   environment: __DEV__ ? 'development' : 'production',
   tracesSampleRate: 0.2,
 });


### PR DESCRIPTION
## Summary
- Sentry was tagging every event with \`release: "1.0.0"\` because we passed \`Constants.expoConfig?.version\` (the marketing version, which doesn't change between builds).
- That broke "Resolved in next release" — Sentry had no way to distinguish whether an error came from build 7, 8, or a hypothetical 9.

## Fix
Combine version with the EAS auto-incremented \`ios.buildNumber\`. Releases now look like:
- \`1.0.0+7\`
- \`1.0.0+8\`
- \`1.0.0+9\`

Falls back to plain \`1.0.0\` when \`buildNumber\` isn't present (local simulator runs where there's no EAS build).

## Effect
- Future builds: every TestFlight or production build reports a unique release. "Resolved in next release" works correctly. Regression detection is meaningful.
- Past events: stay tagged with plain \`1.0.0\`. We can't retroactively split them, but that's fine — the bugs we'd want to track are mostly already fixed in master and just need a fresh build to ship.

## Test plan
- [x] Typecheck clean
- [ ] Next production build emits events tagged \`1.0.0+9\` (or whatever EAS assigns)
- [ ] Sentry's release filter shows the new release as a distinct option

🤖 Generated with [Claude Code](https://claude.com/claude-code)