### PR TITLE
fix: stop patching first/last name back to Clerk

### DIFF
--- a/components/partner/name-confirmation-modal.tsx
+++ b/components/partner/name-confirmation-modal.tsx
@@ -67,15 +67,10 @@ export function NameConfirmationModal({
     setError(null);
 
     try {
-      // Update Clerk (may fail if name fields are disabled in dashboard)
-      await user
-        ?.update({
-          firstName: trimmedFirst,
-          lastName: lastName.trim(),
-        })
-        .catch((err) => Sentry.captureException(err));
-
-      // Update Convex (source of truth)
+      // Convex is the source of truth for display name. We don't write
+      // back to Clerk because the dashboard has first_name/last_name
+      // disabled (PATCH /v1/me would 422). Clerk only contributes the
+      // initial name at sign-up via user.fullName from Apple/Google SSO.
       await confirmName({
         firstName: trimmedFirst,
         lastName: lastName.trim() || undefined,


### PR DESCRIPTION
## Summary

Sentry surfaced a recurring \`first_name is not a valid parameter for this request\` error from a Clerk PATCH \`/v1/me\` returning 422.

**Root cause:** \`NameConfirmationModal\` was calling \`user.update({ firstName, lastName })\` on Clerk after the Convex mutation. Clerk's dashboard has those fields disabled, so the call always 422s. The error was swallowed via \`.catch(...)\` for the user but explicitly captured to Sentry, generating noise on every name save.

**Why Clerk is unnecessary:** Convex is the source of truth for display name. Clerk's only contribution is the initial value at sign-up — \`useStoreUser\` reads \`user.fullName\` (populated by Apple/Google SSO) and writes it to the Convex users row on first mount. After that, Clerk isn't consulted again for name display.

## Fix
Drop the \`user.update()\` call. The Convex \`confirmName\` mutation runs as before.

## Test plan
- [x] Typecheck clean
- [x] Sign-up via email + password (fresh account) → name save in Convex still works, no 422 in Metro/Sentry
- [ ] Verify in next TestFlight build that the Sentry issue stops getting new events

🤖 Generated with [Claude Code](https://claude.com/claude-code)