### PR TITLE
ci: add lint + typecheck workflow on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+# Lightweight JS-toolchain checks on every pull request: lint and
+# typecheck. No native build, no EAS — those run via the manual
+# dispatch workflows. This is the gate that catches Prettier/ESLint
+# regressions and TS errors before review.
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run TypeScript compiler
+        # Default heap OOMs on this project; bump to 8GB to match
+        # the local invocation used during development.
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+        run: npx tsc --noEmit

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -36,9 +36,7 @@ import { initAnalytics } from '@/lib/analytics';
 // catch regressions that come back in a later build.
 const sentryVersion = Constants.expoConfig?.version ?? '1.0.0';
 const sentryBuildNumber = Constants.expoConfig?.ios?.buildNumber;
-const sentryRelease = sentryBuildNumber
-  ? `${sentryVersion}+${sentryBuildNumber}`
-  : sentryVersion;
+const sentryRelease = sentryBuildNumber ? `${sentryVersion}+${sentryBuildNumber}` : sentryVersion;
 
 Sentry.init({
   dsn: process.env.EXPO_PUBLIC_SENTRY_DSN,

--- a/components/matches/decline-sheet.tsx
+++ b/components/matches/decline-sheet.tsx
@@ -38,7 +38,7 @@ export function DeclineSheet({ visible, nameName, onDecline, onClose }: DeclineS
       <View style={styles.content}>
         <View style={styles.handleBar} />
 
-        <Text style={styles.title}>Decline "{nameName}"?</Text>
+        <Text style={styles.title}>Decline &ldquo;{nameName}&rdquo;?</Text>
         <Text style={styles.subtitle}>
           Your partner will be notified. You can both propose again anytime.
         </Text>

--- a/components/matches/proposal-banner.tsx
+++ b/components/matches/proposal-banner.tsx
@@ -57,7 +57,7 @@ export function ProposalBanner({
           <Text style={[styles.bannerText, { color: colors.tabActive }]}>
             {proposerName} proposed <Text style={styles.bannerNameText}>{nameName}</Text>
           </Text>
-          {message ? <Text style={styles.bannerMessage}>"{message}"</Text> : null}
+          {message ? <Text style={styles.bannerMessage}>&ldquo;{message}&rdquo;</Text> : null}
         </View>
       </View>
       <View style={styles.bannerActions}>

--- a/components/ui/styled-input.tsx
+++ b/components/ui/styled-input.tsx
@@ -3,6 +3,7 @@ import {
   StyleSheet,
   View,
   Pressable,
+  type StyleProp,
   type TextInputProps,
   type ViewStyle,
 } from 'react-native';
@@ -61,7 +62,7 @@ export function StyledInput({
 
   return (
     <View className={className} style={containerStyle}>
-      <AnimatedView style={[styles.container, animatedStyle, style]}>
+      <AnimatedView style={[styles.container, animatedStyle, style as StyleProp<ViewStyle>]}>
         {icon && (
           <Ionicons name={icon} size={20} color={CandyColors.textMuted} style={styles.icon} />
         )}


### PR DESCRIPTION
Closes #146.

## Summary
- New `.github/workflows/ci.yml` runs on every `pull_request` with two parallel jobs:
  - **Lint** — `npm ci` + `npm run lint`
  - **Typecheck** — `npm ci` + `npx tsc --noEmit` with `NODE_OPTIONS=--max-old-space-size=8192` (default heap OOMs)
- Node 22 + npm cache, matching the existing Convex/EAS workflows.
- Fixed the pre-existing errors so the gate is green from day one:
  - `app/_layout.tsx` — Prettier ternary formatting (auto-fixed)
  - `components/matches/decline-sheet.tsx`, `components/matches/proposal-banner.tsx` — escape literal quotes in JSX (4 errors)
  - `components/ui/styled-input.tsx` — cast `TextInput`'s `style` prop to `ViewStyle` for the `Animated.View` wrapper (the 1 pre-existing TS error)

## Test plan
- [x] Local `npm run lint` → 0 errors (9 pre-existing warnings remain; not gated)
- [x] Local `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit` → clean
- [ ] CI runs on this PR itself — confirms the workflow file is valid and both jobs pass
- [ ] (Optional, post-merge) Configure branch protection to require `Lint` + `Typecheck` checks before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)