### PR TITLE
fix: delete Clerk user on account deletion (App Store 5.1.1(v))

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -147,11 +147,26 @@ export default function Profile() {
             try {
               await deleteAccount();
               trackEvent(Events.ACCOUNT_DELETED);
-              try {
-                await user?.delete();
-              } catch (clerkErr) {
-                Sentry.captureException(clerkErr, { tags: { phase: 'clerk_delete' } });
+              // DIAGNOSTIC — remove before merging #152
+              const diag: string[] = [];
+              if (!user) {
+                diag.push('user is null');
+              } else {
+                diag.push(`user.id=${user.id}`);
+                try {
+                  await user.delete();
+                  diag.push('delete() resolved OK');
+                } catch (clerkErr: unknown) {
+                  const msg = clerkErr instanceof Error ? clerkErr.message : String(clerkErr);
+                  diag.push(`delete() threw: ${msg}`);
+                  Sentry.captureException(clerkErr, { tags: { phase: 'clerk_delete' } });
+                }
               }
+              await new Promise<void>((resolve) => {
+                Alert.alert('Delete diagnostic', diag.join('\n'), [
+                  { text: 'OK', onPress: () => resolve() },
+                ]);
+              });
               await signOut();
               Sentry.setUser(null);
               resetAnalytics();

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -147,26 +147,11 @@ export default function Profile() {
             try {
               await deleteAccount();
               trackEvent(Events.ACCOUNT_DELETED);
-              // DIAGNOSTIC — remove before merging #152
-              const diag: string[] = [];
-              if (!user) {
-                diag.push('user is null');
-              } else {
-                diag.push(`user.id=${user.id}`);
-                try {
-                  await user.delete();
-                  diag.push('delete() resolved OK');
-                } catch (clerkErr: unknown) {
-                  const msg = clerkErr instanceof Error ? clerkErr.message : String(clerkErr);
-                  diag.push(`delete() threw: ${msg}`);
-                  Sentry.captureException(clerkErr, { tags: { phase: 'clerk_delete' } });
-                }
+              try {
+                await user?.delete();
+              } catch (clerkErr) {
+                Sentry.captureException(clerkErr, { tags: { phase: 'clerk_delete' } });
               }
-              await new Promise<void>((resolve) => {
-                Alert.alert('Delete diagnostic', diag.join('\n'), [
-                  { text: 'OK', onPress: () => resolve() },
-                ]);
-              });
               await signOut();
               Sentry.setUser(null);
               resetAnalytics();

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -147,6 +147,11 @@ export default function Profile() {
             try {
               await deleteAccount();
               trackEvent(Events.ACCOUNT_DELETED);
+              try {
+                await user?.delete();
+              } catch (clerkErr) {
+                Sentry.captureException(clerkErr, { tags: { phase: 'clerk_delete' } });
+              }
               await signOut();
               Sentry.setUser(null);
               resetAnalytics();
@@ -160,7 +165,7 @@ export default function Profile() {
         },
       ],
     );
-  }, [deleteAccount, signOut]);
+  }, [deleteAccount, signOut, user]);
 
   const handleCopyCode = useCallback(async () => {
     if (partnerInfo?.shareCode) {


### PR DESCRIPTION
Closes #152

## Summary
- Calls `user.delete()` between Convex deletion and `signOut()` so the Clerk identity is fully removed, not just deactivated.
- If Clerk delete fails, capture to Sentry with `phase=clerk_delete` and continue — Convex is already gone, no point stranding the user with a half-deleted record.

## Why
App Store Guideline 5.1.1(v): apps with accounts must permanently delete the account. Without this, a reviewer can delete an account and then sign in again with the same email/password (Clerk identity survives, `createOrUpdateUser` re-hydrates the Convex side) and reject the build.

## Test plan
- [ ] Sign in with a throwaway account
- [ ] Profile → Delete Account → confirm
- [ ] Try to sign back in with same email/password → expect "user not found"
- [ ] Verify Sentry doesn't get a `clerk_delete` event on the happy path
- [ ] Update App Review notes to call this out

🤖 Generated with [Claude Code](https://claude.com/claude-code)