### PR TITLE
chore: stop sending user name to PostHog

### DIFF
--- a/hooks/use-store-user.ts
+++ b/hooks/use-store-user.ts
@@ -21,7 +21,6 @@ export function useStoreUser() {
     Sentry.setUser({ id: user.id, email });
     identifyUser(user.id, {
       ...(email ? { email } : {}),
-      ...(name ? { name } : {}),
     });
 
     const syncUser = async () => {


### PR DESCRIPTION
## Summary
- Drops the `name` property from `identifyUser` in `hooks/use-store-user.ts`.
- Email and user ID are still sent (they're the analytics identifier).
- `name` is still passed to `createOrUpdateUser` for Convex sync — that's App Functionality.

## Why
Lining up the App Privacy manifest with App Store Connect. ASC currently lists Name as App Functionality only — but the code was sending it to PostHog as analytics data, which would force me to either expand the ASC purpose or write a manifest that mismatches. Removing the analytics use is the simpler answer and tighter privacy.

## Test plan
- [ ] Sign in on dev — confirm no errors
- [ ] (Optional) Inspect a PostHog person profile after sign-in — `name` property should not be set on new identifies (existing person profiles will keep stale `name` values until cleared in PostHog separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)