### PR TITLE
feat: render Pass/Like buttons when VoiceOver or Reduce Motion is on

### DIFF
--- a/components/swipe/swipe-action-buttons.tsx
+++ b/components/swipe/swipe-action-buttons.tsx
@@ -1,19 +1,28 @@
-import { Pressable, StyleSheet } from 'react-native';
+import { ActivityIndicator, Pressable, Text, View, StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
 import Animated, { FadeInUp } from 'react-native-reanimated';
-import { Ionicons } from '@expo/vector-icons';
+import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 
 interface SwipeActionButtonsProps {
   onLike: () => void;
   onNope: () => void;
   disabled?: boolean;
+  /** When true, skip the FadeInUp entrance — respects user's Reduce Motion setting. */
+  reduceMotion?: boolean;
 }
 
-export function SwipeActionButtons({ onLike, onNope, disabled = false }: SwipeActionButtonsProps) {
-  const { colors } = useTheme();
+export function SwipeActionButtons({
+  onLike,
+  onNope,
+  disabled = false,
+  reduceMotion = false,
+}: SwipeActionButtonsProps) {
+  const { colors, gradients } = useTheme();
+
   return (
     <Animated.View
-      entering={FadeInUp.delay(200).duration(400).springify()}
+      entering={reduceMotion ? undefined : FadeInUp.delay(200).duration(400).springify()}
       style={styles.container}
     >
       <Pressable
@@ -21,15 +30,11 @@ export function SwipeActionButtons({ onLike, onNope, disabled = false }: SwipeAc
         disabled={disabled}
         accessibilityLabel="Pass"
         accessibilityRole="button"
-        style={({ pressed }) => [
-          styles.button,
-          { shadowColor: colors.secondary },
-          styles.dislikeButton,
-          pressed && styles.buttonPressed,
-          disabled && { borderColor: colors.border, backgroundColor: colors.surfaceSubtle },
-        ]}
+        style={[styles.button, disabled && styles.disabled]}
       >
-        <Ionicons name="heart-dislike" size={32} color={disabled ? '#FFD4E0' : '#FF8FAB'} />
+        <View style={[styles.secondaryButton, { borderColor: colors.primary }]}>
+          <Text style={[styles.secondaryText, { color: colors.primary }]}>Pass</Text>
+        </View>
       </Pressable>
 
       <Pressable
@@ -37,51 +42,71 @@ export function SwipeActionButtons({ onLike, onNope, disabled = false }: SwipeAc
         disabled={disabled}
         accessibilityLabel="Like"
         accessibilityRole="button"
-        style={({ pressed }) => [
-          styles.button,
-          { shadowColor: colors.secondary },
-          styles.likeButton,
-          pressed && styles.buttonPressed,
-          disabled && { borderColor: colors.border, backgroundColor: colors.surfaceSubtle },
-        ]}
+        style={[styles.button, disabled && styles.disabled]}
       >
-        <Ionicons name="heart" size={32} color={disabled ? '#B4EAD0' : '#6DD5A0'} />
+        <LinearGradient
+          colors={[...gradients.buttonPrimary]}
+          style={[styles.gradient, { shadowColor: colors.primary }]}
+        >
+          {disabled ? (
+            <ActivityIndicator size="small" color="#ffffff" />
+          ) : (
+            <Text style={styles.gradientText}>Like</Text>
+          )}
+        </LinearGradient>
       </Pressable>
     </Animated.View>
   );
 }
 
+// Approximate height the row takes when rendered. Used by callers to
+// reserve vertical space (e.g. shrink the card so this fits below).
+export const SWIPE_ACTION_BUTTONS_HEIGHT = 80;
+
 const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
-    gap: 40,
-    paddingVertical: 24,
+    gap: 12,
     paddingHorizontal: 16,
+    paddingVertical: 16,
   },
   button: {
-    width: 72,
-    height: 72,
-    borderRadius: 36,
+    flex: 1,
+  },
+  gradient: {
+    flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    shadowOpacity: 0.1,
+    gap: 8,
+    paddingVertical: 16,
+    borderRadius: 14,
+    shadowOpacity: 0.25,
     shadowRadius: 8,
     shadowOffset: { width: 0, height: 4 },
     elevation: 4,
   },
-  dislikeButton: {
-    backgroundColor: '#fff',
-    borderWidth: 3,
-    borderColor: '#FF8FAB',
+  gradientText: {
+    fontSize: 16,
+    fontFamily: Fonts?.sans,
+    fontWeight: '600',
+    color: '#ffffff',
   },
-  likeButton: {
-    backgroundColor: '#fff',
-    borderWidth: 3,
-    borderColor: '#6DD5A0',
+  secondaryButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    paddingVertical: 16,
+    borderRadius: 14,
+    backgroundColor: '#ffffff',
+    borderWidth: 1.5,
   },
-  buttonPressed: {
-    transform: [{ scale: 0.92 }],
+  secondaryText: {
+    fontSize: 16,
+    fontFamily: Fonts?.sans,
+    fontWeight: '600',
+  },
+  disabled: {
+    opacity: 0.6,
   },
 });

--- a/components/swipe/swipe-card-stack.tsx
+++ b/components/swipe/swipe-card-stack.tsx
@@ -7,6 +7,7 @@ import { trackEvent, Events } from '@/lib/analytics';
 import { api } from '@/convex/_generated/api';
 import { Doc } from '@/convex/_generated/dataModel';
 import { SwipeCard } from './swipe-card';
+import { SwipeActionButtons, SWIPE_ACTION_BUTTONS_HEIGHT } from './swipe-action-buttons';
 import { EmptyState } from './empty-state';
 import { MatchToast } from '@/components/matches/match-toast';
 import { ErrorToast } from '@/components/ui/error-toast';
@@ -15,6 +16,7 @@ import { Paywall } from '@/components/paywall';
 import { PushPrimingSheet } from '@/components/push/push-priming-sheet';
 import { CARD_WIDTH, CARD_HEIGHT_FULL } from '@/constants/swipe';
 import { useTheme } from '@/contexts/theme-context';
+import { useA11yPreferences } from '@/hooks/use-a11y-preferences';
 import { usePushPriming } from '@/hooks/use-push-priming';
 import { usePushRequestPermission } from '@/hooks/use-push-registration';
 
@@ -49,6 +51,7 @@ export function SwipeCardStack() {
 
   const { shouldPrime, markAsked, markDismissed } = usePushPriming();
   const requestPermission = usePushRequestPermission();
+  const { needsButtons, reduceMotion } = useA11yPreferences();
 
   // Sync server queue to local state (only when server data arrives)
   useEffect(() => {
@@ -133,9 +136,10 @@ export function SwipeCardStack() {
             key={name._id}
             name={name}
             isTop={index === 0}
-            showSwipeHint={hintEligible}
-            swipeEnabled={!showDetailModal}
+            showSwipeHint={hintEligible && !needsButtons}
+            swipeEnabled={!showDetailModal && !needsButtons}
             detailOpen={showDetailModal}
+            cardHeight={needsButtons ? CARD_HEIGHT_FULL - SWIPE_ACTION_BUTTONS_HEIGHT : undefined}
             onSwipeHintShown={() => setHintEligible(false)}
             onSwipeHintReset={() => setHintEligible(true)}
             onSwipeLeft={() => handleSelection('reject')}
@@ -144,6 +148,17 @@ export function SwipeCardStack() {
           />
         ))}
       </View>
+
+      {/* Accessibility-only Pass/Like buttons — pan gesture conflicts with
+          VoiceOver, and Reduce Motion users may also prefer explicit taps (#162). */}
+      {needsButtons && (
+        <SwipeActionButtons
+          onLike={() => handleSelection('like')}
+          onNope={() => handleSelection('reject')}
+          disabled={localQueue.length === 0}
+          reduceMotion={reduceMotion}
+        />
+      )}
 
       {/* Subsequent match toast */}
       <MatchToast

--- a/components/swipe/swipe-card.tsx
+++ b/components/swipe/swipe-card.tsx
@@ -49,6 +49,9 @@ interface SwipeCardProps {
   onDetailPress?: () => void;
   swipeEnabled?: boolean;
   detailOpen?: boolean;
+  /** Override the default card height. Used when accessibility buttons need
+   *  vertical space below the card. */
+  cardHeight?: number;
 }
 
 // Gender-based underline colors
@@ -91,6 +94,7 @@ export const SwipeCard = forwardRef<SwipeCardRef, SwipeCardProps>(function Swipe
     onDetailPress,
     swipeEnabled = true,
     detailOpen = false,
+    cardHeight,
   },
   ref,
 ) {
@@ -365,6 +369,7 @@ export const SwipeCard = forwardRef<SwipeCardRef, SwipeCardProps>(function Swipe
         style={[
           styles.card,
           { borderColor: colors.primary },
+          cardHeight !== undefined && { height: cardHeight },
           isTop && cardAnimatedStyle,
           isTop && cardBorderStyle,
           { zIndex: isTop ? 2 : 1 },

--- a/hooks/use-a11y-preferences.ts
+++ b/hooks/use-a11y-preferences.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { AccessibilityInfo } from 'react-native';
+
+/**
+ * Live iOS accessibility preferences. Listens for changes so toggling
+ * VoiceOver or Reduce Motion in Settings reconfigures the UI without an
+ * app restart.
+ *
+ * `needsButtons` is true when the swipe gesture would conflict with
+ * VoiceOver navigation OR when the user prefers reduced motion — in
+ * either case, we render explicit Pass/Like buttons and disable the
+ * pan gesture.
+ */
+export function useA11yPreferences() {
+  const [screenReader, setScreenReader] = useState(false);
+  const [reduceMotion, setReduceMotion] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+
+    AccessibilityInfo.isScreenReaderEnabled().then((value) => {
+      if (mounted) setScreenReader(value);
+    });
+    AccessibilityInfo.isReduceMotionEnabled().then((value) => {
+      if (mounted) setReduceMotion(value);
+    });
+
+    const srSub = AccessibilityInfo.addEventListener('screenReaderChanged', setScreenReader);
+    const rmSub = AccessibilityInfo.addEventListener('reduceMotionChanged', setReduceMotion);
+
+    return () => {
+      mounted = false;
+      srSub.remove();
+      rmSub.remove();
+    };
+  }, []);
+
+  return {
+    screenReader,
+    reduceMotion,
+    needsButtons: screenReader || reduceMotion,
+  };
+}


### PR DESCRIPTION
Closes #162

## Summary
The card's horizontal pan gesture conflicts with VoiceOver's swipe-to-navigate, so screen-reader users can't actually swipe names. Adds runtime accessibility detection — buttons only render when the user has VoiceOver or Reduce Motion enabled. Sighted/motor-able users keep the swipe-only experience.

## What changed
- `hooks/use-a11y-preferences.ts` (new) — listens to `screenReaderChanged` / `reduceMotionChanged` so toggling assistive tech in iOS Settings reconfigures the UI without an app restart.
- `swipe-card-stack.tsx` — when `needsButtons` is true:
  - Pan gesture is disabled (lets VoiceOver navigate card content)
  - Swipe hint ("swipe →") is suppressed (would be misleading)
  - `<SwipeActionButtons>` row renders below the card
  - Card height shrinks by `SWIPE_ACTION_BUTTONS_HEIGHT` so the explore header stays visible
- `swipe-action-buttons.tsx` rebuilt — two side-by-side buttons matching the app's existing primary/secondary pattern (`Pass` outlined + `Like` gradient). Skips the `FadeInUp` entrance when `reduceMotion` is true.
- `swipe-card.tsx` — new optional `cardHeight` prop overrides the default `CARD_HEIGHT_FULL`.

## Test plan
- [x] Lint + typecheck clean
- [x] Visual test (Reduce Motion ON): buttons appear, header visible, card sized correctly, no jank
- [ ] VoiceOver test: enable VoiceOver in iOS Settings → buttons appear, pan disabled, like/reject works
- [ ] Toggle VoiceOver / Reduce Motion off mid-session: buttons disappear and pan re-enables (no app restart)
- [ ] Sighted/motor-able users: confirm no visual change vs. master

🤖 Generated with [Claude Code](https://claude.com/claude-code)