### PR TITLE
fix: don't overwrite confirmed names on sign-in (#166)

### DIFF
--- a/convex/users.ts
+++ b/convex/users.ts
@@ -60,8 +60,11 @@ export const createOrUpdateUser = mutation({
       // Only overwrite name/imageUrl when Clerk actually provides a value.
       // Otherwise we'd erase fields set elsewhere (admin seed, name-edit
       // modal) every time useStoreUser fires on app launch.
+      // Once a user has confirmed their name in-app (NameConfirmationModal
+      // sets nameConfirmed=true), don't let Clerk's fullName overwrite it
+      // on subsequent sign-ins (#166).
       const patch: Record<string, unknown> = { email: args.email, updatedAt: now };
-      if (args.name) patch.name = args.name;
+      if (args.name && existingUser.nameConfirmed !== true) patch.name = args.name;
       if (args.imageUrl) patch.imageUrl = args.imageUrl;
       await ctx.db.patch(existingUser._id, patch);
       return existingUser._id;


### PR DESCRIPTION
Closes #166

## Summary
Stop letting Clerk's `fullName` overwrite the user's edited name on every sign-in.

## Root cause
`createOrUpdateUser` only guards on `if (args.name)` — but Apple/Google SSO always populates `fullName`, so that branch always fires. After the user opens NameConfirmationModal and edits their name, the next sign-in clobbers it back.

## Fix
Add `existingUser.nameConfirmed !== true` to the gate. Once a user has explicitly confirmed their name, Clerk doesn't get to overwrite it.

`imageUrl` stays unconditional — profile-photo updates from Clerk should still flow through.

## Test plan
- [x] Lint + typecheck + Convex validate clean
- [ ] Manual: sign up → confirm name as "Sarah" → sign out → sign in → confirm name is still "Sarah" (not "Sarah Anderson")

🤖 Generated with [Claude Code](https://claude.com/claude-code)