### PR TITLE
fix: fail loudly when CLERK_JWT_ISSUER_DOMAIN is missing (#168)

### DIFF
--- a/convex/auth.config.ts
+++ b/convex/auth.config.ts
@@ -1,7 +1,18 @@
+// Validate at module load so deploys fail loudly when CLERK_JWT_ISSUER_DOMAIN
+// is missing, instead of silently producing a backend where every authenticated
+// query returns null. Set with:
+//   npx convex env set CLERK_JWT_ISSUER_DOMAIN https://<your-clerk-frontend-api>
+const domain = process.env.CLERK_JWT_ISSUER_DOMAIN;
+if (!domain) {
+  throw new Error(
+    'Missing CLERK_JWT_ISSUER_DOMAIN env var. Set it via `npx convex env set CLERK_JWT_ISSUER_DOMAIN <https://...>`',
+  );
+}
+
 export default {
   providers: [
     {
-      domain: process.env.CLERK_JWT_ISSUER_DOMAIN,
+      domain,
       applicationID: 'convex',
     },
   ],


### PR DESCRIPTION
Closes #168

## Summary
Throw at module load when `CLERK_JWT_ISSUER_DOMAIN` is unset, so a Convex deploy without the env var fails with an actionable message instead of silently producing a backend where every authenticated query returns null.

## Test plan
- [x] Lint + typecheck + Convex validate (with env var) clean
- [ ] Sanity check: `npx convex env unset CLERK_JWT_ISSUER_DOMAIN && npx convex deploy` should fail with the new message (don't run on prod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)