### PR TITLE
fix: unlinkPartner deletes match rows (#158)

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -278,7 +278,7 @@ export default function Profile() {
   const handleUnlinkPartner = useCallback(() => {
     Alert.alert(
       'Unlink Partner',
-      'Are you sure you want to unlink your partner? Your selections and existing matches will be kept.',
+      'Are you sure you want to unlink your partner? Your liked names will be kept, but matches between you will be cleared.',
       [
         { text: 'Cancel', style: 'cancel' },
         {

--- a/convex/partners.ts
+++ b/convex/partners.ts
@@ -339,6 +339,10 @@ export const unlinkPartner = mutation({
       }
     }
 
+    // Delete every match row between this pair. Keeping them creates two
+    // problems on re-link: (1) stale isFavorite/notes/isChosen reappear,
+    // (2) recordSelection's by_name_users lookup finds the orphan and
+    // suppresses the match toast on a re-like (#158).
     const [u1, u2] =
       user._id < user.partnerId ? [user._id, user.partnerId] : [user.partnerId, user._id];
     const partnerMatches = await ctx.db
@@ -346,15 +350,7 @@ export const unlinkPartner = mutation({
       .withIndex('by_user1_user2', (q) => q.eq('user1Id', u1).eq('user2Id', u2))
       .collect();
     for (const m of partnerMatches) {
-      if (m.proposalStatus === 'pending') {
-        await ctx.db.patch(m._id, {
-          proposedBy: undefined,
-          proposedAt: undefined,
-          proposalMessage: undefined,
-          proposalStatus: undefined,
-          updatedAt: now,
-        });
-      }
+      await ctx.db.delete(m._id);
     }
 
     await ctx.db.patch(user._id, {


### PR DESCRIPTION
Closes #158

## Summary
Replace the proposal-clear loop in `unlinkPartner` with a delete loop over the partnership's matches. Update profile alert copy to match.

## Why
Keeping matches across an unlink caused two bugs:
1. Re-link revived stale `isFavorite` / `notes` / `isChosen` state on old matches.
2. `recordSelection`'s `by_name_users` lookup found orphan matches and returned `null`, suppressing the match toast on a re-like — users thought their like didn't register.

## Test plan
- [x] Lint + typecheck + Convex validate clean
- [ ] Manual: link 2 accounts → match a few names → unlink → re-link → confirm old matches are gone
- [ ] Manual: after unlink + re-like → match toast fires (no orphan suppression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)