### PR TITLE
feat: warn on simultaneous partner proposals (#169)

### DIFF
--- a/app/(tabs)/matches.tsx
+++ b/app/(tabs)/matches.tsx
@@ -27,6 +27,7 @@ import {
   MatchesHeader,
   ProposalBanner,
   ProposeSheet,
+  ProposalConflictSheet,
   DeclineSheet,
   CelebrationModal,
 } from '@/components/matches';
@@ -73,6 +74,11 @@ export default function Matches() {
   const [selectedMatch, setSelectedMatch] = useState<MatchWithName | null>(null);
   const [showPaywall, setShowPaywall] = useState(false);
   const [proposeTarget, setProposeTarget] = useState<MatchWithName | null>(null);
+  const [proposalConflict, setProposalConflict] = useState<{
+    matchId: Id<'matches'>;
+    message: string | undefined;
+    partnerProposalName: string;
+  } | null>(null);
   const [isRestoring, setIsRestoring] = useState(false);
   const [showDeclineSheet, setShowDeclineSheet] = useState(false);
   const [showCelebration, setShowCelebration] = useState(false);
@@ -137,23 +143,39 @@ export default function Matches() {
     }
   }, [chosenName, currentUser?._id]);
 
-  const handlePropose = useCallback(
-    async (message?: string) => {
-      if (!proposeTarget) return;
+  const submitProposal = useCallback(
+    async (matchId: Id<'matches'>, message: string | undefined, force: boolean) => {
       try {
-        await proposeNameMutation({
-          matchId: proposeTarget._id,
-          message,
-        });
+        const result = await proposeNameMutation({ matchId, message, force });
+        if (result && 'error' in result && result.error === 'PARTNER_HAS_PENDING_PROPOSAL') {
+          // Surface the conflict via a bottom sheet (#169). Stash matchId
+          // and message so the "Send mine" button can re-call with force.
+          setProposeTarget(null);
+          setProposalConflict({
+            matchId,
+            message,
+            partnerProposalName: result.partnerProposalName,
+          });
+          return;
+        }
         trackEvent(Events.PROPOSAL_SENT);
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
         setProposeTarget(null);
+        setProposalConflict(null);
       } catch (error) {
         Sentry.captureException(error);
         Alert.alert('Error', 'Failed to propose name. Please try again.');
       }
     },
-    [proposeTarget, proposeNameMutation],
+    [proposeNameMutation],
+  );
+
+  const handlePropose = useCallback(
+    async (message?: string) => {
+      if (!proposeTarget) return;
+      await submitProposal(proposeTarget._id, message, false);
+    },
+    [proposeTarget, submitProposal],
   );
 
   const handleAcceptProposal = useCallback(async () => {
@@ -500,6 +522,19 @@ export default function Matches() {
           name={proposeTarget?.name ?? null}
           onPropose={handlePropose}
           onClose={() => setProposeTarget(null)}
+        />
+
+        {/* Proposal conflict sheet — fires when both partners try to
+            propose at the same time (#169). */}
+        <ProposalConflictSheet
+          visible={proposalConflict !== null}
+          partnerProposalName={proposalConflict?.partnerProposalName ?? null}
+          onSeeTheirs={() => setProposalConflict(null)}
+          onSendMine={async () => {
+            if (!proposalConflict) return;
+            await submitProposal(proposalConflict.matchId, proposalConflict.message, true);
+          }}
+          onClose={() => setProposalConflict(null)}
         />
 
         {/* Decline sheet */}

--- a/components/matches/index.ts
+++ b/components/matches/index.ts
@@ -5,5 +5,6 @@ export { MatchesHeader } from './matches-header';
 export { MatchToast } from './match-toast';
 export { ProposalBanner } from './proposal-banner';
 export { ProposeSheet } from './propose-sheet';
+export { ProposalConflictSheet } from './proposal-conflict-sheet';
 export { DeclineSheet } from './decline-sheet';
 export { CelebrationModal } from './celebration-modal';

--- a/components/matches/proposal-conflict-sheet.tsx
+++ b/components/matches/proposal-conflict-sheet.tsx
@@ -1,0 +1,157 @@
+import { useState } from 'react';
+import { ActivityIndicator, View, Text, Pressable, StyleSheet } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Ionicons } from '@expo/vector-icons';
+import { Fonts } from '@/constants/theme';
+import { useTheme } from '@/contexts/theme-context';
+import { AnimatedBottomSheet } from '@/components/ui/animated-bottom-sheet';
+
+interface ProposalConflictSheetProps {
+  visible: boolean;
+  partnerProposalName: string | null;
+  /** Tap "See their pick" — closes the sheet so the user can find the
+   *  partner's pending proposal banner on the Matches screen. */
+  onSeeTheirs: () => void;
+  /** Tap "Send mine" — re-call proposeName with force=true. */
+  onSendMine: () => Promise<void>;
+  onClose: () => void;
+}
+
+export function ProposalConflictSheet({
+  visible,
+  partnerProposalName,
+  onSeeTheirs,
+  onSendMine,
+  onClose,
+}: ProposalConflictSheetProps) {
+  const { colors, gradients } = useTheme();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSendMine = async () => {
+    setIsSubmitting(true);
+    try {
+      await onSendMine();
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <AnimatedBottomSheet visible={visible} onClose={onClose} maxHeight="55%">
+      <View style={styles.content}>
+        <View style={styles.handleBar} />
+
+        <View style={[styles.iconCircle, { backgroundColor: colors.primaryLight }]}>
+          <Ionicons name="chatbubbles-outline" size={32} color={colors.primary} />
+        </View>
+
+        <Text style={styles.title}>Heads up</Text>
+        <Text style={styles.subtitle}>
+          Your partner proposed {partnerProposalName ?? 'a name'} and is waiting on you. Want to see
+          it first, or send yours anyway?
+        </Text>
+
+        <View style={styles.buttons}>
+          <Pressable
+            onPress={onSeeTheirs}
+            disabled={isSubmitting}
+            style={[isSubmitting && styles.disabled]}
+          >
+            <LinearGradient
+              colors={[...gradients.buttonPrimary]}
+              style={[styles.primaryButton, { shadowColor: colors.primary }]}
+            >
+              <Text style={styles.primaryButtonText}>See their pick</Text>
+            </LinearGradient>
+          </Pressable>
+
+          <Pressable onPress={handleSendMine} disabled={isSubmitting}>
+            {isSubmitting ? (
+              <ActivityIndicator
+                size="small"
+                color={colors.primary}
+                style={styles.secondaryLoader}
+              />
+            ) : (
+              <Text style={[styles.secondaryButtonText, { color: colors.primary }]}>Send mine</Text>
+            )}
+          </Pressable>
+        </View>
+      </View>
+    </AnimatedBottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    alignItems: 'center',
+    paddingBottom: 36,
+  },
+  handleBar: {
+    width: 40,
+    height: 4,
+    backgroundColor: '#E5E7EB',
+    borderRadius: 2,
+    marginTop: 12,
+    marginBottom: 24,
+  },
+  iconCircle: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 16,
+  },
+  title: {
+    fontSize: 22,
+    fontFamily: Fonts?.title || 'Gabarito_800ExtraBold',
+    color: '#2D1B4E',
+    textAlign: 'center',
+    marginBottom: 8,
+    paddingHorizontal: 24,
+  },
+  subtitle: {
+    fontSize: 14,
+    fontFamily: Fonts?.sans,
+    color: '#6B5B7B',
+    textAlign: 'center',
+    marginBottom: 24,
+    paddingHorizontal: 24,
+    lineHeight: 20,
+  },
+  buttons: {
+    width: '100%',
+    paddingHorizontal: 24,
+    gap: 4,
+  },
+  primaryButton: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 16,
+    borderRadius: 12,
+    shadowOpacity: 0.25,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 4,
+  },
+  primaryButtonText: {
+    fontSize: 16,
+    fontFamily: Fonts?.sans,
+    fontWeight: '600',
+    color: '#ffffff',
+  },
+  secondaryButtonText: {
+    fontSize: 16,
+    fontFamily: Fonts?.sans,
+    fontWeight: '600',
+    textAlign: 'center',
+    paddingVertical: 14,
+  },
+  secondaryLoader: {
+    paddingVertical: 14,
+  },
+  disabled: {
+    opacity: 0.6,
+  },
+});

--- a/convex/matches.ts
+++ b/convex/matches.ts
@@ -214,6 +214,10 @@ export const proposeName = mutation({
   args: {
     matchId: v.id('matches'),
     message: v.optional(v.string()),
+    // When true, replace any pending proposal from the partner instead of
+    // returning the PARTNER_HAS_PENDING_PROPOSAL warning. The partner is
+    // notified that their proposal was replaced.
+    force: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     if (args.message !== undefined && args.message.length > 200) {
@@ -234,19 +238,66 @@ export const proposeName = mutation({
     assertCurrentPartner(user, match);
 
     const partnerMatches = await getPartnershipMatches(ctx, user._id, user.partnerId);
+
+    // Check whether the partner has a pending proposal we'd be overwriting
+    // (#169). If so and the caller hasn't acknowledged via force=true,
+    // surface a structured warning so the UI can prompt.
+    const partnerPending = partnerMatches.find(
+      (m) =>
+        m.proposalStatus === 'pending' &&
+        m.proposedBy !== undefined &&
+        m.proposedBy !== user._id,
+    );
+
+    if (partnerPending && !args.force) {
+      const partnerProposalNameDoc = await ctx.db.get(partnerPending.nameId);
+      return {
+        error: 'PARTNER_HAS_PENDING_PROPOSAL' as const,
+        partnerProposalMatchId: partnerPending._id,
+        partnerProposalName: partnerProposalNameDoc?.name ?? 'a name',
+      };
+    }
+
+    const now = Date.now();
+
+    // Clear the caller's own previous pending proposal (if any) — one
+    // pending proposal per side. Do NOT touch the partner's pending
+    // proposal here unless force=true; #169 prevents silent destruction.
     for (const m of partnerMatches) {
-      if (m.proposalStatus === 'pending') {
+      if (m.proposalStatus === 'pending' && m.proposedBy === user._id) {
         await ctx.db.patch(m._id, {
           proposedBy: undefined,
           proposedAt: undefined,
           proposalMessage: undefined,
           proposalStatus: undefined,
-          updatedAt: Date.now(),
+          updatedAt: now,
         });
       }
     }
 
-    const now = Date.now();
+    // If we're force-replacing, clear the partner's pending proposal too
+    // and send them a notification so they aren't surprised.
+    if (partnerPending && args.force) {
+      await ctx.db.patch(partnerPending._id, {
+        proposedBy: undefined,
+        proposedAt: undefined,
+        proposalMessage: undefined,
+        proposalStatus: undefined,
+        updatedAt: now,
+      });
+
+      const proposerName = user.name ?? 'Your partner';
+      const newName = await ctx.db.get(match.nameId);
+      await ctx.scheduler.runAfter(0, internal.notifications.sendPushNotification, {
+        userId: partnerPending.proposedBy as Id<'users'>,
+        title: `${proposerName} replaced your proposal`,
+        body: newName
+          ? `They proposed ${newName.name} instead.`
+          : 'They proposed a different name.',
+        data: { type: 'proposal_replaced', matchId: args.matchId },
+      });
+    }
+
     await ctx.db.patch(args.matchId, {
       proposedBy: user._id,
       proposedAt: now,
@@ -268,7 +319,7 @@ export const proposeName = mutation({
       data: { type: 'proposal', matchId: args.matchId },
     });
 
-    return { success: true };
+    return { success: true as const };
   },
 });
 


### PR DESCRIPTION
Closes #169

## Summary
Stop silently destroying a partner's pending proposal when the user proposes a different name. Surface it explicitly via a bottom sheet that lets them either go look at the partner's proposal first, or send their own anyway (which now notifies the partner).

## What changed
**Backend (`convex/matches.ts`):**
- `proposeName` now only clears the caller's *own* pending proposals.
- New optional `force: true` arg. Without it, if the partner has a pending proposal, returns `{ error: 'PARTNER_HAS_PENDING_PROPOSAL', partnerProposalName }` for the UI to surface.
- With `force=true`: clears the partner's proposal **and** fires a `proposal_replaced` push notification so they aren't surprised.

**Frontend:**
- New `ProposalConflictSheet` bottom sheet styled like the push priming sheet (chatbubbles icon, "Heads up" title, "See their pick" gradient button + "Send mine" secondary).
- `matches.tsx` `submitProposal` opens the sheet on `PARTNER_HAS_PENDING_PROPOSAL`. "Send mine" re-calls with `force=true`.

## Test plan
- [x] Lint + typecheck + Convex validate clean
- [x] Visual: sheet renders, copy reads well, buttons styled correctly (verified in simulator via temporary debug button, removed before commit)
- [ ] End-to-end: with two real test accounts, partner B proposes Olivia → A tries to propose Lucas → confirm sheet appears with "Send mine" → forcing it sends a `proposal_replaced` push to B

🤖 Generated with [Claude Code](https://claude.com/claude-code)