### PR TITLE
feat: harden sign-out flow + ErrorBoundary + Convex remount (#154 + #172 + #224 + #153 + #175)

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -9,7 +9,7 @@ import { usePushRegistration } from '@/hooks/use-push-registration';
 import { useOnboarding } from '@/hooks/use-onboarding';
 import { useTheme } from '@/contexts/theme-context';
 import { OnboardingScreens } from '@/components/onboarding';
-import { GradientBackground } from '@/components/ui/gradient-background';
+import { LoadingScreen } from '@/components/ui/loading-screen';
 
 export default function TabsLayout() {
   const { isSignedIn } = useAuth();
@@ -26,10 +26,12 @@ export default function TabsLayout() {
     return <Redirect href="/(auth)/sign-in" />;
   }
 
-  // Wait silently for onboarding check (near-instant from AsyncStorage).
-  // The root AuthGate loading screen covers this during initial app launch.
+  // Wait for the Convex user query to resolve. On a fresh launch the root
+  // AuthGate already showed the loading animation; for sign-out + sign-in
+  // on the same device we render the Bambino loading screen so the user
+  // sees a clear "still loading" signal instead of a blank gradient.
   if (isOnboardingLoading) {
-    return <GradientBackground>{null}</GradientBackground>;
+    return <LoadingScreen isLoading />;
   }
 
   // Show onboarding for new users

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -3,6 +3,7 @@ import { Image } from 'expo-image';
 import * as WebBrowser from 'expo-web-browser';
 import * as Sentry from '@sentry/react-native';
 import * as Clipboard from 'expo-clipboard';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useCallback, useRef, useState } from 'react';
 import { useFocusEffect } from 'expo-router';
 import { Events, resetAnalytics, trackEvent, trackScreen } from '@/lib/analytics';
@@ -99,6 +100,7 @@ export default function Profile() {
     gracePeriodEndsAt,
   } = useEffectivePremium();
   const deleteAccount = useMutation(api.users.deleteAccount);
+  const clearPushToken = useMutation(api.users.clearPushToken);
   const unlinkPartner = useMutation(api.partners.unlinkPartner);
   const regenerateShareCode = useMutation(api.partners.regenerateShareCode);
   const partnerInfo = useQuery(api.partners.getPartnerInfo);
@@ -127,13 +129,38 @@ export default function Profile() {
     setIsLoading(true);
     try {
       trackEvent(Events.SIGNED_OUT);
+      // Drop the device's push token from this user's row so a subsequent
+      // user on the same device doesn't get the previous user's
+      // notifications (#172). Best-effort — a network failure here
+      // shouldn't block sign-out.
+      try {
+        await clearPushToken();
+      } catch (err) {
+        Sentry.captureException(err, { tags: { phase: 'clear_push_token' } });
+      }
+      // Clear cosmetic per-user preferences from AsyncStorage so a different
+      // user signing in on the same device doesn't inherit them (#154).
+      // Onboarding state is stored on the Convex user row (not here) so it
+      // follows the user across devices and survives sign-out/sign-in on
+      // the same device.
+      await AsyncStorage.multiRemove([
+        'bambino_candy_theme',
+        'bambino_voice_settings',
+        'bambino_skin_tone',
+      ]);
       await signOut();
       Sentry.setUser(null);
       resetAnalytics();
+    } catch (err) {
+      // #224: spinner stops in finally, but the user needs feedback
+      // when signOut itself rejects (e.g. network failure revoking the
+      // Clerk session) — they're silently still signed in otherwise.
+      Sentry.captureException(err, { tags: { phase: 'sign_out' } });
+      Alert.alert('Sign out failed', 'Check your connection and try again.');
     } finally {
       setIsLoading(false);
     }
-  }, [signOut]);
+  }, [signOut, clearPushToken]);
 
   const handleDeleteAccount = useCallback(() => {
     Alert.alert(

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,7 +1,7 @@
 import '@/global.css';
 
 import * as Sentry from '@sentry/react-native';
-import { ClerkProvider, useAuth } from '@clerk/clerk-expo';
+import { ClerkProvider, useAuth, useUser } from '@clerk/clerk-expo';
 import { tokenCache } from '@clerk/clerk-expo/token-cache';
 import { AlfaSlabOne_400Regular } from '@expo-google-fonts/alfa-slab-one';
 import {
@@ -85,30 +85,29 @@ export default function RootLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <ClerkProvider publishableKey={publishableKey} tokenCache={tokenCache}>
-        <ThemeProvider>
-          <ErrorBoundary>
-            <AuthGate>
-              <ConvexProviderWithClerk client={convex} useAuth={useAuth}>
-                <SkinToneProvider>
-                  <VoiceSettingsProvider>
-                    <OnboardingProvider>
-                      <OfflineBanner />
-                      <Slot />
-                    </OnboardingProvider>
-                  </VoiceSettingsProvider>
-                </SkinToneProvider>
-              </ConvexProviderWithClerk>
-            </AuthGate>
-          </ErrorBoundary>
-        </ThemeProvider>
-      </ClerkProvider>
+      {/* Outermost boundary — uses BareErrorFallback (no provider deps) so a
+          crash in ClerkProvider/ThemeProvider itself can still render (#153). */}
+      <ErrorBoundary>
+        <ClerkProvider publishableKey={publishableKey} tokenCache={tokenCache}>
+          <ThemeProvider>
+            {/* Inner themed boundary — when this catches, ThemeProvider is
+                alive, so the fallback can use the user's theme (#153). */}
+            <ErrorBoundary themed>
+              <AuthGate>
+                <OfflineBanner />
+                <Slot />
+              </AuthGate>
+            </ErrorBoundary>
+          </ThemeProvider>
+        </ClerkProvider>
+      </ErrorBoundary>
     </GestureHandlerRootView>
   );
 }
 
 function AuthGate({ children }: { children: React.ReactNode }) {
   const { isLoaded } = useAuth();
+  const { user } = useUser();
   const { isLoading: themeLoading } = useTheme();
   const [animationDone, setAnimationDone] = useState(false);
 
@@ -126,5 +125,17 @@ function AuthGate({ children }: { children: React.ReactNode }) {
     return <LoadingScreen isLoading={!isLoaded} onFinished={() => setAnimationDone(true)} />;
   }
 
-  return <>{children}</>;
+  // Key the Convex provider + the user-scoped contexts on Clerk's user.id.
+  // When A signs out and B signs in, this unmounts in-flight Convex
+  // subscriptions and resets in-memory provider state so B can't see a
+  // flash of A's data or inherit A's onboarding flag (#154, #175).
+  return (
+    <ConvexProviderWithClerk key={user?.id ?? 'anonymous'} client={convex} useAuth={useAuth}>
+      <SkinToneProvider>
+        <VoiceSettingsProvider>
+          <OnboardingProvider>{children}</OnboardingProvider>
+        </VoiceSettingsProvider>
+      </SkinToneProvider>
+    </ConvexProviderWithClerk>
+  );
 }

--- a/components/error-boundary.tsx
+++ b/components/error-boundary.tsx
@@ -9,6 +9,11 @@ import { useTheme } from '@/contexts/theme-context';
 interface Props {
   children: ReactNode;
   fallback?: ReactNode;
+  /** When true, the fallback uses the active theme via useTheme(). Only safe
+   *  when this boundary is mounted INSIDE ThemeProvider. The outermost
+   *  boundary must NOT set this — if ThemeProvider itself errored, useTheme
+   *  would throw and the fallback would crash again. (#153) */
+  themed?: boolean;
 }
 
 interface State {
@@ -39,15 +44,51 @@ export class ErrorBoundary extends Component<Props, State> {
       if (this.props.fallback) {
         return this.props.fallback;
       }
-
-      return <ErrorFallback onRetry={this.handleRetry} />;
+      return this.props.themed ? (
+        <ThemedErrorFallback onRetry={this.handleRetry} />
+      ) : (
+        <BareErrorFallback onRetry={this.handleRetry} />
+      );
     }
 
     return this.props.children;
   }
 }
 
-function ErrorFallback({ onRetry }: { onRetry: () => void }) {
+// Hardcoded styling — no provider deps. Safe to render even if Theme,
+// Clerk, or Convex providers are the cause of the crash. Used as the
+// outermost fallback (#153).
+const FALLBACK_BG = '#FFF8E7';
+const FALLBACK_PRIMARY = '#F5C84B';
+const FALLBACK_PRIMARY_DARK = '#E8A93B';
+const FALLBACK_ACCENT_LIGHT = '#FCE9B6';
+const FALLBACK_TEXT_DARK = '#2D1B4E';
+const FALLBACK_TEXT_MUTED = '#6B5B7B';
+
+function BareErrorFallback({ onRetry }: { onRetry: () => void }) {
+  return (
+    <View style={[styles.container, { backgroundColor: FALLBACK_BG }]}>
+      <View style={[styles.iconContainer, { backgroundColor: FALLBACK_ACCENT_LIGHT }]}>
+        <Ionicons name="heart-half-outline" size={56} color={FALLBACK_PRIMARY} />
+      </View>
+      <Text style={[styles.title, { color: FALLBACK_TEXT_DARK }]}>Oops!</Text>
+      <Text style={[styles.message, { color: FALLBACK_TEXT_MUTED }]}>
+        Something didn&apos;t go as planned.{'\n'}A quick refresh should fix things up.
+      </Text>
+      <Pressable
+        style={({ pressed }) => [styles.retryButton, { opacity: pressed ? 0.85 : 1 }]}
+        onPress={onRetry}
+      >
+        <View style={[styles.retryButtonGradient, { backgroundColor: FALLBACK_PRIMARY_DARK }]}>
+          <Ionicons name="refresh-outline" size={20} color="#fff" />
+          <Text style={styles.retryText}>Refresh</Text>
+        </View>
+      </Pressable>
+    </View>
+  );
+}
+
+function ThemedErrorFallback({ onRetry }: { onRetry: () => void }) {
   const { colors, gradients } = useTheme();
 
   return (
@@ -55,8 +96,8 @@ function ErrorFallback({ onRetry }: { onRetry: () => void }) {
       <View style={[styles.iconContainer, { backgroundColor: colors.primaryLight }]}>
         <Ionicons name="heart-half-outline" size={56} color={colors.primary} />
       </View>
-      <Text style={styles.title}>Oops!</Text>
-      <Text style={styles.message}>
+      <Text style={[styles.title, { color: '#2D1B4E' }]}>Oops!</Text>
+      <Text style={[styles.message, { color: '#6B5B7B' }]}>
         Something didn&apos;t go as planned.{'\n'}A quick refresh should fix things up.
       </Text>
       <Pressable
@@ -96,13 +137,11 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 26,
     fontFamily: Fonts?.title || 'Gabarito_800ExtraBold',
-    color: '#2D1B4E',
     textAlign: 'center',
   },
   message: {
     fontSize: 16,
     fontFamily: Fonts?.sans,
-    color: '#6B5B7B',
     textAlign: 'center',
     lineHeight: 24,
   },

--- a/contexts/onboarding-context.tsx
+++ b/contexts/onboarding-context.tsx
@@ -1,10 +1,10 @@
-import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import React, { createContext, useContext, useCallback } from 'react';
+import { useMutation, useQuery } from 'convex/react';
 import * as Sentry from '@sentry/react-native';
-
-const ONBOARDING_KEY = 'bambino_onboarding_completed';
+import { api } from '@/convex/_generated/api';
 
 interface OnboardingContextValue {
+  // null while the Convex user query is still loading. true/false once known.
   hasCompletedOnboarding: boolean | null;
   isLoading: boolean;
   completeOnboarding: () => Promise<void>;
@@ -18,41 +18,37 @@ interface OnboardingProviderProps {
 }
 
 export function OnboardingProvider({ children }: OnboardingProviderProps) {
-  const [hasCompletedOnboarding, setHasCompletedOnboarding] = useState<boolean | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  // Onboarding state is stored on the Convex user row (#154). Reading it
+  // via useQuery means it follows the active Clerk identity automatically:
+  // sign-out + sign-in on the same device sees the new user's flag, not
+  // the old user's; a returning user's flag persists across launches.
+  const user = useQuery(api.users.getCurrentUser);
+  const setOnboardingCompleted = useMutation(api.users.setOnboardingCompleted);
 
-  useEffect(() => {
-    async function load() {
-      try {
-        const value = await AsyncStorage.getItem(ONBOARDING_KEY);
-        setHasCompletedOnboarding(value === 'true');
-      } catch (error) {
-        Sentry.captureException(error);
-        setHasCompletedOnboarding(false);
-      } finally {
-        setIsLoading(false);
-      }
-    }
-    load();
-  }, []);
+  // user === undefined → query in flight.
+  // user === null     → authenticated but Convex row not yet created
+  //                     (race with useStoreUser's createOrUpdateUser on
+  //                     first sign-in). Treat both as loading so we
+  //                     don't briefly flash onboarding before the row
+  //                     exists with onboardingCompleted=false.
+  const isLoading = user === undefined || user === null;
+  const hasCompletedOnboarding = isLoading ? null : user.onboardingCompleted === true;
 
   const completeOnboarding = useCallback(async () => {
     try {
-      await AsyncStorage.setItem(ONBOARDING_KEY, 'true');
-      setHasCompletedOnboarding(true);
+      await setOnboardingCompleted({ completed: true });
     } catch (error) {
       Sentry.captureException(error);
     }
-  }, []);
+  }, [setOnboardingCompleted]);
 
   const resetOnboarding = useCallback(async () => {
     try {
-      await AsyncStorage.removeItem(ONBOARDING_KEY);
-      setHasCompletedOnboarding(false);
+      await setOnboardingCompleted({ completed: false });
     } catch (error) {
       Sentry.captureException(error);
     }
-  }, []);
+  }, [setOnboardingCompleted]);
 
   return (
     <OnboardingContext.Provider

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -11,6 +11,11 @@ export default defineSchema({
     purchasedAt: v.optional(v.number()),
     premiumRevokedAt: v.optional(v.number()),
     nameConfirmed: v.optional(v.boolean()),
+    // True once the user has completed the in-app onboarding carousel.
+    // Stored per-account (not AsyncStorage) so a sign-out + sign-in on
+    // the same device doesn't re-trigger onboarding, and a fresh device
+    // doesn't skip it. (#154)
+    onboardingCompleted: v.optional(v.boolean()),
     shareCode: v.optional(v.string()),
     partnerId: v.optional(v.id('users')),
     genderFilter: v.optional(v.union(v.literal('boy'), v.literal('girl'), v.literal('both'))),

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -228,16 +228,52 @@ export const deleteAccount = mutation({
   },
 });
 
+// Expo push tokens are always of the form "ExponentPushToken[<base64-ish>]".
+// Anything else is either a different gateway's token (FCM, APNs raw) or
+// garbage from a malicious caller. Reject up front (#172).
+const EXPO_PUSH_TOKEN_REGEX = /^ExponentPushToken\[[A-Za-z0-9_-]+\]$/;
+
 export const setPushToken = mutation({
   args: {
     token: v.string(),
     platform: v.union(v.literal('ios'), v.literal('android')),
   },
   handler: async (ctx, args) => {
+    if (!EXPO_PUSH_TOKEN_REGEX.test(args.token)) {
+      throw new Error('Invalid push token format');
+    }
     const user = await getCurrentUserOrThrow(ctx);
     await ctx.db.patch(user._id, {
       pushToken: args.token,
       pushTokenPlatform: args.platform,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+/** Mark or unmark this user's onboarding as completed. Stored on the user
+ *  row rather than AsyncStorage so it survives sign-out/sign-in on the
+ *  same device and doesn't leak across accounts on shared devices (#154). */
+export const setOnboardingCompleted = mutation({
+  args: { completed: v.boolean() },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUserOrThrow(ctx);
+    await ctx.db.patch(user._id, {
+      onboardingCompleted: args.completed,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+/** Drop the device's push token from this user's row. Called on sign-out
+ *  to prevent cross-user notifications on shared devices (#172). */
+export const clearPushToken = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const user = await getCurrentUserOrThrow(ctx);
+    await ctx.db.patch(user._id, {
+      pushToken: undefined,
+      pushTokenPlatform: undefined,
       updatedAt: Date.now(),
     });
   },


### PR DESCRIPTION
Closes #154
Closes #172
Closes #224
Closes #153
Closes #175

## Summary
Five sign-out / multi-account fixes that all touch the same provider tree and `handleSignOut` path. Bundled because they overlap heavily and shipping them separately would cause merge friction.

## Per-issue
| # | Fix |
|---|---|
| #154 | Sign-out clears the cosmetic per-user AsyncStorage keys (theme/voice/skin-tone). **Onboarding state moved to the Convex users row** (`onboardingCompleted` field + `setOnboardingCompleted` mutation) so it follows the user across devices and survives sign-out/sign-in on the same device. `OnboardingProvider` rewritten to read from `useQuery(getCurrentUser)`. |
| #172 | `setPushToken` validates the Expo token format (`ExponentPushToken[...]`). New `clearPushToken` mutation called best-effort during sign-out so a subsequent user on the same device doesn't get the previous user's match pushes. |
| #224 | `handleSignOut` wrapped in try/catch with Sentry capture + user Alert. Spinner stops in finally for all paths. |
| #153 | `ErrorBoundary` moved to be the outermost wrapper. New `BareErrorFallback` uses hardcoded styling (no `useTheme`) so a crash in ClerkProvider/ThemeProvider itself can still render. Inner `ThemedErrorFallback` (via `themed` prop) wraps the rest of the tree for the prettier fallback when providers are alive. |
| #175 | `ConvexProviderWithClerk` keyed on Clerk `user.id`. Sign-out + sign-in unmounts in-flight subscriptions and remounts user-scoped contexts so the new user can't briefly see the previous user's data. |

## Plus a small UX fix
The (tabs) layout now shows the Bambino `LoadingScreen` during the Convex user-query resolution after a sign-in instead of a blank gradient.

## Test plan
- [x] Lint + typecheck + Convex validate clean
- [x] Sign-out + sign-in same account on same device → onboarding does NOT re-trigger
- [x] Loading screen renders smoothly through the auth handoff (no blank gradient)
- [ ] Two-account test: A signs in, completes onboarding, signs out → B signs up → B sees onboarding (not skipped)
- [ ] Push test on real device: A signs in, registers push token → A signs out → B signs in → A's row no longer has a token; matches notifications meant for A don't reach the device
- [ ] Force a crash inside `ThemeProvider` (temporarily throw in `loadTheme`) → confirm `BareErrorFallback` renders, not a blank screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)