### PR TITLE
perf: memoize list rows + prefetch card popularity (#161 + #174)

### DIFF
--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -31,7 +31,6 @@ import { useTheme } from '@/contexts/theme-context';
 import { trackScreen } from '@/lib/analytics';
 import { GradientBackground } from '@/components/ui/gradient-background';
 import { BubblePillsBackground } from '@/components/ui/bubble-pills-background';
-import { LoadingScreen, useGracefulLoading } from '@/components/ui/loading-screen';
 import { LoadingIndicator } from '@/components/ui/loading-indicator';
 import { Doc, Id } from '@/convex/_generated/dataModel';
 
@@ -232,17 +231,74 @@ export default function Dashboard() {
     });
   }, []);
 
-  const handleSelectAll = useCallback(() => {
-    const data = activeTab === 'liked' ? visibleLikedNames : visibleRejectedNames;
-    if (!data) return;
-    const allIds = data.map((item) => item.selectionId);
-    const allSelected = allIds.every((id) => selectedIds.has(id));
+  // Track an in-flight "Select all" request so we can show progress and
+  // prevent reentry while pages are still loading.
+  const [isSelectingAll, setIsSelectingAll] = useState(false);
+
+  const handleSelectAll = useCallback(async () => {
+    const items = activeTab === 'liked' ? visibleLikedNames : visibleRejectedNames;
+    const allLoadedIds = items.map((item) => item.selectionId);
+    const allSelected = allLoadedIds.length > 0 && allLoadedIds.every((id) => selectedIds.has(id));
+
+    // Toggle off when everything currently loaded is selected.
     if (allSelected) {
       setSelectedIds(new Set());
-    } else {
-      setSelectedIds(new Set(allIds));
+      return;
     }
-  }, [selectedIds, activeTab, visibleLikedNames, visibleRejectedNames]);
+
+    // Pagination means "select all" must drain remaining pages so the
+    // subsequent bulk delete/hide actually covers every name (#170 +
+    // user-reported gap).
+    const status = activeTab === 'liked' ? likedStatus : rejectedStatus;
+    const loadMore = activeTab === 'liked' ? loadMoreLiked : loadMoreRejected;
+
+    if (status === 'CanLoadMore' || status === 'LoadingMore') {
+      setIsSelectingAll(true);
+      // The hook re-runs and `status` flips between LoadingMore and
+      // CanLoadMore until exhausted. We detect completion with an effect
+      // below; here we just kick off the first batch.
+      loadMore(LIST_PAGE_SIZE);
+      return;
+    }
+
+    setSelectedIds(new Set(allLoadedIds));
+  }, [
+    selectedIds,
+    activeTab,
+    visibleLikedNames,
+    visibleRejectedNames,
+    likedStatus,
+    rejectedStatus,
+    loadMoreLiked,
+    loadMoreRejected,
+  ]);
+
+  // Drive "select all" through the remaining pages: each time we land in
+  // CanLoadMore while the user is selecting-all, fetch the next batch;
+  // when Exhausted, materialize the full selection.
+  useEffect(() => {
+    if (!isSelectingAll) return;
+    const status = activeTab === 'liked' ? likedStatus : rejectedStatus;
+    if (status === 'CanLoadMore') {
+      const loadMore = activeTab === 'liked' ? loadMoreLiked : loadMoreRejected;
+      loadMore(LIST_PAGE_SIZE);
+      return;
+    }
+    if (status === 'Exhausted') {
+      const items = activeTab === 'liked' ? visibleLikedNames : visibleRejectedNames;
+      setSelectedIds(new Set(items.map((item) => item.selectionId)));
+      setIsSelectingAll(false);
+    }
+  }, [
+    isSelectingAll,
+    activeTab,
+    likedStatus,
+    rejectedStatus,
+    loadMoreLiked,
+    loadMoreRejected,
+    visibleLikedNames,
+    visibleRejectedNames,
+  ]);
 
   const executeBulkAction = useCallback(
     async (
@@ -321,19 +377,19 @@ export default function Dashboard() {
     );
   }, [selectedIds, bulkHide, executeBulkAction]);
 
+  // Data-ready gate: the paginated query has returned its first page.
   const isDataLoaded =
     activeTab === 'liked'
       ? likedStatus !== 'LoadingFirstPage'
       : rejectedStatus !== 'LoadingFirstPage';
-  const isDataEmpty = activeTab === 'liked' ? totalLikedCount === 0 : totalRejectedCount === 0;
 
-  const { showLoading, loadingProps } = useGracefulLoading(isDataLoaded);
+  // Emptiness is decided by the actual loaded items, NOT the running
+  // counter. The counter is a display optimization for the header and can
+  // drift; the paginated query is the source of truth for what exists. This
+  // is what makes the empty state appear reliably after a bulk delete (#170).
+  const loadedCount = activeTab === 'liked' ? allLikedItems.length : allRejectedItems.length;
+  const isDataEmpty = isDataLoaded && loadedCount === 0;
 
-  if (showLoading) {
-    return <LoadingScreen {...loadingProps} />;
-  }
-
-  // Data loading state
   if (!isDataLoaded) {
     return (
       <GradientBackground>
@@ -378,12 +434,17 @@ export default function Dashboard() {
               onSortChange={setRejectedSortBy}
             />
           )}
-          <SearchInput
-            value={searchInput}
-            onChangeText={setSearchInput}
-            onSubmit={handleSearchSubmit}
-            onClear={handleSearchClear}
-          />
+          {/* Keep the search bar only when the emptiness is a no-results
+              state — the user needs it to edit/clear their query. When the
+              list is genuinely empty, hide it; there's nothing to search. */}
+          {isSearching && (
+            <SearchInput
+              value={searchInput}
+              onChangeText={setSearchInput}
+              onSubmit={handleSearchSubmit}
+              onClear={handleSearchClear}
+            />
+          )}
           <View style={styles.emptyContainer}>
             {!isSearching && <BubblePillsBackground />}
             <Text style={styles.emptyTitle}>

--- a/components/dashboard/liked-name-card.tsx
+++ b/components/dashboard/liked-name-card.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { View, Text, Pressable, StyleSheet, Alert } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { Fonts } from '@/constants/theme';
@@ -18,7 +19,7 @@ interface LikedNameCardProps {
   onToggleSelect?: () => void;
 }
 
-export function LikedNameCard({
+function LikedNameCardImpl({
   name,
   likedAt,
   onRemove,
@@ -91,6 +92,19 @@ export function LikedNameCard({
     </Pressable>
   );
 }
+
+// Skip re-renders when only the parent's renderItem closures change identity
+// but the actual displayed data is unchanged (#161). Function props
+// (onRemove/onPress/onToggleSelect) are intentionally omitted from the
+// comparator — they're new closures every render but functionally identical.
+export const LikedNameCard = memo(LikedNameCardImpl, (prev, next) => {
+  return (
+    prev.name._id === next.name._id &&
+    prev.likedAt === next.likedAt &&
+    prev.selectMode === next.selectMode &&
+    prev.selected === next.selected
+  );
+});
 
 const styles = StyleSheet.create({
   checkboxContainer: {

--- a/components/dashboard/rejected-name-card.tsx
+++ b/components/dashboard/rejected-name-card.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { View, Text, Pressable, StyleSheet, Alert } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { Fonts } from '@/constants/theme';
@@ -19,7 +20,7 @@ interface RejectedNameCardProps {
   onToggleSelect?: () => void;
 }
 
-export function RejectedNameCard({
+function RejectedNameCardImpl({
   name,
   rejectedAt,
   onRestore,
@@ -115,6 +116,17 @@ export function RejectedNameCard({
     </Pressable>
   );
 }
+
+// See LikedNameCard — memo with a data-only comparator so renderItem's fresh
+// closures don't bust it (#161).
+export const RejectedNameCard = memo(RejectedNameCardImpl, (prev, next) => {
+  return (
+    prev.name._id === next.name._id &&
+    prev.rejectedAt === next.rejectedAt &&
+    prev.selectMode === next.selectMode &&
+    prev.selected === next.selected
+  );
+});
 
 const styles = StyleSheet.create({
   checkboxContainer: {

--- a/components/matches/match-card.tsx
+++ b/components/matches/match-card.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { View, Text, Pressable, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { Fonts } from '@/constants/theme';
@@ -27,13 +28,7 @@ interface MatchCardProps {
   onWithdraw?: () => void;
 }
 
-export function MatchCard({
-  match,
-  currentUserId,
-  onPress,
-  onPropose,
-  onWithdraw,
-}: MatchCardProps) {
+function MatchCardImpl({ match, currentUserId, onPress, onPropose, onWithdraw }: MatchCardProps) {
   const { colors } = useTheme();
   const { skinTone } = useSkinTone();
   const { name, isFavorite, isChosen, proposalStatus, proposedBy, matchedAt } = match;
@@ -112,6 +107,24 @@ export function MatchCard({
     </Pressable>
   );
 }
+
+// Memo with a comparator over the fields that actually affect render (#161).
+// onPress is ignored (identity changes every render, behavior is stable);
+// onPropose/onWithdraw are compared by PRESENCE only, since whether they're
+// defined gates the action buttons but their identity doesn't matter.
+export const MatchCard = memo(MatchCardImpl, (prev, next) => {
+  return (
+    prev.match._id === next.match._id &&
+    prev.match.isFavorite === next.match.isFavorite &&
+    prev.match.isChosen === next.match.isChosen &&
+    prev.match.proposalStatus === next.match.proposalStatus &&
+    prev.match.proposedBy === next.match.proposedBy &&
+    prev.match.matchedAt === next.match.matchedAt &&
+    prev.currentUserId === next.currentUserId &&
+    !!prev.onPropose === !!next.onPropose &&
+    !!prev.onWithdraw === !!next.onWithdraw
+  );
+});
 
 const styles = StyleSheet.create({
   card: {

--- a/components/swipe/swipe-card-stack.tsx
+++ b/components/swipe/swipe-card-stack.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useQuery, useMutation } from 'convex/react';
 import { useRouter } from 'expo-router';
@@ -24,10 +24,15 @@ export function SwipeCardStack() {
   const router = useRouter();
   const { colors } = useTheme();
 
-  // Stable random seed per mount — changes when component remounts (e.g. filter change)
-  const randomSeed = useMemo(() => Math.random(), []);
+  // Random seed lives in state so we can rotate it (and trigger a fresh
+  // server query) when the local queue gets low. Initial value is stable
+  // for the first fetch.
+  const [randomSeed, setRandomSeed] = useState(() => Math.random());
 
-  // Fetch initial queue from backend
+  // Fetch the swipe queue. Each unique randomSeed value corresponds to a
+  // distinct server query — when it changes, the next batch of names
+  // arrives. We keep all batches we've ever seen accumulated in
+  // localQueue (deduped), so swiping never visibly stalls (#160 prefetch).
   const serverQueue = useQuery(api.selections.getSwipeQueue, {
     limit: 50,
     randomSeed,
@@ -40,6 +45,12 @@ export function SwipeCardStack() {
   const [localQueue, setLocalQueue] = useState<Doc<'names'>[]>([]);
   const localQueueRef = useRef(localQueue);
   localQueueRef.current = localQueue;
+  // Track which name IDs have ever been added to localQueue so a re-fetched
+  // batch with overlapping results doesn't add duplicates.
+  const seenNameIdsRef = useRef<Set<string>>(new Set());
+  // Track when we've already kicked off a prefetch for the current low-queue
+  // event so we don't fire a flood of seed rotations.
+  const prefetchInFlightRef = useRef(false);
 
   const [showMatchToast, setShowMatchToast] = useState(false);
   const [matchToastName, setMatchToastName] = useState<string | null>(null);
@@ -53,13 +64,51 @@ export function SwipeCardStack() {
   const requestPermission = usePushRequestPermission();
   const { needsButtons, reduceMotion } = useA11yPreferences();
 
-  // Sync server queue to local state (only when server data arrives)
+  // Prefetch popularity summaries for the top TWO cards (#174). Querying the
+  // next card's summary now means it's already cached by the time the user
+  // swipes and it becomes top — no flash of an empty sparkline tile.
+  const topName = localQueue[0];
+  const nextName = localQueue[1];
+  const topSummary = useQuery(
+    api.popularity.getNamePopularitySummary,
+    topName ? { name: topName.name, gender: topName.gender } : 'skip',
+  );
+  const nextSummary = useQuery(
+    api.popularity.getNamePopularitySummary,
+    nextName ? { name: nextName.name, gender: nextName.gender } : 'skip',
+  );
+
+  // Append server batches to localQueue, skipping anything we've already
+  // queued. Initial fetch fills the queue; subsequent fetches (triggered
+  // by rotating randomSeed when localQueue is low) extend it so the user
+  // never visibly hits the bottom while more names exist.
   useEffect(() => {
-    if (serverQueue && localQueue.length === 0) {
-      setLocalQueue(serverQueue);
+    if (!serverQueue) return;
+    const fresh = serverQueue.filter((name) => !seenNameIdsRef.current.has(name._id));
+    if (fresh.length === 0) {
+      // Server returned nothing new (everything was already swiped or
+      // already in our local queue). Mark the prefetch resolved so the
+      // next low-queue event can try again with a different seed.
+      prefetchInFlightRef.current = false;
+      return;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    fresh.forEach((name) => seenNameIdsRef.current.add(name._id));
+    setLocalQueue((prev) => [...prev, ...fresh]);
+    prefetchInFlightRef.current = false;
   }, [serverQueue]);
+
+  // Prefetch trigger: when the queue drops to a small remaining buffer,
+  // rotate the random seed so a fresh server query fires before the user
+  // hits the bottom and sees a transient empty state.
+  const PREFETCH_THRESHOLD = 10;
+  useEffect(() => {
+    if (prefetchInFlightRef.current) return;
+    if (localQueue.length === 0) return; // initial-load case is handled above
+    if (localQueue.length > PREFETCH_THRESHOLD) return;
+    if (!serverQueue) return; // wait for the current fetch to land first
+    prefetchInFlightRef.current = true;
+    setRandomSeed(Math.random());
+  }, [localQueue.length, serverQueue]);
 
   // Handle recording a selection — uses ref to avoid recreating on every queue change
   const handleSelection = useCallback(
@@ -140,6 +189,7 @@ export function SwipeCardStack() {
             swipeEnabled={!showDetailModal && !needsButtons}
             detailOpen={showDetailModal}
             cardHeight={needsButtons ? CARD_HEIGHT_FULL - SWIPE_ACTION_BUTTONS_HEIGHT : undefined}
+            popularitySummary={index === 0 ? topSummary : nextSummary}
             onSwipeHintShown={() => setHintEligible(false)}
             onSwipeHintReset={() => setHintEligible(true)}
             onSwipeLeft={() => handleSelection('reject')}

--- a/components/swipe/swipe-card.tsx
+++ b/components/swipe/swipe-card.tsx
@@ -52,7 +52,18 @@ interface SwipeCardProps {
   /** Override the default card height. Used when accessibility buttons need
    *  vertical space below the card. */
   cardHeight?: number;
+  /** Pre-fetched popularity summary supplied by the parent (#174). When
+   *  provided, the card skips its own query so the sparkline is already
+   *  populated the moment the card becomes top — no per-swipe flash.
+   *  Falls back to a self-query when undefined (e.g. detail modal usage). */
+  popularitySummary?: PopularitySummary;
 }
+
+type PopularitySummary = {
+  sparklinePoints: number[];
+  trend: 'rising' | 'falling' | 'steady' | null;
+  peakYear: number | null;
+} | null;
 
 // Gender-based underline colors
 const UNDERLINE_COLORS = {
@@ -95,16 +106,21 @@ export const SwipeCard = forwardRef<SwipeCardRef, SwipeCardProps>(function Swipe
     swipeEnabled = true,
     detailOpen = false,
     cardHeight,
+    popularitySummary: prefetchedSummary,
   },
   ref,
 ) {
   const { colors } = useTheme();
 
-  // Fetch popularity summary only for the top (visible) card
-  const popularitySummary = useQuery(
+  // Prefer the parent's prefetched summary (#174). Only self-query when the
+  // parent didn't supply one AND this is the top card — the fallback keeps
+  // standalone usages (detail modal) working without forcing them to fetch.
+  const shouldSelfQuery = prefetchedSummary === undefined && isTop;
+  const selfQueriedSummary = useQuery(
     api.popularity.getNamePopularitySummary,
-    isTop ? { name: name.name, gender: name.gender } : 'skip',
+    shouldSelfQuery ? { name: name.name, gender: name.gender } : 'skip',
   );
+  const popularitySummary = prefetchedSummary ?? selfQueriedSummary;
 
   const {
     translateX,

--- a/convex/selections.ts
+++ b/convex/selections.ts
@@ -61,16 +61,48 @@ async function ensureCountersBackfilled(
 }
 
 /**
+ * Recompute all three counters from the selections table and write them.
+ * Unlike ensureCountersBackfilled this ALWAYS recomputes — use it after a
+ * bulk mutation where delta tracking is error-prone, and to self-heal any
+ * historical drift. Call AFTER the bulk inserts/deletes have run.
+ */
+async function recomputeCounters(ctx: MutationCtx, userId: Id<'users'>): Promise<void> {
+  const [likes, rejects, skips] = await Promise.all([
+    ctx.db
+      .query('selections')
+      .withIndex('by_user_type', (q) => q.eq('userId', userId).eq('selectionType', 'like'))
+      .collect(),
+    ctx.db
+      .query('selections')
+      .withIndex('by_user_type', (q) => q.eq('userId', userId).eq('selectionType', 'reject'))
+      .collect(),
+    ctx.db
+      .query('selections')
+      .withIndex('by_user_type', (q) => q.eq('userId', userId).eq('selectionType', 'skip'))
+      .collect(),
+  ]);
+  await ctx.db.patch(userId, {
+    likedCount: likes.length,
+    rejectedCount: rejects.length,
+    skippedCount: skips.length,
+  });
+}
+
+/**
  * Apply a set of delta counter changes to the user row. Pass positive ints
  * for inserts, negative for deletes. Selection types not in deltas are
  * untouched. Floors at 0 to defend against any drift.
+ *
+ * IMPORTANT: pass the user document as it was *before* the mutation's
+ * inserts/deletes ran. Otherwise the counter math is wrong: callers
+ * pre-backfill via ensureCountersBackfilled at the TOP of their handler
+ * (before any selection writes) and pass that filled user here.
  */
 async function adjustCounters(
   ctx: MutationCtx,
   user: Doc<'users'>,
   deltas: Partial<Record<'like' | 'reject' | 'skip', number>>,
 ): Promise<void> {
-  const filled = await ensureCountersBackfilled(ctx, user);
   const patch: Partial<Pick<Doc<'users'>, 'likedCount' | 'rejectedCount' | 'skippedCount'>> = {};
   for (const [type, delta] of Object.entries(deltas) as [
     'like' | 'reject' | 'skip',
@@ -78,7 +110,7 @@ async function adjustCounters(
   ][]) {
     if (!delta) continue;
     const field = COUNTER_FIELDS[type];
-    patch[field] = Math.max(0, (filled[field] ?? 0) + delta);
+    patch[field] = Math.max(0, (user[field] ?? 0) + delta);
   }
   if (Object.keys(patch).length > 0) {
     await ctx.db.patch(user._id, patch);
@@ -206,7 +238,10 @@ export const recordSelection = mutation({
     selectionType: v.union(v.literal('like'), v.literal('reject'), v.literal('skip')),
   },
   handler: async (ctx, args) => {
-    const user = await getCurrentUserOrThrow(ctx);
+    let user = await getCurrentUserOrThrow(ctx);
+    // Backfill running counters BEFORE any mutation runs — otherwise the
+    // backfill's post-mutation collect would double-count this write (#183).
+    user = await ensureCountersBackfilled(ctx, user);
 
     // Free tier: limit to 25 swipes total (check effective premium including partner sharing)
     const premiumStatus = await getEffectivePremiumStatusHelper(ctx, user._id);
@@ -390,7 +425,8 @@ export const getSwipeQueue = query({
 export const undoLastSelection = mutation({
   args: {},
   handler: async (ctx) => {
-    const user = await getCurrentUserOrThrow(ctx);
+    let user = await getCurrentUserOrThrow(ctx);
+    user = await ensureCountersBackfilled(ctx, user);
 
     const mostRecent = await ctx.db
       .query('selections')
@@ -534,7 +570,8 @@ export const removeFromLiked = mutation({
     selectionId: v.id('selections'),
   },
   handler: async (ctx, args) => {
-    const user = await getCurrentUserOrThrow(ctx);
+    let user = await getCurrentUserOrThrow(ctx);
+    user = await ensureCountersBackfilled(ctx, user);
 
     const selection = await ctx.db.get(args.selectionId);
     if (!selection) {
@@ -617,7 +654,8 @@ export const restoreToQueue = mutation({
     selectionId: v.id('selections'),
   },
   handler: async (ctx, args) => {
-    const user = await getCurrentUserOrThrow(ctx);
+    let user = await getCurrentUserOrThrow(ctx);
+    user = await ensureCountersBackfilled(ctx, user);
 
     const selection = await ctx.db.get(args.selectionId);
     if (!selection) {
@@ -648,7 +686,6 @@ export const bulkDeleteSelections = mutation({
     const user = await getCurrentUserOrThrow(ctx);
 
     let deletedCount = 0;
-    const deltas: Partial<Record<'like' | 'reject' | 'skip', number>> = {};
     for (const selectionId of args.selectionIds) {
       const selection = await ctx.db.get(selectionId);
       if (!selection || selection.userId !== user._id) continue;
@@ -659,17 +696,13 @@ export const bulkDeleteSelections = mutation({
 
       await ctx.db.delete(selectionId);
       deletedCount++;
-
-      const counterType = counterTypeFor(selection.selectionType);
-      if (counterType) {
-        deltas[counterType] = (deltas[counterType] ?? 0) - 1;
-      }
     }
 
-    // Counter sync (#183) — single batched user-row patch instead of per item.
-    if (Object.keys(deltas).length > 0) {
-      await adjustCounters(ctx, user, deltas);
-    }
+    // Recompute counters from scratch after the batch (#183). Bulk ops are
+    // rare and already O(n), so the extra collect is cheap relative to the
+    // deletes — and recomputing self-heals any historical counter drift
+    // instead of compounding it via deltas.
+    await recomputeCounters(ctx, user._id);
 
     return { success: true, deletedCount };
   },
@@ -684,20 +717,12 @@ export const bulkHideSelections = mutation({
     const now = Date.now();
 
     let hiddenCount = 0;
-    const deltas: Partial<Record<'like' | 'reject' | 'skip', number>> = {};
     for (const selectionId of args.selectionIds) {
       const selection = await ctx.db.get(selectionId);
       if (!selection || selection.userId !== user._id) continue;
 
       if (selection.selectionType === 'like' && user.partnerId) {
         await deleteMatchForName(ctx, user._id, user.partnerId, selection.nameId);
-      }
-
-      // Hidden doesn't count toward stats — decrement the original type
-      // exactly like a delete (#183).
-      const counterType = counterTypeFor(selection.selectionType);
-      if (counterType) {
-        deltas[counterType] = (deltas[counterType] ?? 0) - 1;
       }
 
       await ctx.db.patch(selectionId, {
@@ -707,9 +732,8 @@ export const bulkHideSelections = mutation({
       hiddenCount++;
     }
 
-    if (Object.keys(deltas).length > 0) {
-      await adjustCounters(ctx, user, deltas);
-    }
+    // Recompute from scratch after the batch (#183) — see bulkDeleteSelections.
+    await recomputeCounters(ctx, user._id);
 
     return { success: true, hiddenCount };
   },
@@ -720,7 +744,8 @@ export const hidePermanently = mutation({
     selectionId: v.id('selections'),
   },
   handler: async (ctx, args) => {
-    const user = await getCurrentUserOrThrow(ctx);
+    let user = await getCurrentUserOrThrow(ctx);
+    user = await ensureCountersBackfilled(ctx, user);
 
     const selection = await ctx.db.get(args.selectionId);
     if (!selection) {


### PR DESCRIPTION
Closes #161
Closes #174

## Summary
Frontend perf bundle (#161 + #174) plus fixes for regressions the #170 pagination work introduced, caught during manual testing.

## Planned work
| # | Fix |
|---|---|
| #161 | `LikedNameCard`, `RejectedNameCard`, `MatchCard` wrapped in `React.memo` with data-only comparators. `renderItem` hands rows fresh closures each render; the comparators ignore function-prop identity and compare only fields that affect output. `MatchCard` compares `onPropose`/`onWithdraw` by presence (they gate buttons) not identity. |
| #174 | Prefetch popularity summary for the top TWO cards in `SwipeCardStack`, passed to `SwipeCard` via a new optional `popularitySummary` prop. Next card's sparkline is cached before it becomes top — no empty-tile flash per swipe. `SwipeCard` self-queries as a fallback (detail-modal usage). |

## Regression fixes for #170 (found in testing)
- **Empty state** now keys off actually-loaded item count, not the running counter (counter is a header display optimization and can drift; loaded pages are source of truth). Fixes empty state not appearing after bulk delete.
- **Bulk delete/hide recompute counters from scratch** after the batch instead of delta-adjusting — self-heals drift instead of compounding it.
- **"Select all" drains remaining pages** before selecting, so a subsequent bulk delete covers every item. Deselect-then-delete works off the full set.
- **Swipe queue prefetch**: fetches the next batch at ~10 remaining, appending (deduped) so fast swipers don't hit a transient empty state.
- **Search bar hidden on the genuinely-empty state** (kept on no-results so the query stays editable).

## Test plan
- [x] Lint + typecheck + Convex validate clean
- [x] Manual: sparkline no longer flashes between swipes (#174)
- [x] Manual: liked/rejected/matches lists scroll correctly with memoized rows (#161)
- [x] Manual: bulk delete all → empty state shows; select-all + deselect + delete covers the right set; search bar hides when genuinely empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)