### PR TITLE
fix: gate (tabs) on Convex user row (#167)

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -3,7 +3,9 @@ import { Ionicons } from '@expo/vector-icons';
 import { Redirect, Tabs } from 'expo-router';
 import { Platform, StyleSheet } from 'react-native';
 import { BlurView } from 'expo-blur';
+import { useQuery } from 'convex/react';
 
+import { api } from '@/convex/_generated/api';
 import { useStoreUser } from '@/hooks/use-store-user';
 import { usePushRegistration } from '@/hooks/use-push-registration';
 import { useOnboarding } from '@/hooks/use-onboarding';
@@ -13,24 +15,30 @@ import { LoadingScreen } from '@/components/ui/loading-screen';
 
 export default function TabsLayout() {
   const { isSignedIn } = useAuth();
+  // useStoreUser fires createOrUpdateUser; it must stay above the gate since
+  // it's what creates the row the gate waits for.
   useStoreUser();
-  usePushRegistration();
+  // Gate the whole tab tree on the Convex user row existing (#167).
+  // getCurrentUser returns undefined while loading and null until
+  // createOrUpdateUser lands. Until it's a real row, every authenticated
+  // query/mutation in (tabs)/* that calls getCurrentUserOrThrow would throw
+  // "User not found" — so we hold the loading screen.
+  const convexUser = useQuery(api.users.getCurrentUser, isSignedIn ? {} : 'skip');
   const {
     hasCompletedOnboarding,
     isLoading: isOnboardingLoading,
     completeOnboarding,
   } = useOnboarding();
-  const { colors, gradients } = useTheme();
 
   if (!isSignedIn) {
     return <Redirect href="/(auth)/sign-in" />;
   }
 
-  // Wait for the Convex user query to resolve. On a fresh launch the root
-  // AuthGate already showed the loading animation; for sign-out + sign-in
-  // on the same device we render the Bambino loading screen so the user
-  // sees a clear "still loading" signal instead of a blank gradient.
-  if (isOnboardingLoading) {
+  // Wait for the user row to exist before rendering any screen. On a fresh
+  // launch the root AuthGate already showed the loading animation; for
+  // sign-out + sign-in on the same device this shows the Bambino loading
+  // screen instead of a blank gradient.
+  if (convexUser === undefined || convexUser === null || isOnboardingLoading) {
     return <LoadingScreen isLoading />;
   }
 
@@ -38,6 +46,15 @@ export default function TabsLayout() {
   if (!hasCompletedOnboarding) {
     return <OnboardingScreens onComplete={completeOnboarding} />;
   }
+
+  // Push registration lives here, below the gate, so the user row is
+  // guaranteed to exist — the hook no longer needs its own existence guard.
+  return <TabsNavigator />;
+}
+
+function TabsNavigator() {
+  const { colors, gradients } = useTheme();
+  usePushRegistration();
 
   return (
     <Tabs

--- a/hooks/use-push-registration.ts
+++ b/hooks/use-push-registration.ts
@@ -1,5 +1,5 @@
 import { useUser } from '@clerk/clerk-expo';
-import { useMutation, useQuery } from 'convex/react';
+import { useMutation } from 'convex/react';
 import * as Device from 'expo-device';
 import * as Notifications from 'expo-notifications';
 import Constants from 'expo-constants';
@@ -38,16 +38,13 @@ async function registerToken(
 export function usePushRegistration() {
   const { isSignedIn } = useUser();
   const setPushToken = useMutation(api.users.setPushToken);
-  // Wait until the Convex user row exists before registering, otherwise
-  // setPushToken throws "User not found" (createOrUpdateUser in
-  // useStoreUser races with this hook on first sign-up).
-  const convexUser = useQuery(api.users.getCurrentUser, isSignedIn ? {} : 'skip');
+  // No user-row existence guard here: the (tabs) layout gates rendering on
+  // getCurrentUser, so this hook only mounts once the row exists (#167).
 
   useEffect(() => {
     if (!isSignedIn) return;
     if (Platform.OS !== 'ios') return;
     if (!Device.isDevice) return;
-    if (!convexUser) return;
 
     const refresh = async () => {
       try {
@@ -60,7 +57,7 @@ export function usePushRegistration() {
     };
 
     refresh();
-  }, [isSignedIn, convexUser, setPushToken]);
+  }, [isSignedIn, setPushToken]);
 }
 
 /**


### PR DESCRIPTION
Closes #167

## Summary
Gate the whole tab tree on `getCurrentUser` so screens only render once the Convex user row exists — closing the race where `createOrUpdateUser` (fired in a `useEffect` by `useStoreUser`) hasn't landed yet but a screen already calls a mutation that throws "User not found".

## What changed
- `(tabs)/_layout.tsx` queries `getCurrentUser` directly and holds the loading screen while it's `undefined` (loading) or `null` (row not yet created).
- `usePushRegistration` moved into a child component (`TabsNavigator`) below the gate, so it only mounts once the row exists — and dropped its own workaround `getCurrentUser` query.
- `useStoreUser` stays above the gate (it's what creates the row).

## Notes
- The onboarding flag moved to the user row in #154, so `useOnboarding` was already implicitly providing part of this gate. This makes it explicit and removes the last per-hook workaround.
- Convex dedupes the now-two `getCurrentUser` subscriptions (layout + useOnboarding), so no extra network cost.

## Test plan
- [x] Lint + typecheck clean
- [x] Existing user normal launch — no extra loading delay (row resolves instantly)
- [x] Sign out + sign in same account — loading screen → tabs, no crash
- [x] Brand-new sign-up — onboarding → tabs, no "User not found"
- [ ] Real device: push still registers when permission already granted

🤖 Generated with [Claude Code](https://claude.com/claude-code)