### PR TITLE
fix: Convex safety hardening bundle (#165, #225, #173, #200, #203, #207, #230)

### DIFF
--- a/components/search/origin-toggle-list.tsx
+++ b/components/search/origin-toggle-list.tsx
@@ -52,11 +52,12 @@ export function OriginToggleList({ value, onChange, genderFilter }: OriginToggle
       // From "all" state: select all EXCEPT this one
       onChange(availableOrigins.filter((o) => o !== origin));
     } else if (selectedSet.has(origin)) {
-      // Deselect this origin
-      onChange(value!.filter((o) => o !== origin));
+      // Deselect this origin. value is non-null in this branch (isAllSelected
+      // is false), but use `?? []` instead of a non-null assertion (#207).
+      onChange((value ?? []).filter((o) => o !== origin));
     } else {
       // Select this origin — if all are now selected, collapse to null (all)
-      const next = [...value!, origin].sort();
+      const next = [...(value ?? []), origin].sort();
       onChange(next.length === availableOrigins.length ? null : next);
     }
   };

--- a/convex/names.ts
+++ b/convex/names.ts
@@ -168,38 +168,49 @@ export const searchNames = query({
   },
   handler: async (ctx, args) => {
     const limit = args.limit ?? 50;
-    let results;
+    const { gender, firstLetter, minLength, maxLength, search } = args;
 
-    if (args.gender && args.firstLetter) {
+    // Require an indexed filter (gender or firstLetter). Without one this
+    // would .collect() the entire ~80k-row names table and blow past
+    // Convex's 32k read limit. search/minLength/maxLength are post-filters
+    // applied to an already-narrowed index scan (#200).
+    if (!gender && !firstLetter) {
+      throw new Error('searchNames requires at least a gender or firstLetter filter');
+    }
+
+    const normalizedLetter = firstLetter?.toUpperCase();
+
+    let results;
+    if (gender && normalizedLetter) {
       results = await ctx.db
         .query('names')
         .withIndex('by_gender_and_first_letter', (q) =>
-          q.eq('gender', args.gender!).eq('firstLetter', args.firstLetter!.toUpperCase()),
+          q.eq('gender', gender).eq('firstLetter', normalizedLetter),
         )
         .collect();
-    } else if (args.gender) {
+    } else if (gender) {
       results = await ctx.db
         .query('names')
-        .withIndex('by_gender', (q) => q.eq('gender', args.gender!))
-        .collect();
-    } else if (args.firstLetter) {
-      results = await ctx.db
-        .query('names')
-        .withIndex('by_first_letter', (q) => q.eq('firstLetter', args.firstLetter!.toUpperCase()))
+        .withIndex('by_gender', (q) => q.eq('gender', gender))
         .collect();
     } else {
-      results = await ctx.db.query('names').collect();
+      // normalizedLetter is defined here: the guard above guarantees gender
+      // or firstLetter, and we're in the else of `gender`.
+      results = await ctx.db
+        .query('names')
+        .withIndex('by_first_letter', (q) => q.eq('firstLetter', normalizedLetter as string))
+        .collect();
     }
 
-    if (args.minLength !== undefined) {
-      results = results.filter((n) => n.length >= args.minLength!);
+    if (minLength !== undefined) {
+      results = results.filter((n) => n.length >= minLength);
     }
-    if (args.maxLength !== undefined) {
-      results = results.filter((n) => n.length <= args.maxLength!);
+    if (maxLength !== undefined) {
+      results = results.filter((n) => n.length <= maxLength);
     }
 
-    if (args.search) {
-      const searchLower = args.search.toLowerCase();
+    if (search) {
+      const searchLower = search.toLowerCase();
       results = results.filter((n) => n.name.toLowerCase().includes(searchLower));
     }
 

--- a/convex/popularity.ts
+++ b/convex/popularity.ts
@@ -90,8 +90,11 @@ export const updateNamesWithCurrentRank = internalMutation({
         const femaleRank = femaleRecord?.rank ?? Infinity;
 
         if (maleRecord || femaleRecord) {
+          // No non-null assertions (#207): maleRank/femaleRank already fold
+          // the null case into Infinity, and at least one record exists here,
+          // so the smaller rank is finite and correct.
           const isMaleBetter = maleRank <= femaleRank;
-          const chosenRank = isMaleBetter ? maleRecord!.rank : femaleRecord!.rank;
+          const chosenRank = isMaleBetter ? maleRank : femaleRank;
           await ctx.db.patch(name._id, {
             currentRank: chosenRank,
             primaryGender: isMaleBetter ? 'male' : 'female',

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -22,6 +22,10 @@ export default defineSchema({
     likedCount: v.optional(v.number()),
     rejectedCount: v.optional(v.number()),
     skippedCount: v.optional(v.number()),
+    // Monotonic count of swipes ever recorded — only ever increments, never
+    // decremented by undo. Gates the free-tier swipe limit so undo can't be
+    // used to ratchet past the cap indefinitely (#165).
+    lifetimeSwipeCount: v.optional(v.number()),
     shareCode: v.optional(v.string()),
     partnerId: v.optional(v.id('users')),
     genderFilter: v.optional(v.union(v.literal('boy'), v.literal('girl'), v.literal('both'))),
@@ -100,6 +104,10 @@ export default defineSchema({
     .index('by_user_name', ['userId', 'nameId'])
     .index('by_user_type', ['userId', 'selectionType'])
     .index('by_user_createdAt', ['userId', 'createdAt'])
+    // undoLastSelection orders by this so "undo" targets the most recently
+    // *actioned* selection (re-swiping an old name patches updatedAt), not
+    // the most recently created one (#225).
+    .index('by_user_updatedAt', ['userId', 'updatedAt'])
     .index('by_name', ['nameId']),
 
   // Pre-computed total count of names per (origin, gender) so the

--- a/convex/selections.ts
+++ b/convex/selections.ts
@@ -5,6 +5,10 @@ import { Doc, Id } from './_generated/dataModel';
 import { getEffectivePremiumStatusHelper } from './premium';
 
 const FREE_TIER_SWIPE_LIMIT = 25;
+// Cap on selectionIds accepted by the bulk mutations (#203). The dashboard's
+// "select all" only ever covers the loaded list, so 200 is generous while
+// still bounding the sequential per-item DB calls a single mutation makes.
+const BULK_SELECTION_LIMIT = 200;
 
 // ---- Selection counter helpers (#183) -------------------------------------
 
@@ -243,17 +247,27 @@ export const recordSelection = mutation({
     // backfill's post-mutation collect would double-count this write (#183).
     user = await ensureCountersBackfilled(ctx, user);
 
-    // Free tier: limit to 25 swipes total (check effective premium including partner sharing)
+    // Free tier: limit total swipes via a monotonic lifetime counter (#165).
+    // Using a counter that never decrements (vs counting current selections)
+    // means undoLastSelection can't be used to ratchet back under the cap
+    // and swipe forever. Backfill once from the current selection count for
+    // users predating the field.
     const premiumStatus = await getEffectivePremiumStatusHelper(ctx, user._id);
-    if (!premiumStatus.isPremium) {
+    let lifetimeSwipeCount = user.lifetimeSwipeCount;
+    if (lifetimeSwipeCount === undefined) {
       const existing = await ctx.db
         .query('selections')
         .withIndex('by_user', (q) => q.eq('userId', user._id))
-        .take(FREE_TIER_SWIPE_LIMIT);
-
-      if (existing.length >= FREE_TIER_SWIPE_LIMIT) {
-        return { error: 'FREE_TIER_SWIPE_LIMIT' as const };
-      }
+        .collect();
+      lifetimeSwipeCount = existing.length;
+      // Persist the backfill immediately, even if we're about to reject for
+      // the cap below. Otherwise a capped user whose field was never written
+      // could undo (lowering the current count) and the next call would
+      // backfill to the lowered number — reopening the bypass (#165).
+      await ctx.db.patch(user._id, { lifetimeSwipeCount });
+    }
+    if (!premiumStatus.isPremium && lifetimeSwipeCount >= FREE_TIER_SWIPE_LIMIT) {
+      return { error: 'FREE_TIER_SWIPE_LIMIT' as const };
     }
 
     const existingSelection = await ctx.db
@@ -293,6 +307,10 @@ export const recordSelection = mutation({
       }
       await ctx.db.patch(existingSelection._id, patch);
 
+      // (Re-swiping an already-recorded name doesn't consume a new swipe, so
+      // lifetimeSwipeCount isn't incremented here. Its backfill was already
+      // persisted above.)
+
       // Counter sync (#183): selection type changed → decrement old, increment new
       const oldCounterType = counterTypeFor(existingSelection.selectionType);
       const newCounterType = counterTypeFor(args.selectionType);
@@ -321,6 +339,9 @@ export const recordSelection = mutation({
       createdAt: now,
       updatedAt: now,
     });
+
+    // A genuinely new swipe — advance the monotonic lifetime counter (#165).
+    await ctx.db.patch(user._id, { lifetimeSwipeCount: lifetimeSwipeCount + 1 });
 
     // Counter sync (#183): new selection of countable type → increment
     const newCounterType = counterTypeFor(args.selectionType);
@@ -428,9 +449,12 @@ export const undoLastSelection = mutation({
     let user = await getCurrentUserOrThrow(ctx);
     user = await ensureCountersBackfilled(ctx, user);
 
+    // Order by updatedAt so "undo" targets the most recently *actioned*
+    // selection. Re-swiping an old name patches updatedAt (not createdAt),
+    // so ordering by createdAt would undo the wrong row (#225).
     const mostRecent = await ctx.db
       .query('selections')
-      .withIndex('by_user_createdAt', (q) => q.eq('userId', user._id))
+      .withIndex('by_user_updatedAt', (q) => q.eq('userId', user._id))
       .order('desc')
       .first();
 
@@ -666,6 +690,14 @@ export const restoreToQueue = mutation({
       throw new Error('Not authorized to restore this selection');
     }
 
+    // Defense in depth (#173): restoreToQueue is only wired up for rejected
+    // names today (which have no match), but if it's ever called on a like
+    // we must delete the corresponding match — same as removeFromLiked —
+    // or we'd leave an orphan match row that breaks match-toast suppression.
+    if (selection.selectionType === 'like' && user.partnerId) {
+      await deleteMatchForName(ctx, user._id, user.partnerId, selection.nameId);
+    }
+
     await ctx.db.delete(args.selectionId);
 
     // Counter sync (#183)
@@ -678,11 +710,21 @@ export const restoreToQueue = mutation({
   },
 });
 
+// NOTE on atomicity (#230): Convex mutations are a single transaction. If
+// any per-item call throws, the WHOLE mutation rolls back — nothing is
+// deleted/hidden. The returned count is therefore only meaningful on full
+// success; callers should treat a thrown error as "nothing happened", not a
+// partial result. We intentionally don't try/catch per item: silently
+// swallowing a mid-batch error would leave counts and matches inconsistent.
+
 export const bulkDeleteSelections = mutation({
   args: {
     selectionIds: v.array(v.id('selections')),
   },
   handler: async (ctx, args) => {
+    if (args.selectionIds.length > BULK_SELECTION_LIMIT) {
+      throw new Error(`Cannot delete more than ${BULK_SELECTION_LIMIT} selections at once`);
+    }
     const user = await getCurrentUserOrThrow(ctx);
 
     let deletedCount = 0;
@@ -713,6 +755,9 @@ export const bulkHideSelections = mutation({
     selectionIds: v.array(v.id('selections')),
   },
   handler: async (ctx, args) => {
+    if (args.selectionIds.length > BULK_SELECTION_LIMIT) {
+      throw new Error(`Cannot hide more than ${BULK_SELECTION_LIMIT} selections at once`);
+    }
     const user = await getCurrentUserOrThrow(ctx);
     const now = Date.now();
 


### PR DESCRIPTION
Closes #165, #225, #173, #200, #203, #207, #230

Seven low-risk backend correctness/safety fixes in `convex/`. No UI changes.

| # | Fix |
|---|---|
| #165 | Free-tier swipe cap gated on a monotonic `lifetimeSwipeCount` (user row) instead of current selection count. `undoLastSelection` can no longer ratchet a capped free user back under the limit. Backfilled from current count and persisted immediately — including on the cap-reject path — so undoing before the field existed can't reopen the bypass. |
| #225 | `undoLastSelection` orders by a new `by_user_updatedAt` index, so "undo" targets the most recently *actioned* selection (re-swipes patch `updatedAt`, not `createdAt`). |
| #173 | `restoreToQueue` deletes the match when the selection is a like (mirrors `removeFromLiked`). Defense-in-depth — only rejections reach it today. |
| #200 | `searchNames` requires a gender/firstLetter filter; the unfiltered branch would `.collect()` ~80k rows past Convex's 32k limit. Query is currently unused, so no breakage. |
| #203 | `bulkDeleteSelections` / `bulkHideSelections` cap input at 200 IDs. |
| #207 | Removed non-null assertions in `popularity.ts`, `names.ts`, and `origin-toggle-list.tsx` (guards / `?? []` instead). |
| #230 | Documented bulk-mutation atomicity (Convex rolls back the whole tx on any throw; count is only meaningful on full success). |

## Schema changes
- `users.lifetimeSwipeCount` (optional number)
- `selections.by_user_updatedAt` index

## Test plan
- [x] Lint + typecheck + Convex validate (new index deployed)
- [ ] **Free-account check (revenue-sensitive):** as a free user, swipe to the 25 cap → confirm blocked → undo a few → confirm still blocked (can't swipe past via undo)
- [ ] Undo after re-swiping an old name targets the re-swiped one
- [ ] Dashboard bulk delete/hide still works for normal selections

🤖 Generated with [Claude Code](https://claude.com/claude-code)