### PR TITLE
fix: Convex uniqueness self-heal + submitFeedback hardening (#164, #171)

### DIFF
--- a/convex/feedback.ts
+++ b/convex/feedback.ts
@@ -1,5 +1,6 @@
 import { v } from 'convex/values';
-import { action } from './_generated/server';
+import { action, internalMutation } from './_generated/server';
+import { internal } from './_generated/api';
 
 const CATEGORY_LABELS: Record<string, string> = {
   bug: 'Bug Report',
@@ -12,6 +13,64 @@ const CATEGORY_EMOJI: Record<string, string> = {
   feature: ':bulb:',
   general: ':speech_balloon:',
 };
+
+// #171: minimum gap between feedback submissions per user, to stop a single
+// authenticated user from flooding the Slack channel in a loop.
+const FEEDBACK_RATE_WINDOW_MS = 60 * 1000;
+
+// #171: hard cap on message length. Slack has its own block-text limits, but
+// capping here keeps payloads small and bounds abuse.
+const MAX_FEEDBACK_LENGTH = 2000;
+
+/**
+ * #171: Strip Slack mrkdwn control characters from user-controlled text before
+ * it reaches the webhook. Slack interprets `<!channel>` / `<!here>` as mass
+ * pings, `<@U123>` as user mentions, and `<url|text>` as links — all injectable
+ * via the message body OR via a Clerk display name the user controls. Removing
+ * angle brackets disables every one of those, and escaping `&` keeps Slack from
+ * mis-parsing entities. We additionally render user text in `plain_text` blocks
+ * (see below), but this defends the `context` block where only mrkdwn is
+ * available.
+ */
+function sanitizeSlackText(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/[<>]/g, '');
+}
+
+/**
+ * #171: Rate-limit gate for submitFeedback. Runs as a mutation (the public
+ * entry point is an action, which can't touch the DB directly). Resolves the
+ * caller's user row, rejects if they submitted within the window, otherwise
+ * records the submission time. Called BEFORE the Slack POST so a rejected
+ * caller never reaches the webhook.
+ */
+export const checkAndRecordFeedbackRateLimit = internalMutation({
+  args: { clerkId: v.string() },
+  handler: async (ctx, args) => {
+    const user = await ctx.db
+      .query('users')
+      .withIndex('by_clerk_id', (q) => q.eq('clerkId', args.clerkId))
+      .first();
+    if (!user) {
+      throw new Error('User not found');
+    }
+
+    const now = Date.now();
+    const record = await ctx.db
+      .query('feedbackRateLimits')
+      .withIndex('by_user', (q) => q.eq('userId', user._id))
+      .first();
+
+    if (record && now - record.lastSubmittedAt < FEEDBACK_RATE_WINDOW_MS) {
+      throw new Error('Please wait a minute before sending more feedback.');
+    }
+
+    if (record) {
+      await ctx.db.patch(record._id, { lastSubmittedAt: now });
+    } else {
+      await ctx.db.insert('feedbackRateLimits', { userId: user._id, lastSubmittedAt: now });
+    }
+  },
+});
 
 export const submitFeedback = action({
   args: {
@@ -28,16 +87,33 @@ export const submitFeedback = action({
     if (!trimmed) {
       throw new Error('Message cannot be empty');
     }
+    // #171: length cap.
+    if (trimmed.length > MAX_FEEDBACK_LENGTH) {
+      throw new Error(`Feedback must be ${MAX_FEEDBACK_LENGTH} characters or fewer.`);
+    }
 
     const webhookUrl = process.env.SLACK_FEEDBACK_WEBHOOK_URL;
     if (!webhookUrl) {
       throw new Error('Slack webhook URL not configured');
     }
 
+    // #171: enforce the per-user rate limit BEFORE hitting Slack. Throws
+    // ("Please wait a minute…") if the user submitted within the window.
+    // NOTE: the window is recorded here, so it's consumed even if the Slack
+    // POST below fails — a deliberate flood-control trade-off (a rejected
+    // caller must never reach the webhook), not a bug. A user whose delivery
+    // genuinely failed waits out the window before retrying.
+    await ctx.runMutation(internal.feedback.checkAndRecordFeedbackRateLimit, {
+      clerkId: identity.subject,
+    });
+
     const label = CATEGORY_LABELS[args.category];
     const emoji = CATEGORY_EMOJI[args.category];
-    const userName = identity.name ?? 'Unknown';
-    const userEmail = identity.email ?? 'No email';
+    // #171: identity.name/email are user-controlled (Clerk profile), so they
+    // are injection vectors too — sanitize alongside the message body.
+    const safeMessage = sanitizeSlackText(trimmed);
+    const safeName = sanitizeSlackText(identity.name ?? 'Unknown');
+    const safeEmail = sanitizeSlackText(identity.email ?? 'No email');
 
     const payload = {
       blocks: [
@@ -50,18 +126,30 @@ export const submitFeedback = action({
           },
         },
         {
+          // #171: plain_text (not mrkdwn) for the user's message — Slack won't
+          // render mentions or links inside a plain_text block, so this is the
+          // primary defense; sanitizeSlackText is belt-and-suspenders.
           type: 'section',
           text: {
-            type: 'mrkdwn',
-            text: trimmed,
+            type: 'plain_text',
+            text: safeMessage,
+            emoji: false,
           },
         },
         {
+          // #171: keep the static label in mrkdwn but render the
+          // Clerk-controlled name/email in plain_text. Stripping <> defeats raw
+          // mention/link syntax, but mrkdwn still AUTO-LINKIFIES a bare URL
+          // (e.g. a display name of "http://evil.com" becomes clickable).
+          // plain_text is neither linkified nor formatted by Slack, closing
+          // that residual vector.
           type: 'context',
           elements: [
+            { type: 'mrkdwn', text: '*From:*' },
             {
-              type: 'mrkdwn',
-              text: `*From:* ${userName} (${userEmail}) — ${new Date().toISOString()}`,
+              type: 'plain_text',
+              text: `${safeName} (${safeEmail}) — ${new Date().toISOString()}`,
+              emoji: false,
             },
           ],
         },

--- a/convex/matches.ts
+++ b/convex/matches.ts
@@ -9,10 +9,12 @@ async function getCurrentUserOrThrow(ctx: QueryCtx | MutationCtx) {
     throw new Error('Not authenticated');
   }
 
+  // #164: tolerant read — a stray duplicate clerkId row shouldn't throw and
+  // break match screens. createOrUpdateUser self-heals duplicates.
   const user = await ctx.db
     .query('users')
     .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
-    .unique();
+    .first();
 
   if (!user) {
     throw new Error('User not found');
@@ -25,10 +27,11 @@ async function getCurrentUserOrNull(ctx: QueryCtx | MutationCtx) {
   const identity = await ctx.auth.getUserIdentity();
   if (!identity) return null;
 
+  // #164: tolerant read — see getCurrentUserOrThrow.
   return await ctx.db
     .query('users')
     .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
-    .unique();
+    .first();
 }
 
 /**

--- a/convex/partners.ts
+++ b/convex/partners.ts
@@ -39,10 +39,12 @@ async function getCurrentUserOrThrow(ctx: QueryCtx | MutationCtx) {
     throw new Error('Not authenticated');
   }
 
+  // #164: tolerant read — a stray duplicate clerkId row shouldn't throw and
+  // break partner linking. createOrUpdateUser self-heals duplicates.
   const user = await ctx.db
     .query('users')
     .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
-    .unique();
+    .first();
 
   if (!user) {
     throw new Error('User not found');
@@ -149,10 +151,11 @@ export const getPartnerInfo = query({
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) return null;
 
+    // #164: tolerant read — see the linking helper above.
     const user = await ctx.db
       .query('users')
       .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
-      .unique();
+      .first();
 
     if (!user) return null;
 

--- a/convex/premium.ts
+++ b/convex/premium.ts
@@ -63,10 +63,12 @@ export const getEffectivePremiumStatus = query({
       return { isPremium: false, isOwnPremium: false, isPartnerPremium: false };
     }
 
+    // #164: tolerant read — a stray duplicate clerkId row shouldn't throw and
+    // break premium gating. createOrUpdateUser self-heals duplicates.
     const user = await ctx.db
       .query('users')
       .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
-      .unique();
+      .first();
 
     if (!user) {
       return { isPremium: false, isOwnPremium: false, isPartnerPremium: false };

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -136,6 +136,14 @@ export default defineSchema({
     lockedUntil: v.optional(v.number()),
   }).index('by_user', ['userId']),
 
+  // Per-user throttle for submitFeedback (#171). One row per user, holding the
+  // timestamp of their last successful submission. Enforces a minimum gap
+  // between feedback messages so a user can't flood the Slack channel.
+  feedbackRateLimits: defineTable({
+    userId: v.id('users'),
+    lastSubmittedAt: v.number(),
+  }).index('by_user', ['userId']),
+
   matches: defineTable({
     nameId: v.id('names'),
     user1Id: v.id('users'),

--- a/convex/selections.ts
+++ b/convex/selections.ts
@@ -136,10 +136,12 @@ async function getCurrentUserOrThrow(ctx: QueryCtx | MutationCtx) {
     throw new Error('Not authenticated');
   }
 
+  // #164: tolerant read — a stray duplicate clerkId row shouldn't throw here.
+  // createOrUpdateUser self-heals duplicates; this keeps the oldest meanwhile.
   const user = await ctx.db
     .query('users')
     .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
-    .unique();
+    .first();
 
   if (!user) {
     throw new Error('User not found');
@@ -157,14 +159,17 @@ async function deleteMatchForName(
 ) {
   const [user1Id, user2Id] = userId < partnerId ? [userId, partnerId] : [partnerId, userId];
 
-  const match = await ctx.db
+  // #164: collect + delete-all rather than .unique() + delete-one. A duplicate
+  // match row (legacy data) would make .unique() throw and leave an orphan;
+  // deleting every matching row is both throw-safe and the correct cleanup.
+  const matches = await ctx.db
     .query('matches')
     .withIndex('by_name_users', (q) =>
       q.eq('nameId', nameId).eq('user1Id', user1Id).eq('user2Id', user2Id),
     )
-    .unique();
+    .collect();
 
-  if (match) {
+  for (const match of matches) {
     await ctx.db.delete(match._id);
   }
 }
@@ -173,10 +178,11 @@ async function getCurrentUserOrNull(ctx: QueryCtx | MutationCtx) {
   const identity = await ctx.auth.getUserIdentity();
   if (!identity) return null;
 
+  // #164: tolerant read — see getCurrentUserOrThrow.
   return await ctx.db
     .query('users')
     .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
-    .unique();
+    .first();
 }
 
 // Check for a match when a user likes a name
@@ -191,11 +197,12 @@ async function checkForMatchAndCreate(
   matchedAt: number;
   isFirstMatch: boolean;
 } | null> {
-  // Check if partner has liked this name
+  // Check if partner has liked this name. #164: .first() — a duplicate
+  // partner selection row shouldn't throw and block match creation.
   const partnerSelection = await ctx.db
     .query('selections')
     .withIndex('by_user_name', (q) => q.eq('userId', partnerId).eq('nameId', nameId))
-    .unique();
+    .first();
 
   if (!partnerSelection || partnerSelection.selectionType !== 'like') {
     return null;
@@ -205,12 +212,13 @@ async function checkForMatchAndCreate(
   const [user1Id, user2Id] =
     likingUserId < partnerId ? [likingUserId, partnerId] : [partnerId, likingUserId];
 
+  // #164: .first() not .unique() — tolerant of a pre-existing duplicate match.
   const existingMatch = await ctx.db
     .query('matches')
     .withIndex('by_name_users', (q) =>
       q.eq('nameId', nameId).eq('user1Id', user1Id).eq('user2Id', user2Id),
     )
-    .unique();
+    .first();
 
   if (existingMatch) {
     return null;
@@ -231,9 +239,32 @@ async function checkForMatchAndCreate(
     updatedAt: now,
   });
 
+  // #164: the highest-impact race — both partners liking the same name at the
+  // same instant. Convex OCC should serialize these (both read+write the same
+  // by_name_users range), but indexes aren't unique constraints, so re-read
+  // and collapse to the oldest match if two rows exist. Return the survivor.
+  const afterInsert = await ctx.db
+    .query('matches')
+    .withIndex('by_name_users', (q) =>
+      q.eq('nameId', nameId).eq('user1Id', user1Id).eq('user2Id', user2Id),
+    )
+    .collect();
+  let survivingMatchId = matchId;
+  if (afterInsert.length > 1) {
+    afterInsert.sort((a, b) => a._creationTime - b._creationTime);
+    survivingMatchId = afterInsert[0]._id;
+    for (let i = 1; i < afterInsert.length; i++) {
+      await ctx.db.delete(afterInsert[i]._id);
+    }
+    // A concurrent writer beat us to it — they already surfaced the match toast.
+    if (survivingMatchId !== matchId) {
+      return null;
+    }
+  }
+
   const name = await ctx.db.get(nameId);
 
-  return { matchId, name, matchedAt: now, isFirstMatch: existingPartnerMatch === null };
+  return { matchId: survivingMatchId, name, matchedAt: now, isFirstMatch: existingPartnerMatch === null };
 }
 
 export const recordSelection = mutation({
@@ -270,10 +301,19 @@ export const recordSelection = mutation({
       return { error: 'FREE_TIER_SWIPE_LIMIT' as const };
     }
 
-    const existingSelection = await ctx.db
+    // #164: collect + heal rather than .unique(). A duplicate (user, name)
+    // selection row (legacy data) would make .unique() throw here and in
+    // getSwipeQueue's isAlreadySwiped, breaking the swipe screen. Keep the
+    // oldest, delete the rest, and treat the oldest as the existing row.
+    const existingRows = await ctx.db
       .query('selections')
       .withIndex('by_user_name', (q) => q.eq('userId', user._id).eq('nameId', args.nameId))
-      .unique();
+      .collect();
+    existingRows.sort((a, b) => a._creationTime - b._creationTime);
+    const existingSelection = existingRows[0] ?? null;
+    for (let i = 1; i < existingRows.length; i++) {
+      await ctx.db.delete(existingRows[i]._id);
+    }
 
     const now = Date.now();
 
@@ -340,6 +380,27 @@ export const recordSelection = mutation({
       updatedAt: now,
     });
 
+    // #164 belt-and-suspenders: re-read by (user, name) and collapse to the
+    // oldest if a concurrent insert also won. OCC should prevent this (both
+    // touch the same by_user_name range), but indexes aren't unique. If our
+    // row lost, delete it and bail without double-counting the swipe.
+    const afterInsert = await ctx.db
+      .query('selections')
+      .withIndex('by_user_name', (q) => q.eq('userId', user._id).eq('nameId', args.nameId))
+      .collect();
+    if (afterInsert.length > 1) {
+      afterInsert.sort((a, b) => a._creationTime - b._creationTime);
+      const survivor = afterInsert[0];
+      for (let i = 1; i < afterInsert.length; i++) {
+        await ctx.db.delete(afterInsert[i]._id);
+      }
+      if (survivor._id !== selectionId) {
+        // A concurrent call already recorded this swipe and did its own
+        // counting. Don't increment lifetime/counters again.
+        return { selectionId: survivor._id, match: null };
+      }
+    }
+
     // A genuinely new swipe — advance the monotonic lifetime counter (#165).
     await ctx.db.patch(user._id, { lifetimeSwipeCount: lifetimeSwipeCount + 1 });
 
@@ -381,10 +442,12 @@ export const getSwipeQueue = query({
     // many names the user has swiped, so the subscription doesn't bloat
     // linearly with engagement.
     const isAlreadySwiped = async (nameId: Id<'names'>): Promise<boolean> => {
+      // #164: .first() — a duplicate selection row shouldn't throw and crash
+      // the swipe queue. recordSelection self-heals duplicates on next write.
       const existing = await ctx.db
         .query('selections')
         .withIndex('by_user_name', (q) => q.eq('userId', user._id).eq('nameId', nameId))
-        .unique();
+        .first();
       return existing !== null;
     };
 

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -8,10 +8,14 @@ async function getCurrentUserOrThrow(ctx: QueryCtx | MutationCtx) {
     throw new Error('Not authenticated');
   }
 
+  // #164: .first() instead of .unique() so a stray duplicate clerkId row
+  // (legacy data, before createOrUpdateUser's heal ran) can't throw and break
+  // every authed screen. by_clerk_id returns oldest-first, matching the row
+  // createOrUpdateUser keeps when it dedupes.
   const user = await ctx.db
     .query('users')
     .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
-    .unique();
+    .first();
 
   if (!user) {
     throw new Error('User not found');
@@ -28,10 +32,11 @@ export const getCurrentUser = query({
       return null;
     }
 
+    // #164: tolerant read — see getCurrentUserOrThrow.
     const user = await ctx.db
       .query('users')
       .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
-      .unique();
+      .first();
 
     return user;
   },
@@ -49,10 +54,22 @@ export const createOrUpdateUser = mutation({
       throw new Error('Not authenticated');
     }
 
-    const existingUser = await ctx.db
+    // #164: collect (not .unique()) so we can self-heal duplicate clerkId rows
+    // created before this guard existed (e.g. concurrent first-sign-in from two
+    // devices on the same Apple ID). Convex's OCC already prevents NEW races —
+    // the existence read and the insert below touch the same by_clerk_id range,
+    // so a concurrent second insert conflicts and retries — but a pre-existing
+    // duplicate would make .unique() throw here and everywhere else. Keep the
+    // oldest row, delete the rest.
+    const existingRows = await ctx.db
       .query('users')
       .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
-      .unique();
+      .collect();
+    existingRows.sort((a, b) => a._creationTime - b._creationTime);
+    const existingUser = existingRows[0] ?? null;
+    for (let i = 1; i < existingRows.length; i++) {
+      await ctx.db.delete(existingRows[i]._id);
+    }
 
     const now = Date.now();
 
@@ -82,6 +99,21 @@ export const createOrUpdateUser = mutation({
       createdAt: now,
       updatedAt: now,
     });
+
+    // #164 belt-and-suspenders: if a concurrent insert somehow also won (OCC
+    // should make this impossible since both touch by_clerk_id, but indexes
+    // are not unique constraints), re-read and keep only the oldest row.
+    const afterInsert = await ctx.db
+      .query('users')
+      .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
+      .collect();
+    if (afterInsert.length > 1) {
+      afterInsert.sort((a, b) => a._creationTime - b._creationTime);
+      for (let i = 1; i < afterInsert.length; i++) {
+        await ctx.db.delete(afterInsert[i]._id);
+      }
+      return afterInsert[0]._id;
+    }
 
     return userId;
   },


### PR DESCRIPTION
Bundle B2 of the pre-launch audit. Closes #164, #171. Backend-only, no UI changes.

## #164 — Defensive uniqueness on selections, matches, users.clerkId
Convex indexes are **not** unique constraints, so a stray duplicate row (legacy data) makes `.unique()` reads throw and break whole screens. Convex's OCC already prevents *new* double-insert races — the existence read and the insert touch the same index range, so a concurrent second insert conflicts and retries — so this is **defense-in-depth + self-heal**, framed honestly in the comments (not claimed as the sole race fix).

- **createOrUpdateUser**: collect by `clerkId`, keep oldest, delete extras; re-read after insert and collapse to the oldest survivor.
- **recordSelection**: heal `(user, name)` duplicates to oldest; after a new insert, if *our* row lost the re-read, delete losers and return early **without** double-counting `lifetimeSwipeCount` (#165) or stats counters (#183).
- **checkForMatchAndCreate**: re-read `by_name_users` after insert, collapse to oldest match; if a concurrent writer won, return `null` to suppress a duplicate match toast. `isFirstMatch` is read pre-insert, so it stays correct.
- **deleteMatchForName**: collect + delete-all (throw-safe *and* correct cleanup of any duplicate).
- Tolerant `.unique()`→`.first()` on `by_clerk_id` user reads (users/selections/matches/partners/premium) and selection existence checks (getSwipeQueue). `by_clerk_id` is oldest-first, matching the row createOrUpdateUser keeps, so every reader agrees on the survivor.

## #171 — submitFeedback: rate-limit, length cap, Slack injection
`submitFeedback` is an action that POSTs to a Slack webhook; it was spammable and an unsanitized mrkdwn-injection surface (message **and** Clerk-controlled name/email — a user can set their display name to `<!channel>`).

- New **`feedbackRateLimits`** table + internal mutation enforcing a **60s per-user window**, checked **before** the Slack POST so a rejected caller never pings Slack.
- **2000-char** length cap.
- **`sanitizeSlackText`** strips `<>` (kills `<!channel>` / `<@U123>` / `<url|text>`) and escapes `&`; user message rendered as `plain_text`; name/email moved to a `plain_text` context element so Slack can't auto-linkify a bare URL in a display name.

## Verification
- `npx convex dev --once` → schema + handlers compile, `feedbackRateLimits.by_user` index added
- `npm run lint` → 0 errors (8 pre-existing warnings)
- `tsc --noEmit` → clean
- Self-reviewed via code-reviewer agent; applied its `plain_text` context-block fix (closed a residual auto-linkify vector). Plain `Error` throughout — ConvexError migration deferred to #178.

## Acceptance mapping
- #164: concurrent/duplicate selection → one surviving row; duplicate match collapsed to one; duplicate user healed to oldest; single-call paths unchanged.
- #171: `<!channel> hi` → no mass-ping (plain_text + `<>` stripped, literal text shown); rapid resubmits → 1 succeeds, rest get the wait-a-minute error; >2000 chars rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)