### PR TITLE
fix: security hardening — gate catalog queries, validate imageUrl, type Clerk errors (#201, #202, #205)

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -18,6 +18,7 @@ import type * as popularity from "../popularity.js";
 import type * as premium from "../premium.js";
 import type * as selections from "../selections.js";
 import type * as users from "../users.js";
+import type * as validation from "../validation.js";
 
 import type {
   ApiFromModules,
@@ -36,6 +37,7 @@ declare const fullApi: ApiFromModules<{
   premium: typeof premium;
   selections: typeof selections;
   users: typeof users;
+  validation: typeof validation;
 }>;
 
 /**

--- a/convex/names.ts
+++ b/convex/names.ts
@@ -167,6 +167,13 @@ export const searchNames = query({
     limit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
+    // #201: require auth to drop the unauthenticated scrape surface. The app
+    // always authenticates, so this is a no-op for legitimate clients.
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error('Not authenticated');
+    }
+
     const limit = args.limit ?? 50;
     const { gender, firstLetter, minLength, maxLength, search } = args;
 

--- a/convex/partners.ts
+++ b/convex/partners.ts
@@ -1,6 +1,7 @@
 import { v } from 'convex/values';
 import { mutation, query, QueryCtx, MutationCtx } from './_generated/server';
 import type { Id } from './_generated/dataModel';
+import { sanitizeImageUrl } from './validation';
 
 // 31-char alphabet with confusables (I/O/0/1) removed for readability when
 // users dictate codes verbally. 31^8 ≈ 8.5e11 keyspace.
@@ -166,7 +167,9 @@ export const getPartnerInfo = query({
         partner = {
           _id: partnerDoc._id,
           name: partnerDoc.name,
-          imageUrl: partnerDoc.imageUrl,
+          // #202: strip on read too, so a legacy non-Clerk URL stored before
+          // write-validation existed can't leak the partner's IP/UA via <Image>.
+          imageUrl: sanitizeImageUrl(partnerDoc.imageUrl),
         };
       }
     }

--- a/convex/popularity.ts
+++ b/convex/popularity.ts
@@ -1,5 +1,16 @@
 import { v } from 'convex/values';
-import { internalMutation, query } from './_generated/server';
+import { internalMutation, query, QueryCtx } from './_generated/server';
+
+// #201: catalog data is public-domain SSA data (no PII), but these queries
+// were reachable by anyone with the deployment URL. Require auth to drop the
+// unauthenticated scrape surface — a no-op for the app, which always
+// authenticates. internalMutations above are already private.
+async function requireAuth(ctx: QueryCtx): Promise<void> {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) {
+    throw new Error('Not authenticated');
+  }
+}
 
 // Tier boundaries used by the swipe queue. Keep in sync with the swipe
 // queue logic in convex/selections.ts.
@@ -295,6 +306,7 @@ export const getNamePopularity = query({
     endYear: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
+    await requireAuth(ctx); // #201
     // Map app gender to SSA gender format
     const ssaGender = args.gender === 'male' ? 'M' : args.gender === 'female' ? 'F' : args.gender;
 
@@ -331,6 +343,7 @@ export const getPopularNamesForYear = query({
     limit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
+    await requireAuth(ctx); // #201
     const limit = args.limit ?? 10;
     let records;
 
@@ -367,6 +380,7 @@ export const getNamePopularitySummary = query({
     gender: v.string(),
   },
   handler: async (ctx, args) => {
+    await requireAuth(ctx); // #201
     // Determine which SSA gender(s) to query. For 'male'/'female' it's a
     // direct mapping. For 'neutral' (or any other value), fetch both M and F
     // and pick the series whose most recent record is more recent — matches

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,6 +1,7 @@
 import { v } from 'convex/values';
 import { mutation, query, QueryCtx, MutationCtx } from './_generated/server';
 import { generateUniqueShareCode } from './partners';
+import { sanitizeImageUrl } from './validation';
 
 async function getCurrentUserOrThrow(ctx: QueryCtx | MutationCtx) {
   const identity = await ctx.auth.getUserIdentity();
@@ -73,6 +74,9 @@ export const createOrUpdateUser = mutation({
 
     const now = Date.now();
 
+    // #202: drop any imageUrl not on Clerk's CDN before it's stored or exposed.
+    const safeImageUrl = sanitizeImageUrl(args.imageUrl);
+
     if (existingUser) {
       // Only overwrite name/imageUrl when Clerk actually provides a value.
       // Otherwise we'd erase fields set elsewhere (admin seed, name-edit
@@ -82,7 +86,7 @@ export const createOrUpdateUser = mutation({
       // on subsequent sign-ins (#166).
       const patch: Record<string, unknown> = { email: args.email, updatedAt: now };
       if (args.name && existingUser.nameConfirmed !== true) patch.name = args.name;
-      if (args.imageUrl) patch.imageUrl = args.imageUrl;
+      if (safeImageUrl) patch.imageUrl = safeImageUrl;
       await ctx.db.patch(existingUser._id, patch);
       return existingUser._id;
     }
@@ -93,7 +97,7 @@ export const createOrUpdateUser = mutation({
       clerkId: identity.subject,
       email: args.email,
       name: args.name,
-      imageUrl: args.imageUrl,
+      imageUrl: safeImageUrl, // #202
       shareCode,
       genderFilter: 'both',
       createdAt: now,

--- a/convex/validation.ts
+++ b/convex/validation.ts
@@ -1,0 +1,17 @@
+// Shared, dependency-free validation helpers used across Convex handlers.
+// Kept in its own leaf module so both users.ts and partners.ts can import it
+// without creating a circular dependency between them.
+
+// #202: only accept profile image URLs hosted on Clerk's CDN. Clerk normally
+// re-hosts SSO/uploaded avatars on its own CDN, but a custom URL set via
+// Clerk's update API could point anywhere — and the partner's app loads it in
+// an <Image>, leaking their IP/UA/timing to whoever controls the URL. We drop
+// (not reject) a non-matching URL: some SSO providers briefly return a
+// Google/Apple URL before Clerk re-hosts, and we'd rather show no avatar than
+// throw on a legitimate sign-in.
+const CLERK_IMAGE_URL_REGEX = /^https:\/\/(img\.)?clerk\.(com|services|dev)\//;
+
+export function sanitizeImageUrl(imageUrl: string | undefined): string | undefined {
+  if (!imageUrl) return undefined;
+  return CLERK_IMAGE_URL_REGEX.test(imageUrl) ? imageUrl : undefined;
+}

--- a/hooks/use-profile-photo.ts
+++ b/hooks/use-profile-photo.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import { Alert } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import * as Sentry from '@sentry/react-native';
+import { isClerkAPIResponseError } from '@clerk/clerk-expo';
 import type { UserResource } from '@clerk/types';
 
 export function useProfilePhoto(user: UserResource | null | undefined) {
@@ -36,17 +37,21 @@ export function useProfilePhoto(user: UserResource | null | undefined) {
       await user.setProfileImage({
         file: `data:${mimeType};base64,${asset.base64!}`,
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
       Sentry.captureException(error);
       if (__DEV__) {
-        console.error('Profile photo upload failed:', {
-          message: error?.message,
-          status: error?.status,
-          code: error?.errors?.[0]?.code,
-          longMessage: error?.errors?.[0]?.longMessage,
-          clerkError: error?.clerkError,
-          raw: JSON.stringify(error, null, 2),
-        });
+        // #205: narrow with Clerk's type guard instead of `as any`, so the
+        // shape we log is type-checked and Clerk API drift surfaces at compile
+        // time. Non-Clerk errors fall through to the generic fields.
+        if (isClerkAPIResponseError(error)) {
+          console.error('Profile photo upload failed (Clerk API error):', {
+            status: error.status,
+            code: error.errors[0]?.code,
+            longMessage: error.errors[0]?.longMessage,
+          });
+        } else {
+          console.error('Profile photo upload failed:', error);
+        }
       }
       Alert.alert('Error', 'Failed to update profile photo. Please try again.');
     } finally {
@@ -60,7 +65,9 @@ export function useProfilePhoto(user: UserResource | null | undefined) {
     setIsUploading(true);
     try {
       await user.setProfileImage({ file: null });
-    } catch (error: any) {
+    } catch (error: unknown) {
+      // #205: typed catch — the message is generic, so we only need Sentry to
+      // capture the (unknown) error; no `as any` shape access required.
       Sentry.captureException(error);
       Alert.alert('Error', 'Failed to remove profile photo. Please try again.');
     } finally {


### PR DESCRIPTION
Bundle E (security backend) of the pre-launch audit. Closes #201, #202, #205. No UI changes. **#185 (Report-message affordance) was moved to the Bundle D simulator batch** since it's UI-visible.

## #201 — Auth-gate public catalog queries
SSA catalog data is public-domain (no PII), but the queries were reachable by anyone with the deployment URL. Added auth checks so the unauthenticated scrape surface is gone — a no-op for the app, which always authenticates.
- `popularity.ts`: `getNamePopularity`, `getPopularNamesForYear`, `getNamePopularitySummary` → `requireAuth(ctx)` helper
- `names.ts`: `searchNames` → throws `Not authenticated` for anonymous callers
- Verified every client caller is inside the authenticated `(tabs)` gate. `getPopularNamesForYear` + `searchNames` have **no** client callers — pure surface reduction.

## #202 — Validate imageUrl on Clerk's CDN
A user can point their Clerk profile image at an attacker URL; the partner's app loads it via `<Image>`, leaking IP/UA/timing. New leaf module **`convex/validation.ts`** holds `sanitizeImageUrl`, which **drops** (not rejects — SSO can briefly return un-rehosted Google/Apple URLs) any URL not on Clerk's CDN. Applied **on write** (`createOrUpdateUser`, insert + patch paths) **and on read** (`getPartnerInfo`, to neutralize any legacy row).
- Note: extracted to `validation.ts` specifically to avoid a `users ↔ partners` circular import.

## #205 — Type Clerk error catches
`use-profile-photo.ts` used `catch (error: any)`. Now `catch (error: unknown)` + `isClerkAPIResponseError` (imported from `@clerk/clerk-expo`, which re-exports it — no deep `/internal` import as the issue suggested). Dev-only error logging is now type-checked. Both catch-any sites migrated.

## Verification
- `npx convex dev --once` → compiles, no circular import, `validation` module registered in generated API
- `npm run lint` → 0 errors (8 pre-existing warnings)
- `tsc --noEmit` → clean
- Plain `Error` throughout — ConvexError migration deferred to #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)