### PR TITLE
feat: Report message + Unlink affordance for partner UGC (Apple Guideline 1.2) (#185)

### DIFF
--- a/app/(tabs)/matches.tsx
+++ b/app/(tabs)/matches.tsx
@@ -38,6 +38,7 @@ import { MatchAnimation } from '@/components/ui/match-animation';
 import { LoadingScreen, useGracefulLoading } from '@/components/ui/loading-screen';
 import { LoadingIndicator } from '@/components/ui/loading-indicator';
 import { Doc, Id } from '@/convex/_generated/dataModel';
+import { ReportMessageSheet } from '@/components/matches/report-message-sheet';
 import * as Haptics from 'expo-haptics';
 
 import type { MatchSortOption } from '@/components/matches/matches-header';
@@ -81,6 +82,7 @@ export default function Matches() {
   } | null>(null);
   const [isRestoring, setIsRestoring] = useState(false);
   const [showDeclineSheet, setShowDeclineSheet] = useState(false);
+  const [reportMatchId, setReportMatchId] = useState<Id<'matches'> | null>(null);
   const [showCelebration, setShowCelebration] = useState(false);
   const [celebrationName, setCelebrationName] = useState('');
 
@@ -476,6 +478,7 @@ export default function Matches() {
             onWithdraw={() =>
               handleWithdrawProposal(pendingProposal._id, pendingProposal.name?.name ?? '')
             }
+            onReport={() => setReportMatchId(pendingProposal._id)}
           />
         )}
 
@@ -543,6 +546,11 @@ export default function Matches() {
           nameName={pendingProposal?.name?.name ?? ''}
           onDecline={handleDeclineProposal}
           onClose={() => setShowDeclineSheet(false)}
+        />
+        <ReportMessageSheet
+          visible={reportMatchId !== null}
+          matchId={reportMatchId}
+          onClose={() => setReportMatchId(null)}
         />
 
         {/* Celebration modal */}

--- a/app/(tabs)/matches.tsx
+++ b/app/(tabs)/matches.tsx
@@ -31,6 +31,7 @@ import {
   DeclineSheet,
   CelebrationModal,
 } from '@/components/matches';
+import { ReportMessageSheet } from '@/components/matches/report-message-sheet';
 import { SearchInput } from '@/components/dashboard/search-input';
 import { NameDetailModal } from '@/components/name-detail/name-detail-modal';
 import { GradientBackground } from '@/components/ui/gradient-background';
@@ -38,7 +39,6 @@ import { MatchAnimation } from '@/components/ui/match-animation';
 import { LoadingScreen, useGracefulLoading } from '@/components/ui/loading-screen';
 import { LoadingIndicator } from '@/components/ui/loading-indicator';
 import { Doc, Id } from '@/convex/_generated/dataModel';
-import { ReportMessageSheet } from '@/components/matches/report-message-sheet';
 import * as Haptics from 'expo-haptics';
 
 import type { MatchSortOption } from '@/components/matches/matches-header';
@@ -123,6 +123,13 @@ export default function Matches() {
   const chosenName = useQuery(api.matches.getChosenName);
   const currentUser = useQuery(api.users.getCurrentUser);
   const pendingProposal = useQuery(api.matches.getPendingProposal);
+
+  // Close the report sheet if the proposal it targets disappears (partner
+  // withdrew/accepted, or unlinked) so it can't act on a stale match. (#185)
+  useEffect(() => {
+    if (!pendingProposal) setReportMatchId(null);
+  }, [pendingProposal]);
+
   const proposeNameMutation = useMutation(api.matches.proposeName);
   const respondToProposalMutation = useMutation(api.matches.respondToProposal);
   const withdrawProposalMutation = useMutation(api.matches.withdrawProposal);

--- a/components/matches/proposal-banner.tsx
+++ b/components/matches/proposal-banner.tsx
@@ -11,6 +11,7 @@ interface ProposalBannerProps {
   onAccept: () => void;
   onDecline: () => void;
   onWithdraw: () => void;
+  onReport: () => void;
 }
 
 export function ProposalBanner({
@@ -21,6 +22,7 @@ export function ProposalBanner({
   onAccept,
   onDecline,
   onWithdraw,
+  onReport,
 }: ProposalBannerProps) {
   const { colors } = useTheme();
 
@@ -59,6 +61,15 @@ export function ProposalBanner({
           </Text>
           {message ? <Text style={styles.bannerMessage}>&ldquo;{message}&rdquo;</Text> : null}
         </View>
+        <Pressable
+          style={styles.reportTrigger}
+          onPress={onReport}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel="Report message"
+        >
+          <Ionicons name="ellipsis-horizontal" size={20} color={colors.primary} />
+        </Pressable>
       </View>
       <View style={styles.bannerActions}>
         <Pressable
@@ -91,6 +102,12 @@ const styles = StyleSheet.create({
   },
   bannerTextContainer: {
     flex: 1,
+  },
+  reportTrigger: {
+    width: 44,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   bannerText: {
     fontSize: 15,

--- a/components/matches/report-message-sheet.tsx
+++ b/components/matches/report-message-sheet.tsx
@@ -1,0 +1,297 @@
+import { useState } from 'react';
+import {
+  View,
+  Text,
+  Pressable,
+  TextInput,
+  StyleSheet,
+  Alert,
+  ActivityIndicator,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useAction, useMutation } from 'convex/react';
+import * as Sentry from '@sentry/react-native';
+import { api } from '@/convex/_generated/api';
+import { Id } from '@/convex/_generated/dataModel';
+import { Fonts } from '@/constants/theme';
+import { useTheme } from '@/contexts/theme-context';
+import { AnimatedBottomSheet } from '@/components/ui/animated-bottom-sheet';
+import { Events, trackEvent } from '@/lib/analytics';
+
+const CATEGORIES = [
+  { key: 'abusive' as const, label: 'Abusive', icon: 'alert-circle-outline' as const },
+  { key: 'harmful' as const, label: 'Harmful', icon: 'warning-outline' as const },
+  { key: 'spam' as const, label: 'Spam', icon: 'mail-unread-outline' as const },
+  { key: 'other' as const, label: 'Other', icon: 'help-circle-outline' as const },
+];
+
+type ReportCategory = 'abusive' | 'harmful' | 'spam' | 'other';
+
+interface ReportMessageSheetProps {
+  visible: boolean;
+  matchId: Id<'matches'> | null;
+  onClose: () => void;
+}
+
+export function ReportMessageSheet({ visible, matchId, onClose }: ReportMessageSheetProps) {
+  const { colors } = useTheme();
+  const reportContent = useAction(api.feedback.reportContent);
+  const unlinkPartner = useMutation(api.partners.unlinkPartner);
+
+  const [category, setCategory] = useState<ReportCategory | null>(null);
+  const [notes, setNotes] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const resetAndClose = () => {
+    setCategory(null);
+    setNotes('');
+    setErrorMessage(null);
+    setShowSuccess(false);
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    if (!matchId || !category) return;
+    setIsSubmitting(true);
+    setErrorMessage(null);
+    try {
+      await reportContent({ matchId, category, notes: notes.trim() || undefined });
+      trackEvent(Events.CONTENT_REPORTED, { category });
+      setShowSuccess(true);
+      setTimeout(resetAndClose, 1800);
+    } catch (err) {
+      setErrorMessage('Could not send your report. Please try again.');
+      Sentry.captureException(err, { tags: { flow: 'content_report' } });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleUnlink = () => {
+    Alert.alert(
+      'Unlink Partner',
+      'Are you sure you want to unlink your partner? Your liked names will be kept, but matches between you will be cleared.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Unlink',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await unlinkPartner();
+              trackEvent(Events.PARTNER_UNLINKED);
+              resetAndClose();
+            } catch (error) {
+              Sentry.captureException(error);
+              Alert.alert('Error', 'Failed to unlink partner. Please try again.');
+            }
+          },
+        },
+      ],
+    );
+  };
+
+  return (
+    <AnimatedBottomSheet visible={visible} onClose={resetAndClose} maxHeight="70%">
+      <View style={styles.content}>
+        <View style={styles.handleBar} />
+
+        {showSuccess ? (
+          <View style={styles.successContainer}>
+            <Ionicons name="checkmark-circle" size={32} color={colors.primary} />
+            <Text style={styles.successText}>Thanks &mdash; we&rsquo;ll review this.</Text>
+          </View>
+        ) : (
+          <>
+            <Text style={styles.title}>Report Message</Text>
+            <Text style={styles.subtitle}>
+              Tell us what&rsquo;s wrong. Reports go to our team for review.
+            </Text>
+
+            <View style={styles.categoryRow}>
+              {CATEGORIES.map((cat) => {
+                const isSelected = category === cat.key;
+                return (
+                  <Pressable
+                    key={cat.key}
+                    style={[
+                      styles.categoryPill,
+                      {
+                        backgroundColor: isSelected ? colors.primary : colors.surface,
+                        borderColor: isSelected ? colors.primary : colors.border,
+                      },
+                    ]}
+                    onPress={() => setCategory(cat.key)}
+                    disabled={isSubmitting}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Report category: ${cat.label}`}
+                  >
+                    <Ionicons name={cat.icon} size={16} color={isSelected ? '#fff' : '#6B5B7B'} />
+                    <Text
+                      style={[styles.categoryLabel, { color: isSelected ? '#fff' : '#6B5B7B' }]}
+                    >
+                      {cat.label}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+
+            <TextInput
+              style={[
+                styles.notesInput,
+                { backgroundColor: colors.surfaceSubtle, borderColor: colors.border },
+              ]}
+              placeholder="Add context (optional)..."
+              placeholderTextColor="#A89BB5"
+              multiline
+              numberOfLines={3}
+              value={notes}
+              onChangeText={(t) => setNotes(t.slice(0, 2000))}
+              textAlignVertical="top"
+              editable={!isSubmitting}
+            />
+
+            <Pressable
+              style={[
+                styles.reportButton,
+                { backgroundColor: colors.primary },
+                (!category || isSubmitting) && styles.buttonDisabled,
+              ]}
+              onPress={handleSubmit}
+              disabled={!category || isSubmitting}
+              accessibilityRole="button"
+              accessibilityLabel="Submit report"
+            >
+              {isSubmitting ? (
+                <ActivityIndicator size="small" color="#fff" />
+              ) : (
+                <Text style={styles.reportButtonText}>Report</Text>
+              )}
+            </Pressable>
+
+            {errorMessage && <Text style={styles.errorText}>{errorMessage}</Text>}
+
+            <Pressable
+              style={styles.unlinkButton}
+              onPress={handleUnlink}
+              disabled={isSubmitting}
+              accessibilityRole="button"
+              accessibilityLabel="Unlink partner"
+            >
+              <Ionicons name="close-circle-outline" size={18} color="#ef4444" />
+              <Text style={styles.unlinkButtonText}>Unlink Partner</Text>
+            </Pressable>
+          </>
+        )}
+      </View>
+    </AnimatedBottomSheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    paddingHorizontal: 24,
+    paddingBottom: 36,
+  },
+  handleBar: {
+    width: 40,
+    height: 4,
+    backgroundColor: '#E5E7EB',
+    borderRadius: 2,
+    alignSelf: 'center',
+    marginTop: 12,
+    marginBottom: 20,
+  },
+  title: {
+    fontSize: 18,
+    fontFamily: Fonts?.title || 'Gabarito_800ExtraBold',
+    color: '#2D1B4E',
+    marginBottom: 6,
+  },
+  subtitle: {
+    fontSize: 14,
+    fontFamily: Fonts?.sans,
+    color: '#6B5B7B',
+    marginBottom: 16,
+  },
+  categoryRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 12,
+  },
+  categoryPill: {
+    flex: 1,
+    borderRadius: 10,
+    borderWidth: 1,
+    paddingVertical: 10,
+    paddingHorizontal: 4,
+    alignItems: 'center',
+    gap: 4,
+  },
+  categoryLabel: {
+    fontSize: 11,
+    fontFamily: Fonts?.sans,
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  notesInput: {
+    borderRadius: 12,
+    borderWidth: 1,
+    padding: 14,
+    fontSize: 15,
+    fontFamily: Fonts?.sans,
+    color: '#2D1B4E',
+    minHeight: 90,
+    marginBottom: 16,
+  },
+  reportButton: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 16,
+    borderRadius: 12,
+  },
+  reportButtonText: {
+    fontSize: 16,
+    fontFamily: Fonts?.sans,
+    fontWeight: '600',
+    color: '#fff',
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  errorText: {
+    fontSize: 13,
+    fontFamily: Fonts?.sans,
+    color: '#FF6B6B',
+    textAlign: 'center',
+    marginTop: 8,
+  },
+  unlinkButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    paddingVertical: 14,
+    marginTop: 8,
+  },
+  unlinkButtonText: {
+    fontSize: 15,
+    fontFamily: Fonts?.sans,
+    fontWeight: '600',
+    color: '#ef4444',
+  },
+  successContainer: {
+    paddingVertical: 32,
+    alignItems: 'center',
+    gap: 8,
+  },
+  successText: {
+    fontSize: 16,
+    fontFamily: Fonts?.sans,
+    fontWeight: '600',
+    color: '#2D1B4E',
+  },
+});

--- a/components/matches/report-message-sheet.tsx
+++ b/components/matches/report-message-sheet.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -43,8 +43,19 @@ export function ReportMessageSheet({ visible, matchId, onClose }: ReportMessageS
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const successTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (successTimer.current) clearTimeout(successTimer.current);
+    };
+  }, []);
 
   const resetAndClose = () => {
+    if (successTimer.current) {
+      clearTimeout(successTimer.current);
+      successTimer.current = null;
+    }
     setCategory(null);
     setNotes('');
     setErrorMessage(null);
@@ -60,7 +71,7 @@ export function ReportMessageSheet({ visible, matchId, onClose }: ReportMessageS
       await reportContent({ matchId, category, notes: notes.trim() || undefined });
       trackEvent(Events.CONTENT_REPORTED, { category });
       setShowSuccess(true);
-      setTimeout(resetAndClose, 1800);
+      successTimer.current = setTimeout(resetAndClose, 1800);
     } catch (err) {
       setErrorMessage('Could not send your report. Please try again.');
       Sentry.captureException(err, { tags: { flow: 'content_report' } });
@@ -126,6 +137,7 @@ export function ReportMessageSheet({ visible, matchId, onClose }: ReportMessageS
                     onPress={() => setCategory(cat.key)}
                     disabled={isSubmitting}
                     accessibilityRole="button"
+                    accessibilityState={{ selected: isSelected, disabled: isSubmitting }}
                     accessibilityLabel={`Report category: ${cat.label}`}
                   >
                     <Ionicons name={cat.icon} size={16} color={isSelected ? '#fff' : '#6B5B7B'} />
@@ -152,6 +164,7 @@ export function ReportMessageSheet({ visible, matchId, onClose }: ReportMessageS
               onChangeText={(t) => setNotes(t.slice(0, 2000))}
               textAlignVertical="top"
               editable={!isSubmitting}
+              accessibilityLabel="Additional context for your report"
             />
 
             <Pressable

--- a/components/matches/report-message-sheet.tsx
+++ b/components/matches/report-message-sheet.tsx
@@ -51,6 +51,18 @@ export function ReportMessageSheet({ visible, matchId, onClose }: ReportMessageS
     };
   }, []);
 
+  // Reset to a clean slate each time the sheet opens, so nothing leaks from a
+  // previous session — including when the parent force-closes it by clearing
+  // the target match (see matches.tsx). (#185)
+  useEffect(() => {
+    if (visible) {
+      setCategory(null);
+      setNotes('');
+      setErrorMessage(null);
+      setShowSuccess(false);
+    }
+  }, [visible]);
+
   const resetAndClose = () => {
     if (successTimer.current) {
       clearTimeout(successTimer.current);

--- a/convex/feedback.ts
+++ b/convex/feedback.ts
@@ -1,5 +1,5 @@
 import { v } from 'convex/values';
-import { action, internalMutation } from './_generated/server';
+import { action, internalMutation, internalQuery } from './_generated/server';
 import { internal } from './_generated/api';
 
 const CATEGORY_LABELS: Record<string, string> = {
@@ -12,6 +12,13 @@ const CATEGORY_EMOJI: Record<string, string> = {
   bug: ':bug:',
   feature: ':bulb:',
   general: ':speech_balloon:',
+};
+
+const REPORT_CATEGORY_LABELS: Record<string, string> = {
+  abusive: 'Abusive',
+  harmful: 'Harmful / Threatening',
+  spam: 'Spam',
+  other: 'Other',
 };
 
 // #171: minimum gap between feedback submissions per user, to stop a single
@@ -164,6 +171,140 @@ export const submitFeedback = action({
 
     if (!response.ok) {
       throw new Error('Failed to send feedback to Slack');
+    }
+
+    return { success: true };
+  },
+});
+
+/**
+ * #185: Authorizes a content report and resolves the reported message + its
+ * author. Internal query called by the reportContent action (actions can't
+ * touch the DB directly). Throws if the caller isn't a member of the match.
+ */
+export const getReportTarget = internalQuery({
+  args: { clerkId: v.string(), matchId: v.id('matches') },
+  handler: async (ctx, args) => {
+    const user = await ctx.db
+      .query('users')
+      .withIndex('by_clerk_id', (q) => q.eq('clerkId', args.clerkId))
+      .first();
+    if (!user) {
+      throw new Error('User not found');
+    }
+
+    const match = await ctx.db.get(args.matchId);
+    if (!match) {
+      throw new Error('This match is no longer available.');
+    }
+    if (match.user1Id !== user._id && match.user2Id !== user._id) {
+      throw new Error('Not authorized');
+    }
+
+    // The proposer authored the proposalMessage. Fall back to "the other
+    // member" if proposedBy is somehow unset.
+    const proposerId =
+      match.proposedBy ?? (match.user1Id === user._id ? match.user2Id : match.user1Id);
+    const proposer = await ctx.db.get(proposerId);
+
+    return {
+      reportedMessage: match.proposalMessage ?? null,
+      proposerName: proposer?.name ?? 'Unknown',
+      proposerEmail: proposer?.email ?? 'No email',
+    };
+  },
+});
+
+/**
+ * #185: User-facing report for partner UGC (the proposal message). Reuses the
+ * feedback rate-limit gate and Slack sanitization, posting a report to the
+ * team's Slack channel with a distinct header so it's separable from feedback.
+ */
+export const reportContent = action({
+  args: {
+    matchId: v.id('matches'),
+    category: v.union(
+      v.literal('abusive'),
+      v.literal('harmful'),
+      v.literal('spam'),
+      v.literal('other'),
+    ),
+    notes: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error('Not authenticated');
+    }
+
+    const trimmedNotes = (args.notes ?? '').trim();
+    if (trimmedNotes.length > MAX_FEEDBACK_LENGTH) {
+      throw new Error(`Report notes must be ${MAX_FEEDBACK_LENGTH} characters or fewer.`);
+    }
+
+    const webhookUrl = process.env.SLACK_FEEDBACK_WEBHOOK_URL;
+    if (!webhookUrl) {
+      throw new Error('Slack webhook URL not configured');
+    }
+
+    // Reuse the per-user feedback throttle (shared 60s window) so reports
+    // can't be flooded either. Throws ("Please wait a minute…") if too soon.
+    await ctx.runMutation(internal.feedback.checkAndRecordFeedbackRateLimit, {
+      clerkId: identity.subject,
+    });
+
+    const target = await ctx.runQuery(internal.feedback.getReportTarget, {
+      clerkId: identity.subject,
+      matchId: args.matchId,
+    });
+
+    const categoryLabel = REPORT_CATEGORY_LABELS[args.category];
+    const safeReporterName = sanitizeSlackText(identity.name ?? 'Unknown');
+    const safeReporterEmail = sanitizeSlackText(identity.email ?? 'No email');
+    const safeProposerName = sanitizeSlackText(target.proposerName);
+    const safeProposerEmail = sanitizeSlackText(target.proposerEmail);
+    const safeMessage = sanitizeSlackText(target.reportedMessage ?? '(no message)');
+    const safeNotes = trimmedNotes ? sanitizeSlackText(trimmedNotes) : '(none)';
+
+    const payload = {
+      blocks: [
+        {
+          type: 'header',
+          text: { type: 'plain_text', text: ':rotating_light: [Content Report]', emoji: true },
+        },
+        {
+          type: 'section',
+          text: { type: 'plain_text', text: `Category: ${categoryLabel}`, emoji: false },
+        },
+        {
+          type: 'section',
+          text: { type: 'plain_text', text: `Reported message:\n${safeMessage}`, emoji: false },
+        },
+        {
+          type: 'section',
+          text: { type: 'plain_text', text: `Reporter notes:\n${safeNotes}`, emoji: false },
+        },
+        {
+          type: 'context',
+          elements: [
+            { type: 'mrkdwn', text: '*Reporter:*' },
+            { type: 'plain_text', text: `${safeReporterName} (${safeReporterEmail})`, emoji: false },
+            { type: 'mrkdwn', text: '*Reported user:*' },
+            { type: 'plain_text', text: `${safeProposerName} (${safeProposerEmail})`, emoji: false },
+            { type: 'mrkdwn', text: `*Match:* ${args.matchId} — ${new Date().toISOString()}` },
+          ],
+        },
+      ],
+    };
+
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to send report to Slack');
     }
 
     return { success: true };

--- a/convex/feedback.ts
+++ b/convex/feedback.ts
@@ -291,7 +291,7 @@ export const reportContent = action({
             { type: 'plain_text', text: `${safeReporterName} (${safeReporterEmail})`, emoji: false },
             { type: 'mrkdwn', text: '*Reported user:*' },
             { type: 'plain_text', text: `${safeProposerName} (${safeProposerEmail})`, emoji: false },
-            { type: 'mrkdwn', text: `*Match:* ${args.matchId} — ${new Date().toISOString()}` },
+            { type: 'mrkdwn', text: `*Match:* ${sanitizeSlackText(String(args.matchId))} — ${new Date().toISOString()}` },
           ],
         },
       ],

--- a/docs/app-review-1.2.md
+++ b/docs/app-review-1.2.md
@@ -1,0 +1,23 @@
+# App Review notes — Guideline 1.2 (User-Generated Content)
+
+Bambino lets two linked partners exchange private, pairwise text (a "proposal
+message" attached to a name proposal). It is never broadcast beyond the pair.
+
+How Bambino satisfies Guideline 1.2:
+
+- **Filter objectionable material:** UGC is private 1:1 and not publicly
+  discoverable, so there is no public feed to pre-moderate.
+- **Report offensive content + timely response:** A "Report message" control on
+  the proposal banner (tap the overflow / three-dot icon) lets a user flag a
+  partner's message by category (Abusive / Harmful / Spam / Other) with optional
+  context. Reports are delivered to our team's Slack channel and triaged; users
+  can also reach us at hello@bambinobaby.xyz.
+- **Block abusive users:** "Unlink Partner" (available in the same report sheet
+  and in Profile) immediately severs the connection and clears shared matches,
+  stopping all further messages from that partner.
+- **Published contact information:** hello@bambinobaby.xyz, listed in our
+  privacy policy.
+
+Reviewer repro steps: link two accounts via share code, propose a name with a
+note from account A, then on account B tap the overflow control on the proposal
+banner to Report or Unlink.

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -65,6 +65,9 @@ export const Events = {
   PARTNER_LINKED: 'partner_linked',
   PARTNER_UNLINKED: 'partner_unlinked',
 
+  // Safety
+  CONTENT_REPORTED: 'content_reported',
+
   // Settings
   THEME_CHANGED: 'theme_changed',
   SKIN_TONE_CHANGED: 'skin_tone_changed',


### PR DESCRIPTION
Closes #185.

## Why

Partners exchange free-text content (proposal messages) that the other partner sees. Apple **App Store Review Guideline 1.2 (User-Generated Content)** requires apps with UGC to provide *both* a **mechanism to report offensive content** and the **ability to block abusive users** — these are two separate required bullets. We had the block (Unlink Partner) but no report mechanism, which is a known 1.2 rejection pattern. This adds the missing report flow and surfaces unlink alongside it.

## Scope decision (narrower than the issue's original acceptance list)

#185 listed three surfaces (notes, proposalMessage, declineMessage). Tracing where partner content is actually *displayed to a recipient*:

| Content | Shown to recipient? | In scope |
|---|---|---|
| `proposalMessage` | Yes — `proposal-banner.tsx` (recipient branch) | ✅ |
| `notes` | A shared, co-edited match field you can already edit/delete yourself | ❌ |
| `declineMessage` | Stored but **never rendered** anywhere in the app | ❌ |

So the report affordance lives on the **proposal banner only** — the single genuine "receive" surface. A consent/approval step before partner linking was also considered and is **not required by 1.2** (report + block satisfies it); left as a possible future safety improvement, out of scope here.

## How 1.2 is satisfied
- **Report (flag):** overflow control on the proposal banner → category (Abusive/Harmful/Spam/Other) + optional notes → routed to the team Slack channel (reuses the `submitFeedback` rate-limit + injection-sanitization infra).
- **Block:** Unlink Partner, surfaced in the same sheet.
- **Contact:** `hello@bambinobaby.xyz` (existing).
- Documented for reviewers in `docs/app-review-1.2.md`.

## Changes
- `convex/feedback.ts` — `reportContent` action + `getReportTarget` internal query (auth + match-membership gated; reuses `checkAndRecordFeedbackRateLimit` + `sanitizeSlackText`; distinct `:rotating_light: [Content Report]` Slack header).
- `components/matches/report-message-sheet.tsx` — Report + Unlink bottom sheet (category pills, optional notes, a11y labels/state, success + error states, timer cleanup, reset-on-open).
- `components/matches/proposal-banner.tsx` — overflow trigger in the recipient branch only (44pt target, `accessibilityLabel`).
- `app/(tabs)/matches.tsx` — sheet state + wiring; auto-closes the sheet if the pending proposal clears (stale-match guard).
- `lib/analytics.ts` — `CONTENT_REPORTED` event.
- `docs/app-review-1.2.md` — App Review notes.

## Test plan
- `npm run lint` — 0 errors (only pre-existing warnings in untouched files).
- `npx tsc --noEmit` — exit 0, no type errors.
- `npx expo export --platform ios` — bundles clean.
- Manual (two linked accounts): propose with a note → recipient opens overflow → Report → confirmed `[Content Report]` lands in Slack with the message + reporter + reported user → Unlink from the same sheet → banner clears. ✅ Verified.

> Note: the new Convex functions are deployed to dev; the **prod** deployment will need `npx convex deploy` before the App Store build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)