### PR TITLE
fix: migrate Convex errors to ConvexError with typed codes (#178)

### DIFF
--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -29,12 +29,27 @@ import { useEffectivePremium } from '@/hooks/use-effective-premium';
 import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { trackScreen } from '@/lib/analytics';
+import { decodeConvexError } from '@/lib/convex-errors';
 import { GradientBackground } from '@/components/ui/gradient-background';
 import { BubblePillsBackground } from '@/components/ui/bubble-pills-background';
 import { LoadingIndicator } from '@/components/ui/loading-indicator';
 import { Doc, Id } from '@/convex/_generated/dataModel';
 
 type TabType = 'liked' | 'rejected';
+
+/**
+ * Decode a Convex selection-mutation failure into a specific alert. A
+ * SELECTION_NOT_FOUND means the row was already gone — the dashboard's reactive
+ * queries self-heal, so it's a silent no-op rather than an error. Everything
+ * else is reported and shows the decoded message instead of a generic alert.
+ */
+function alertSelectionMutationError(error: unknown, fallback: string) {
+  const { code, message } = decodeConvexError(error, fallback);
+  if (code === 'SELECTION_NOT_FOUND') return;
+  Sentry.captureException(error);
+  Alert.alert("Couldn't update that", message);
+}
+
 const BULK_BATCH_SIZE = 25;
 // Pagination batch size for liked/rejected queries (#170). Tuned for the
 // dashboard list — large enough that most users finish in 1-2 pages, small
@@ -178,8 +193,7 @@ export default function Dashboard() {
     try {
       await removeFromLiked({ selectionId: selectedItem.selectionId });
     } catch (error) {
-      Sentry.captureException(error);
-      Alert.alert('Error', 'Failed to remove name. Please try again.');
+      alertSelectionMutationError(error, 'Could not remove this name.');
     }
     setSelectedItem(null);
   };
@@ -190,8 +204,7 @@ export default function Dashboard() {
     try {
       await restoreToQueue({ selectionId: selectedItem.selectionId });
     } catch (error) {
-      Sentry.captureException(error);
-      Alert.alert('Error', 'Failed to restore name. Please try again.');
+      alertSelectionMutationError(error, 'Could not restore this name.');
     }
     setSelectedItem(null);
   };
@@ -202,8 +215,7 @@ export default function Dashboard() {
     try {
       await hidePermanently({ selectionId: selectedItem.selectionId });
     } catch (error) {
-      Sentry.captureException(error);
-      Alert.alert('Error', 'Failed to hide name. Please try again.');
+      alertSelectionMutationError(error, 'Could not hide this name.');
     }
     setSelectedItem(null);
   };
@@ -319,7 +331,8 @@ export default function Dashboard() {
       } catch (error) {
         Sentry.captureException(error);
         setSelectedIds(new Set());
-        Alert.alert('Error', errorMessage);
+        const { message } = decodeConvexError(error, errorMessage);
+        Alert.alert("Couldn't update those", message);
       } finally {
         bulkLoadingRef.current = false;
         setBulkAction(null);

--- a/app/(tabs)/matches.tsx
+++ b/app/(tabs)/matches.tsx
@@ -20,6 +20,7 @@ import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { useEffectivePremium } from '@/hooks/use-effective-premium';
 import { Events, trackEvent, trackScreen } from '@/lib/analytics';
+import { alertMatchMutationError } from '@/components/matches/match-error-alert';
 import { usePurchases } from '@/hooks/use-purchases';
 import { Paywall } from '@/components/paywall';
 import {
@@ -172,8 +173,7 @@ export default function Matches() {
         setProposeTarget(null);
         setProposalConflict(null);
       } catch (error) {
-        Sentry.captureException(error);
-        Alert.alert('Error', 'Failed to propose name. Please try again.');
+        alertMatchMutationError(error, 'Could not propose this name.');
       }
     },
     [proposeNameMutation],
@@ -199,8 +199,7 @@ export default function Matches() {
       setShowCelebration(true);
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
     } catch (error) {
-      Sentry.captureException(error);
-      Alert.alert('Error', 'Failed to accept proposal. Please try again.');
+      alertMatchMutationError(error, 'Could not accept this proposal.');
     }
   }, [pendingProposal, respondToProposalMutation]);
 
@@ -217,8 +216,7 @@ export default function Matches() {
         setShowDeclineSheet(false);
         Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
       } catch (error) {
-        Sentry.captureException(error);
-        Alert.alert('Error', 'Failed to decline proposal. Please try again.');
+        alertMatchMutationError(error, 'Could not decline this proposal.');
       }
     },
     [pendingProposal, respondToProposalMutation],
@@ -239,8 +237,7 @@ export default function Matches() {
                 trackEvent(Events.PROPOSAL_WITHDRAWN);
                 Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
               } catch (error) {
-                Sentry.captureException(error);
-                Alert.alert('Error', 'Failed to withdraw proposal. Please try again.');
+                alertMatchMutationError(error, 'Could not withdraw this proposal.');
               }
             },
           },

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -7,6 +7,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useCallback, useRef, useState } from 'react';
 import { useFocusEffect } from 'expo-router';
 import { Events, resetAnalytics, trackEvent, trackScreen } from '@/lib/analytics';
+import { decodeConvexError } from '@/lib/convex-errors';
 import {
   Alert,
   Pressable,
@@ -292,7 +293,8 @@ export default function Profile() {
               await regenerateShareCode();
             } catch (error) {
               Sentry.captureException(error);
-              Alert.alert('Error', 'Failed to generate a new code. Please try again.');
+              const { message } = decodeConvexError(error, 'Could not generate a new code.');
+              Alert.alert("Couldn't generate a code", message);
             } finally {
               setIsRegeneratingCode(false);
             }
@@ -318,7 +320,8 @@ export default function Profile() {
               trackEvent(Events.PARTNER_UNLINKED);
             } catch (error) {
               Sentry.captureException(error);
-              Alert.alert('Error', 'Failed to unlink partner. Please try again.');
+              const { message } = decodeConvexError(error, 'Could not unlink your partner.');
+              Alert.alert("Couldn't unlink", message);
             } finally {
               setIsUnlinking(false);
             }

--- a/components/matches/match-detail-modal.tsx
+++ b/components/matches/match-detail-modal.tsx
@@ -11,6 +11,8 @@ import * as Haptics from 'expo-haptics';
 import * as Sentry from '@sentry/react-native';
 import { AnimatedBottomSheet } from '@/components/ui/animated-bottom-sheet';
 import { Events, trackEvent } from '@/lib/analytics';
+import { alertMatchMutationError } from '@/components/matches/match-error-alert';
+import { decodeConvexError } from '@/lib/convex-errors';
 
 interface MatchDetailModalProps {
   visible: boolean;
@@ -66,8 +68,7 @@ export function MatchDetailModal({ visible, match, onClose }: MatchDetailModalPr
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       onClose();
     } catch (error) {
-      Sentry.captureException(error);
-      Alert.alert('Error', 'Failed to save changes. Please try again.');
+      alertMatchMutationError(error, 'Could not save your changes.');
     } finally {
       setIsSaving(false);
     }
@@ -82,7 +83,7 @@ export function MatchDetailModal({ visible, match, onClose }: MatchDetailModalPr
       trackEvent(Events.MATCH_FAVORITED, { favorited: !isFavorite });
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     } catch (error) {
-      Sentry.captureException(error);
+      alertMatchMutationError(error, 'Could not update this favorite.');
     }
   };
 
@@ -104,8 +105,7 @@ export function MatchDetailModal({ visible, match, onClose }: MatchDetailModalPr
               Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
               onClose();
             } catch (error) {
-              Sentry.captureException(error);
-              Alert.alert('Error', 'Failed to choose name. Please try again.');
+              alertMatchMutationError(error, 'Could not choose this name.');
             }
           },
         },
@@ -129,8 +129,15 @@ export function MatchDetailModal({ visible, match, onClose }: MatchDetailModalPr
               Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
               onClose();
             } catch (error) {
+              const { code, message } = decodeConvexError(error, 'Could not remove this match.');
+              // Already gone (removed elsewhere, or the partnership ended) —
+              // the user's goal is met, so just close quietly.
+              if (code === 'MATCH_NOT_FOUND' || code === 'MATCH_FROM_PREVIOUS_PARTNERSHIP') {
+                onClose();
+                return;
+              }
               Sentry.captureException(error);
-              Alert.alert('Error', 'Failed to remove match. Please try again.');
+              Alert.alert("Couldn't remove match", message);
             }
           },
         },

--- a/components/matches/match-error-alert.ts
+++ b/components/matches/match-error-alert.ts
@@ -1,0 +1,34 @@
+import { Alert } from 'react-native';
+import * as Sentry from '@sentry/react-native';
+import { decodeConvexError } from '@/lib/convex-errors';
+
+/**
+ * Decode a Convex match-mutation failure and surface a specific, actionable
+ * alert. Predictable outcomes (a deleted match, a stale partnership, a proposal
+ * that's no longer pending) are expected control flow rather than bugs — they
+ * skip Sentry, and the matches/proposal screens self-heal via their reactive
+ * queries. Unknown codes and non-Convex (e.g. network) failures are reported
+ * and show the decoded server message instead of a generic "please try again".
+ */
+export function alertMatchMutationError(error: unknown, fallback: string) {
+  const { code, message } = decodeConvexError(error, fallback);
+  switch (code) {
+    case 'MATCH_NOT_FOUND':
+    case 'MATCH_FROM_PREVIOUS_PARTNERSHIP':
+      Alert.alert(
+        'Match unavailable',
+        'This match is no longer available. Your list will refresh.',
+      );
+      return;
+    case 'NO_PARTNER_LINKED':
+      Alert.alert('No partner linked', 'Link a partner first to do this.');
+      return;
+    case 'NO_PENDING_PROPOSAL':
+    case 'PROPOSAL_NOT_PENDING':
+      Alert.alert('Proposal unavailable', 'This proposal is no longer pending.');
+      return;
+    default:
+      Sentry.captureException(error);
+      Alert.alert("Couldn't complete that", message);
+  }
+}

--- a/components/matches/report-message-sheet.tsx
+++ b/components/matches/report-message-sheet.tsx
@@ -17,6 +17,7 @@ import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { AnimatedBottomSheet } from '@/components/ui/animated-bottom-sheet';
 import { Events, trackEvent } from '@/lib/analytics';
+import { decodeConvexError } from '@/lib/convex-errors';
 
 const CATEGORIES = [
   { key: 'abusive' as const, label: 'Abusive', icon: 'alert-circle-outline' as const },
@@ -108,7 +109,8 @@ export function ReportMessageSheet({ visible, matchId, onClose }: ReportMessageS
               resetAndClose();
             } catch (error) {
               Sentry.captureException(error);
-              Alert.alert('Error', 'Failed to unlink partner. Please try again.');
+              const { message } = decodeConvexError(error, 'Could not unlink your partner.');
+              Alert.alert("Couldn't unlink", message);
             }
           },
         },

--- a/components/partner/partner-link-modal.tsx
+++ b/components/partner/partner-link-modal.tsx
@@ -18,6 +18,7 @@ import { Paywall } from '@/components/paywall';
 import * as Sentry from '@sentry/react-native';
 import { useTheme } from '@/contexts/theme-context';
 import { Events, trackEvent } from '@/lib/analytics';
+import { decodeConvexError } from '@/lib/convex-errors';
 import { AnimatedBottomSheet } from '@/components/ui/animated-bottom-sheet';
 import { StyledInput } from '@/components/ui/styled-input';
 import { NameConfirmationModal } from './name-confirmation-modal';
@@ -87,9 +88,11 @@ export function PartnerLinkModal({ visible, onClose }: PartnerLinkModalProps) {
         setPreview({ name: result.name, imageUrl: result.imageUrl });
       }
     } catch (err) {
-      // Rate-limit errors come back here as plain Error messages — surface
-      // them verbatim so the user sees "Try again in N minutes".
-      setError(err instanceof Error ? err.message : 'An error occurred. Please try again.');
+      // Thrown failures here are rate-limit (RATE_LIMITED) or auth errors,
+      // now ConvexError. Decode so the user sees "Try again in N minutes"
+      // rather than the raw "[CONVEX M(...)] ..." framing.
+      const { message } = decodeConvexError(err, 'An error occurred. Please try again.');
+      setError(message);
       Sentry.captureException(err, { tags: { flow: 'partner_preview' } });
     } finally {
       setIsLookingUp(false);
@@ -128,7 +131,11 @@ export function PartnerLinkModal({ visible, onClose }: PartnerLinkModalProps) {
       trackEvent(Events.PARTNER_LINKED);
       handleClose();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to link partner');
+      // linkPartner throws specific ConvexErrors (CANNOT_LINK_SELF,
+      // TARGET_ALREADY_HAS_PARTNER, RATE_LIMITED, …) — decode to show the
+      // actionable message instead of a generic "Failed to link partner".
+      const { message } = decodeConvexError(err, 'Failed to link partner');
+      setError(message);
       Sentry.captureException(err, { tags: { flow: 'partner_link' } });
       setIsLinking(false);
     }

--- a/components/swipe/swipe-card-stack.tsx
+++ b/components/swipe/swipe-card-stack.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation } from 'convex/react';
 import { useRouter, useFocusEffect } from 'expo-router';
 import * as Sentry from '@sentry/react-native';
 import { trackEvent, Events } from '@/lib/analytics';
+import { decodeConvexError } from '@/lib/convex-errors';
 import { api } from '@/convex/_generated/api';
 import { Doc } from '@/convex/_generated/dataModel';
 import { SwipeCard } from './swipe-card';
@@ -85,6 +86,9 @@ export function SwipeCardStack() {
   const [showPaywall, setShowPaywall] = useState(false);
   const [showDetailModal, setShowDetailModal] = useState(false);
   const [showErrorToast, setShowErrorToast] = useState(false);
+  const [errorToastMessage, setErrorToastMessage] = useState(
+    'Something went wrong. Please try again.',
+  );
   const [hintEligible, setHintEligible] = useState(true);
   const [showPushPriming, setShowPushPriming] = useState(false);
 
@@ -181,7 +185,10 @@ export function SwipeCardStack() {
         }
       } catch (error: unknown) {
         Sentry.captureException(error);
+        // Roll back the optimistic removal so the card returns to the queue.
         setLocalQueue((prev) => [currentName, ...prev]);
+        const { message } = decodeConvexError(error, 'Something went wrong. Please try again.');
+        setErrorToastMessage(message);
         setShowErrorToast(true);
       }
     },
@@ -272,7 +279,7 @@ export function SwipeCardStack() {
       {/* Swipe error toast */}
       <ErrorToast
         visible={showErrorToast}
-        message="Something went wrong. Please try again."
+        message={errorToastMessage}
         onDismiss={() => setShowErrorToast(false)}
       />
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -9,6 +9,7 @@
  */
 
 import type * as admin from "../admin.js";
+import type * as errors from "../errors.js";
 import type * as feedback from "../feedback.js";
 import type * as matches from "../matches.js";
 import type * as names from "../names.js";
@@ -28,6 +29,7 @@ import type {
 
 declare const fullApi: ApiFromModules<{
   admin: typeof admin;
+  errors: typeof errors;
   feedback: typeof feedback;
   matches: typeof matches;
   names: typeof names;

--- a/convex/errors.ts
+++ b/convex/errors.ts
@@ -1,0 +1,58 @@
+import { ConvexError } from 'convex/values';
+
+/**
+ * Canonical set of structured error codes thrown by Convex mutations.
+ *
+ * The mobile client switches on these via `decodeConvexError`
+ * (`lib/convex-errors.ts`) to show specific, actionable messages instead of a
+ * generic "please try again". Plain `throw new Error('...')` is redacted to
+ * "Server Error" in production by Convex — only `ConvexError` data survives the
+ * wire, which is why every user-facing mutation failure goes through here.
+ *
+ * NOTE: returned-object discriminants (e.g. `NAME_NOT_CONFIRMED`,
+ * `FREE_TIER_PARTNER_LIMIT`, `PARTNER_HAS_PENDING_PROPOSAL`) are a separate,
+ * intentional pattern — they are *values returned* from mutations, not thrown
+ * errors, so they are NOT part of this union.
+ */
+export type ConvexErrorCode =
+  // Shared / auth
+  | 'UNAUTHENTICATED'
+  | 'USER_NOT_FOUND'
+  // partners.ts
+  | 'SHARE_CODE_GENERATION_FAILED'
+  | 'INVALID_SHARE_CODE'
+  | 'CODE_NOT_FOUND'
+  | 'CANNOT_LINK_SELF'
+  | 'PARTNER_ALREADY_LINKED'
+  | 'TARGET_ALREADY_HAS_PARTNER'
+  | 'NO_PARTNER_LINKED'
+  | 'RATE_LIMITED'
+  // matches.ts
+  | 'MATCH_NOT_FOUND'
+  | 'NOT_AUTHORIZED'
+  | 'MATCH_FROM_PREVIOUS_PARTNERSHIP'
+  | 'NOTES_TOO_LONG'
+  | 'MESSAGE_TOO_LONG'
+  | 'NO_PENDING_PROPOSAL'
+  | 'CANNOT_RESPOND_OWN_PROPOSAL'
+  | 'NOT_PROPOSER'
+  | 'PROPOSAL_NOT_PENDING'
+  // selections.ts
+  | 'SELECTION_NOT_FOUND'
+  | 'BULK_LIMIT_EXCEEDED';
+
+export interface ConvexErrorData {
+  code: ConvexErrorCode;
+  message: string;
+  /** Optional structured extras (e.g. RATE_LIMITED carries `retryAfterMs`). */
+  [key: string]: unknown;
+}
+
+/**
+ * Build a `ConvexError` with a structured `{ code, message }` payload that the
+ * client can decode. `extra` adds machine-readable fields alongside the
+ * human-readable message (e.g. `{ retryAfterMs }`).
+ */
+export function convexError(code: ConvexErrorCode, message: string, extra?: Record<string, unknown>) {
+  return new ConvexError({ code, message, ...extra });
+}

--- a/convex/matches.ts
+++ b/convex/matches.ts
@@ -2,11 +2,12 @@ import { v } from 'convex/values';
 import { mutation, query, QueryCtx, MutationCtx } from './_generated/server';
 import { internal } from './_generated/api';
 import { Doc, Id } from './_generated/dataModel';
+import { convexError } from './errors';
 
 async function getCurrentUserOrThrow(ctx: QueryCtx | MutationCtx) {
   const identity = await ctx.auth.getUserIdentity();
   if (!identity) {
-    throw new Error('Not authenticated');
+    throw convexError('UNAUTHENTICATED', 'Not authenticated');
   }
 
   // #164: tolerant read — a stray duplicate clerkId row shouldn't throw and
@@ -17,7 +18,7 @@ async function getCurrentUserOrThrow(ctx: QueryCtx | MutationCtx) {
     .first();
 
   if (!user) {
-    throw new Error('User not found');
+    throw convexError('USER_NOT_FOUND', 'User not found');
   }
 
   return user;
@@ -50,11 +51,11 @@ function getOtherUserId(match: Doc<'matches'>, userId: Id<'users'>): Id<'users'>
 
 function assertCurrentPartner(user: Doc<'users'>, match: Doc<'matches'>) {
   if (match.user1Id !== user._id && match.user2Id !== user._id) {
-    throw new Error('Not authorized to update this match');
+    throw convexError('NOT_AUTHORIZED', 'Not authorized to update this match');
   }
   const otherId = getOtherUserId(match, user._id);
   if (user.partnerId !== otherId) {
-    throw new Error('This match is from a previous partnership');
+    throw convexError('MATCH_FROM_PREVIOUS_PARTNERSHIP', 'This match is from a previous partnership');
   }
 }
 
@@ -167,14 +168,14 @@ export const updateMatch = mutation({
   },
   handler: async (ctx, args) => {
     if (args.notes !== undefined && args.notes.length > 2000) {
-      throw new Error('Notes must be 2000 characters or fewer');
+      throw convexError('NOTES_TOO_LONG', 'Notes must be 2000 characters or fewer');
     }
 
     const user = await getCurrentUserOrThrow(ctx);
 
     const match = await ctx.db.get(args.matchId);
     if (!match) {
-      throw new Error('Match not found');
+      throw convexError('MATCH_NOT_FOUND', 'Match not found');
     }
 
     assertCurrentPartner(user, match);
@@ -224,18 +225,18 @@ export const proposeName = mutation({
   },
   handler: async (ctx, args) => {
     if (args.message !== undefined && args.message.length > 200) {
-      throw new Error('Message must be 200 characters or fewer');
+      throw convexError('MESSAGE_TOO_LONG', 'Message must be 200 characters or fewer');
     }
 
     const user = await getCurrentUserOrThrow(ctx);
 
     if (!user.partnerId) {
-      throw new Error('No partner linked');
+      throw convexError('NO_PARTNER_LINKED', 'No partner linked');
     }
 
     const match = await ctx.db.get(args.matchId);
     if (!match) {
-      throw new Error('Match not found');
+      throw convexError('MATCH_NOT_FOUND', 'Match not found');
     }
 
     assertCurrentPartner(user, match);
@@ -334,24 +335,24 @@ export const respondToProposal = mutation({
   },
   handler: async (ctx, args) => {
     if (args.message !== undefined && args.message.length > 200) {
-      throw new Error('Message must be 200 characters or fewer');
+      throw convexError('MESSAGE_TOO_LONG', 'Message must be 200 characters or fewer');
     }
 
     const user = await getCurrentUserOrThrow(ctx);
 
     const match = await ctx.db.get(args.matchId);
     if (!match) {
-      throw new Error('Match not found');
+      throw convexError('MATCH_NOT_FOUND', 'Match not found');
     }
 
     assertCurrentPartner(user, match);
 
     if (match.proposalStatus !== 'pending') {
-      throw new Error('No pending proposal on this match');
+      throw convexError('NO_PENDING_PROPOSAL', 'No pending proposal on this match');
     }
 
     if (match.proposedBy === user._id) {
-      throw new Error('Cannot respond to your own proposal');
+      throw convexError('CANNOT_RESPOND_OWN_PROPOSAL', 'Cannot respond to your own proposal');
     }
 
     const now = Date.now();
@@ -409,15 +410,15 @@ export const withdrawProposal = mutation({
 
     const match = await ctx.db.get(args.matchId);
     if (!match) {
-      throw new Error('Match not found');
+      throw convexError('MATCH_NOT_FOUND', 'Match not found');
     }
 
     if (match.proposedBy !== user._id) {
-      throw new Error('Only the proposer can withdraw');
+      throw convexError('NOT_PROPOSER', 'Only the proposer can withdraw');
     }
 
     if (match.proposalStatus !== 'pending') {
-      throw new Error('Proposal is not pending');
+      throw convexError('PROPOSAL_NOT_PENDING', 'Proposal is not pending');
     }
 
     await ctx.db.patch(args.matchId, {
@@ -443,7 +444,7 @@ export const deleteMatch = mutation({
 
     const match = await ctx.db.get(args.matchId);
     if (!match) {
-      throw new Error('Match not found');
+      throw convexError('MATCH_NOT_FOUND', 'Match not found');
     }
 
     assertCurrentPartner(user, match);

--- a/convex/partners.ts
+++ b/convex/partners.ts
@@ -2,6 +2,7 @@ import { v } from 'convex/values';
 import { mutation, query, QueryCtx, MutationCtx } from './_generated/server';
 import type { Id } from './_generated/dataModel';
 import { sanitizeImageUrl } from './validation';
+import { convexError } from './errors';
 
 // 31-char alphabet with confusables (I/O/0/1) removed for readability when
 // users dictate codes verbally. 31^8 ≈ 8.5e11 keyspace.
@@ -31,13 +32,13 @@ export async function generateUniqueShareCode(ctx: QueryCtx | MutationCtx): Prom
       .unique();
     if (!existing) return code;
   }
-  throw new Error('Could not generate a unique share code');
+  throw convexError('SHARE_CODE_GENERATION_FAILED', 'Could not generate a unique share code');
 }
 
 async function getCurrentUserOrThrow(ctx: QueryCtx | MutationCtx) {
   const identity = await ctx.auth.getUserIdentity();
   if (!identity) {
-    throw new Error('Not authenticated');
+    throw convexError('UNAUTHENTICATED', 'Not authenticated');
   }
 
   // #164: tolerant read — a stray duplicate clerkId row shouldn't throw and
@@ -48,7 +49,7 @@ async function getCurrentUserOrThrow(ctx: QueryCtx | MutationCtx) {
     .first();
 
   if (!user) {
-    throw new Error('User not found');
+    throw convexError('USER_NOT_FOUND', 'User not found');
   }
 
   return user;
@@ -66,17 +67,15 @@ const LOCKOUT_DURATIONS_MS = [
   60 * 60 * 1000, // 60 min
 ];
 
-class RateLimitError extends Error {
-  constructor(public retryAfterMs: number) {
-    const seconds = Math.ceil(retryAfterMs / 1000);
-    const minutes = Math.ceil(seconds / 60);
-    super(
-      seconds < 60
-        ? `Too many attempts. Try again in ${seconds} seconds.`
-        : `Too many attempts. Try again in ${minutes} minute${minutes === 1 ? '' : 's'}.`,
-    );
-    this.name = 'RateLimitError';
-  }
+function rateLimitError(retryAfterMs: number) {
+  const seconds = Math.ceil(retryAfterMs / 1000);
+  const minutes = Math.ceil(seconds / 60);
+  const message =
+    seconds < 60
+      ? `Too many attempts. Try again in ${seconds} seconds.`
+      : `Too many attempts. Try again in ${minutes} minute${minutes === 1 ? '' : 's'}.`;
+  // Carry retryAfterMs as structured data so the client can drive a countdown.
+  return convexError('RATE_LIMITED', message, { retryAfterMs });
 }
 
 async function enforceRateLimit(ctx: MutationCtx, userId: Id<'users'>): Promise<void> {
@@ -87,7 +86,7 @@ async function enforceRateLimit(ctx: MutationCtx, userId: Id<'users'>): Promise<
     .unique();
 
   if (record?.lockedUntil && now < record.lockedUntil) {
-    throw new RateLimitError(record.lockedUntil - now);
+    throw rateLimitError(record.lockedUntil - now);
   }
 
   if (!record) {
@@ -121,7 +120,7 @@ async function enforceRateLimit(ctx: MutationCtx, userId: Id<'users'>): Promise<
       lockoutCount: nextLockoutCount,
       lockedUntil: now + lockoutMs,
     });
-    throw new RateLimitError(lockoutMs);
+    throw rateLimitError(lockoutMs);
   }
 
   await ctx.db.patch(record._id, { attempts: newAttempts });
@@ -236,7 +235,7 @@ export const linkPartner = mutation({
 
     const normalizedCode = normalizeAndValidateCode(args.code);
     if (!normalizedCode) {
-      throw new Error('Please enter a valid share code');
+      throw convexError('INVALID_SHARE_CODE', 'Please enter a valid share code');
     }
 
     const targetUser = await ctx.db
@@ -245,19 +244,19 @@ export const linkPartner = mutation({
       .unique();
 
     if (!targetUser) {
-      throw new Error('User not found. Please check the code.');
+      throw convexError('CODE_NOT_FOUND', 'User not found. Please check the code.');
     }
 
     if (targetUser._id === user._id) {
-      throw new Error("You can't link with yourself");
+      throw convexError('CANNOT_LINK_SELF', "You can't link with yourself");
     }
 
     if (user.partnerId) {
-      throw new Error('You already have a partner linked');
+      throw convexError('PARTNER_ALREADY_LINKED', 'You already have a partner linked');
     }
 
     if (targetUser.partnerId) {
-      throw new Error('This user already has a partner linked');
+      throw convexError('TARGET_ALREADY_HAS_PARTNER', 'This user already has a partner linked');
     }
 
     if (user.nameConfirmed !== true) {
@@ -355,7 +354,10 @@ export const regenerateShareCode = mutation({
     const user = await getCurrentUserOrThrow(ctx);
 
     if (user.partnerId) {
-      throw new Error('You already have a partner — share code is no longer needed');
+      throw convexError(
+        'PARTNER_ALREADY_LINKED',
+        'You already have a partner — share code is no longer needed',
+      );
     }
 
     const newCode = await generateUniqueShareCode(ctx);
@@ -373,7 +375,7 @@ export const unlinkPartner = mutation({
     const user = await getCurrentUserOrThrow(ctx);
 
     if (!user.partnerId) {
-      throw new Error('No partner linked');
+      throw convexError('NO_PARTNER_LINKED', 'No partner linked');
     }
 
     const partner = await ctx.db.get(user.partnerId);

--- a/convex/selections.ts
+++ b/convex/selections.ts
@@ -3,6 +3,7 @@ import { paginationOptsValidator } from 'convex/server';
 import { mutation, query, QueryCtx, MutationCtx } from './_generated/server';
 import { Doc, Id } from './_generated/dataModel';
 import { getEffectivePremiumStatusHelper } from './premium';
+import { convexError } from './errors';
 
 const FREE_TIER_SWIPE_LIMIT = 25;
 // Cap on selectionIds accepted by the bulk mutations (#203). The dashboard's
@@ -133,7 +134,7 @@ function counterTypeFor(
 async function getCurrentUserOrThrow(ctx: QueryCtx | MutationCtx) {
   const identity = await ctx.auth.getUserIdentity();
   if (!identity) {
-    throw new Error('Not authenticated');
+    throw convexError('UNAUTHENTICATED', 'Not authenticated');
   }
 
   // #164: tolerant read — a stray duplicate clerkId row shouldn't throw here.
@@ -144,7 +145,7 @@ async function getCurrentUserOrThrow(ctx: QueryCtx | MutationCtx) {
     .first();
 
   if (!user) {
-    throw new Error('User not found');
+    throw convexError('USER_NOT_FOUND', 'User not found');
   }
 
   return user;
@@ -662,11 +663,11 @@ export const removeFromLiked = mutation({
 
     const selection = await ctx.db.get(args.selectionId);
     if (!selection) {
-      throw new Error('Selection not found');
+      throw convexError('SELECTION_NOT_FOUND', 'Selection not found');
     }
 
     if (selection.userId !== user._id) {
-      throw new Error('Not authorized to remove this selection');
+      throw convexError('NOT_AUTHORIZED', 'Not authorized to remove this selection');
     }
 
     // Delete corresponding match if the user has a partner
@@ -746,11 +747,11 @@ export const restoreToQueue = mutation({
 
     const selection = await ctx.db.get(args.selectionId);
     if (!selection) {
-      throw new Error('Selection not found');
+      throw convexError('SELECTION_NOT_FOUND', 'Selection not found');
     }
 
     if (selection.userId !== user._id) {
-      throw new Error('Not authorized to restore this selection');
+      throw convexError('NOT_AUTHORIZED', 'Not authorized to restore this selection');
     }
 
     // Defense in depth (#173): restoreToQueue is only wired up for rejected
@@ -786,7 +787,10 @@ export const bulkDeleteSelections = mutation({
   },
   handler: async (ctx, args) => {
     if (args.selectionIds.length > BULK_SELECTION_LIMIT) {
-      throw new Error(`Cannot delete more than ${BULK_SELECTION_LIMIT} selections at once`);
+      throw convexError(
+        'BULK_LIMIT_EXCEEDED',
+        `Cannot delete more than ${BULK_SELECTION_LIMIT} selections at once`,
+      );
     }
     const user = await getCurrentUserOrThrow(ctx);
 
@@ -819,7 +823,10 @@ export const bulkHideSelections = mutation({
   },
   handler: async (ctx, args) => {
     if (args.selectionIds.length > BULK_SELECTION_LIMIT) {
-      throw new Error(`Cannot hide more than ${BULK_SELECTION_LIMIT} selections at once`);
+      throw convexError(
+        'BULK_LIMIT_EXCEEDED',
+        `Cannot hide more than ${BULK_SELECTION_LIMIT} selections at once`,
+      );
     }
     const user = await getCurrentUserOrThrow(ctx);
     const now = Date.now();
@@ -857,11 +864,11 @@ export const hidePermanently = mutation({
 
     const selection = await ctx.db.get(args.selectionId);
     if (!selection) {
-      throw new Error('Selection not found');
+      throw convexError('SELECTION_NOT_FOUND', 'Selection not found');
     }
 
     if (selection.userId !== user._id) {
-      throw new Error('Not authorized to hide this selection');
+      throw convexError('NOT_AUTHORIZED', 'Not authorized to hide this selection');
     }
 
     if (selection.selectionType === 'like' && user.partnerId) {

--- a/lib/convex-errors.ts
+++ b/lib/convex-errors.ts
@@ -1,0 +1,54 @@
+import { ConvexError } from 'convex/values';
+import type { ConvexErrorCode, ConvexErrorData } from '@/convex/errors';
+
+export interface DecodedConvexError {
+  /** Present when the server threw a structured `ConvexError`. */
+  code?: ConvexErrorCode;
+  /** Always a clean, user-presentable string (never the raw Convex framing). */
+  message: string;
+}
+
+/**
+ * Normalize an unknown value thrown by a Convex mutation/query into a
+ * `{ code, message }` the UI can switch on.
+ *
+ * - `ConvexError` with `{ code, message }` data → returns them verbatim so the
+ *   caller can special-case predictable codes (e.g. `MATCH_NOT_FOUND`).
+ * - any other `Error` (a not-yet-migrated mutation, or an infra failure) →
+ *   strips Convex's `"[CONVEX M(foo:bar)] Server Error\nUncaught Error: ..."`
+ *   framing so a half-migrated surface still shows something readable.
+ * - anything else → the caller's `fallback`.
+ */
+export function decodeConvexError(err: unknown, fallback: string): DecodedConvexError {
+  if (err instanceof ConvexError) {
+    const data = err.data as Partial<ConvexErrorData> | string | undefined;
+    if (data && typeof data === 'object') {
+      const message =
+        typeof data.message === 'string' && data.message.length > 0 ? data.message : fallback;
+      return { code: data.code, message };
+    }
+    // A ConvexError thrown with a bare string payload.
+    if (typeof data === 'string' && data.length > 0) {
+      return { message: stripConvexFraming(data) || fallback };
+    }
+    return { message: fallback };
+  }
+
+  if (err instanceof Error) {
+    return { message: stripConvexFraming(err.message) || fallback };
+  }
+
+  return { message: fallback };
+}
+
+/**
+ * Strip the `[CONVEX M(module:fn)] Server Error` / `Uncaught Error:` framing
+ * Convex 1.x prepends to plain (non-ConvexError) server errors, leaving just
+ * the underlying message.
+ */
+function stripConvexFraming(message: string): string {
+  return message
+    .replace(/^\[CONVEX [^\]]+\][^\n]*\n*/i, '')
+    .replace(/^Uncaught (?:ConvexError|Error):\s*/i, '')
+    .trim();
+}


### PR DESCRIPTION
## What

Migrates `convex/partners.ts`, `convex/matches.ts` and `convex/selections.ts` from plain `throw new Error(...)` to `ConvexError` with a structured `{ code, message }` payload, and wires the mobile client to decode and switch on those codes.

Plain `throw new Error(...)` is redacted to `"Server Error"` in production by Convex, so the client surfaced generic **"Please try again"** alerts even when the server knew exactly what went wrong (match deleted, bad share code, rate limited, ...). This establishes the `decodeConvexError` helper + typed-code pattern the rest of the error-handling cluster builds on.

## Changes

**New**
- `convex/errors.ts` — `ConvexErrorCode` union (21 codes) + `convexError(code, message, extra?)` factory
- `lib/convex-errors.ts` — `decodeConvexError(err, fallback)` → `{ code?, message }`, strips the `[CONVEX M(...)] Server Error / Uncaught Error:` framing for un-migrated / infra errors
- `components/matches/match-error-alert.ts` — shared match-error → alert mapping (used by `matches.tsx` + `match-detail-modal.tsx`)

**Server** — every `throw` in the three modules now carries a typed code. `RateLimitError` became `ConvexError('RATE_LIMITED', …, { retryAfterMs })` so the "try again in N minutes" message actually reaches the production client (it didn't before).

**Client** — `matches.tsx`, `match-detail-modal.tsx`, `partner-link-modal.tsx`, `swipe-card-stack.tsx`, `dashboard.tsx`, `profile.tsx`, `report-message-sheet.tsx` decode and special-case predictable codes (`MATCH_NOT_FOUND`, `SELECTION_NOT_FOUND`, `NO_PARTNER_LINKED`, …). Expected outcomes (a deleted match/selection) skip Sentry since the reactive queries self-heal.

## Verification
- `npx convex codegen` ✓
- `tsc --noEmit` ✓ clean
- `npm run lint` ✓ (0 errors; pre-existing warnings only)

## Not covered (manual)
- Two-account simulator test: propose against a deleted match → "this match was removed" rather than "try again". Logic is type-checked; the race needs two linked accounts to reproduce.

Closes #178

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)