### PR TITLE
fix: derive MatchWithName from getMatches via FunctionReturnType (#179)

### DIFF
--- a/app/(tabs)/matches.tsx
+++ b/app/(tabs)/matches.tsx
@@ -39,31 +39,16 @@ import { GradientBackground } from '@/components/ui/gradient-background';
 import { MatchAnimation } from '@/components/ui/match-animation';
 import { LoadingScreen, useGracefulLoading } from '@/components/ui/loading-screen';
 import { LoadingIndicator } from '@/components/ui/loading-indicator';
-import { Doc, Id } from '@/convex/_generated/dataModel';
+import { Id } from '@/convex/_generated/dataModel';
+import type { FunctionReturnType } from 'convex/server';
 import * as Haptics from 'expo-haptics';
 
 import type { MatchSortOption } from '@/components/matches/matches-header';
 
-type MatchWithName = {
-  _id: Id<'matches'>;
-  nameId: Id<'names'>;
-  user1Id: Id<'users'>;
-  user2Id: Id<'users'>;
-  isFavorite?: boolean;
-  notes?: string;
-  rank?: number;
-  isChosen?: boolean;
-  proposedBy?: Id<'users'>;
-  proposedAt?: number;
-  proposalMessage?: string;
-  proposalStatus?: 'pending' | 'accepted' | 'declined';
-  respondedAt?: number;
-  declineMessage?: string;
-  matchedAt: number;
-  createdAt: number;
-  updatedAt: number;
-  name: Doc<'names'>;
-};
+// Inferred from the server so the client can't silently drift from the actual
+// getMatches return shape (#179). Adding/removing/renaming a field there now
+// fails tsc at the consumer sites instead of being hidden behind a cast.
+type MatchWithName = FunctionReturnType<typeof api.matches.getMatches>[number];
 
 export default function Matches() {
   const { colors } = useTheme();
@@ -506,7 +491,7 @@ export default function Matches() {
 
         {/* Match list */}
         <FlatList
-          data={matches as MatchWithName[]}
+          data={matches}
           renderItem={renderItem}
           keyExtractor={keyExtractor}
           contentContainerStyle={styles.listContent}


### PR DESCRIPTION
## What
`app/(tabs)/matches.tsx` declared a hand-rolled `MatchWithName` type mirroring `getMatches`' return shape, then rendered with `data={matches as MatchWithName[]}` — casting away the real server type. A field added/removed/renamed server-side would drift silently.

Derive the type via `FunctionReturnType<typeof api.matches.getMatches>[number]` and drop the cast.

## Acceptance
- [x] `MatchWithName` derived via `FunctionReturnType`, not declared
- [x] `data={matches}` no longer requires a cast
- [x] tsc passes; no `any` introduced
- [x] Changing `getMatches`' fields now fails tsc at the consumer instead of drifting

## Verification
- `tsc --noEmit` ✓ clean
- `npm run lint` ✓ (matches.tsx clean; dropped now-unused `Doc` import)

Closes #179

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)