### PR TITLE
fix: validate profile-photo asset + base64 before building data URL (#180)

### DIFF
--- a/hooks/use-profile-photo.ts
+++ b/hooks/use-profile-photo.ts
@@ -30,30 +30,58 @@ export function useProfilePhoto(user: UserResource | null | undefined) {
 
     if (result.canceled) return;
 
+    const asset = result.assets[0];
+    // ImagePicker can return no asset (multi-pick race) or an asset with no
+    // base64 — HEIC images are the common offender, where encoding fails. Bail
+    // with an actionable message instead of sending `base64,undefined` to Clerk
+    // and trapping the user in a retry loop (#180).
+    if (!asset || !asset.base64) {
+      Alert.alert(
+        'Could not read image',
+        'Please try a different photo. (HEIC images sometimes fail — try converting to JPG.)',
+      );
+      Sentry.captureMessage('Profile photo: missing asset or base64', {
+        level: 'warning',
+        extra: {
+          hasAssets: !!result.assets,
+          length: result.assets?.length,
+          assetKeys: asset ? Object.keys(asset) : null,
+        },
+      });
+      return;
+    }
+
+    const mimeType = asset.mimeType ?? 'image/jpeg';
     setIsUploading(true);
     try {
-      const asset = result.assets[0];
-      const mimeType = asset.mimeType || 'image/jpeg';
       await user.setProfileImage({
-        file: `data:${mimeType};base64,${asset.base64!}`,
+        file: `data:${mimeType};base64,${asset.base64}`,
       });
     } catch (error: unknown) {
       Sentry.captureException(error);
-      if (__DEV__) {
-        // #205: narrow with Clerk's type guard instead of `as any`, so the
-        // shape we log is type-checked and Clerk API drift surfaces at compile
-        // time. Non-Clerk errors fall through to the generic fields.
-        if (isClerkAPIResponseError(error)) {
+      // #205: narrow with Clerk's type guard instead of `as any`, so the shape
+      // we read is type-checked and Clerk API drift surfaces at compile time.
+      if (isClerkAPIResponseError(error)) {
+        const code = error.errors[0]?.code;
+        if (__DEV__) {
           console.error('Profile photo upload failed (Clerk API error):', {
             status: error.status,
-            code: error.errors[0]?.code,
+            code,
             longMessage: error.errors[0]?.longMessage,
           });
-        } else {
+        }
+        Alert.alert(
+          'Error',
+          code === 'image_too_large'
+            ? 'That photo is too large. Try a smaller one.'
+            : 'Failed to update profile photo. Please try again.',
+        );
+      } else {
+        if (__DEV__) {
           console.error('Profile photo upload failed:', error);
         }
+        Alert.alert('Error', 'Failed to update profile photo. Please try again.');
       }
-      Alert.alert('Error', 'Failed to update profile photo. Please try again.');
     } finally {
       setIsUploading(false);
     }


### PR DESCRIPTION
## What
`hooks/use-profile-photo.ts` bracket-indexed `result.assets[0]` and non-null-asserted `asset.base64!`. When ImagePicker returns no asset or fails to encode base64 (HEIC images are the common offender), this produced `data:image/jpeg;base64,undefined`, which Clerk rejects with an opaque error — leaving the user in a generic "try again" loop on every HEIC photo.

## Changes
- Guard `assets[0]` and `base64` before building the data URL; show an actionable message (suggest converting HEIC → JPG) + a Sentry warning, then return
- Drop the `base64!` non-null assertion
- Narrow Clerk's `image_too_large` to a specific "That photo is too large" alert (keeps the existing typed dev logging)

`error: unknown` + Clerk-typed narrowing was already in place (#205), including on `removePhoto`.

## Acceptance
- [x] `pickAndUploadImage` validates `assets[0]` and `base64` before the data URL
- [x] HEIC users get a specific message instead of a generic retry loop
- [x] `error: unknown` + Clerk-typed narrowing (no `any`)
- [ ] Manual: pick a HEIC photo on iOS → succeeds or shows a specific error (no infinite loop) — needs a device/simulator

## Verification
- `tsc --noEmit` ✓ clean
- `npm run lint` ✓ (use-profile-photo.ts clean)

Closes #180

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)