### PR TITLE
fix: capture real Share errors in celebration modal (#206)

### DIFF
--- a/components/matches/celebration-modal.tsx
+++ b/components/matches/celebration-modal.tsx
@@ -5,6 +5,7 @@ import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { Confetti } from '@/components/ui/confetti';
 import * as Haptics from 'expo-haptics';
+import * as Sentry from '@sentry/react-native';
 
 interface CelebrationModalProps {
   visible: boolean;
@@ -51,8 +52,11 @@ export function CelebrationModal({
         message: `We've chosen a name! ${nameName}\n\nDiscovered together on Bambino`,
         title: "We've chosen a name!",
       });
-    } catch {
-      // User cancelled share
+    } catch (err: unknown) {
+      // RN Share resolves (not throws) on user cancel — any throw here is a
+      // real failure (no share extension on simulator, sandbox/asset errors),
+      // so report it instead of swallowing silently (#206).
+      Sentry.captureException(err, { tags: { flow: 'share_match' } });
     }
   };
 


### PR DESCRIPTION
## What
`components/matches/celebration-modal.tsx` had an empty `catch {}` commented "User cancelled share". But RN `Share.share` *resolves* (with `{ action: 'dismissedAction' }`) on cancel — it doesn't throw. So the empty catch only ever swallowed **real** errors: no share extension (simulator), iOS sandbox failures, asset access errors. Sentry never saw them.

## Changes
- Capture any throw to Sentry (tagged `share_match`)
- User cancellation stays silent (it resolves, never reaches the catch)

## Acceptance
- [x] Real share errors captured to Sentry
- [x] User cancellation still silent

## Verification
- `tsc --noEmit` ✓ clean
- `npm run lint` ✓ (celebration-modal.tsx clean)

Closes #206

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)