### PR TITLE
fix: wrap handleCopyCode clipboard write in try/catch (#223)

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -198,10 +198,16 @@ export default function Profile() {
   }, [deleteAccount, signOut, user]);
 
   const handleCopyCode = useCallback(async () => {
-    if (partnerInfo?.shareCode) {
+    if (!partnerInfo?.shareCode) return;
+    try {
       await Clipboard.setStringAsync(partnerInfo.shareCode);
       trackEvent(Events.PARTNER_CODE_COPIED);
       Alert.alert('Copied', 'Share code copied to clipboard!');
+    } catch (err) {
+      // Clipboard writes can fail (restricted device profile, sandbox). Don't
+      // claim success when nothing landed on the clipboard (#223).
+      Sentry.captureException(err, { tags: { flow: 'copy_share_code' } });
+      Alert.alert("Couldn't copy", 'Tap and hold the code to copy it manually.');
     }
   }, [partnerInfo?.shareCode]);
 


### PR DESCRIPTION
## What
`handleCopyCode` in `app/(tabs)/profile.tsx` awaited `Clipboard.setStringAsync` then unconditionally showed "Copied!". `setStringAsync` can fail (restricted device profile, sandbox), so the user would see success while nothing landed on the clipboard.

## Changes
- Guard the clipboard write in try/catch
- On failure: capture to Sentry (tagged `copy_share_code`) and show a fallback ("tap and hold the code to copy it manually") instead of the success alert

## Acceptance
- [x] Clipboard write wrapped in try/catch
- [x] Failure shows specific fallback, not the success alert
- [x] Sentry captures real failures

## Verification
- `tsc --noEmit` ✓ clean
- `npm run lint` ✓ (profile.tsx clean)

Closes #223

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)