### PR TITLE
fix: enable noUncheckedIndexedAccess and guard all findings (#187)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ app-example
 
 # Claude Code
 .claude/
+.mcp.json
 
 # Superpowers
 .superpowers/

--- a/components/onboarding/welcome-splash.tsx
+++ b/components/onboarding/welcome-splash.tsx
@@ -174,6 +174,7 @@ export function WelcomeSplash({ isActive }: { isActive: boolean }) {
       const available = NAME_POOL.filter((n) => !usedNames.has(n));
       const pool = available.length > 0 ? available : NAME_POOL;
       const name = pool[Math.floor(Math.random() * pool.length)];
+      if (!name) return prev;
       // Random X: leave 20px margin on each side, account for pill width (~100px)
       const startX = 20 + Math.random() * (SCREEN_WIDTH - 140);
       const rotation = (Math.random() - 0.5) * 12; // -6 to +6 degrees

--- a/components/settings/voice-settings-section.tsx
+++ b/components/settings/voice-settings-section.tsx
@@ -24,7 +24,7 @@ const ALLOWED_VOICES = ['Samantha', 'Karen', 'Daniel', 'Moira', 'Tessa', 'Rishi'
 const SAMPLE_NAMES = ['Emma', 'Oliver', 'Sophia', 'Liam', 'Charlotte'];
 
 function getRandomSampleName(): string {
-  return SAMPLE_NAMES[Math.floor(Math.random() * SAMPLE_NAMES.length)];
+  return SAMPLE_NAMES[Math.floor(Math.random() * SAMPLE_NAMES.length)] ?? 'Emma';
 }
 
 // Format language code to friendly name

--- a/components/swipe/swipe-card-stack.tsx
+++ b/components/swipe/swipe-card-stack.tsx
@@ -156,6 +156,7 @@ export function SwipeCardStack() {
       if (queue.length === 0) return;
 
       const currentName = queue[0];
+      if (!currentName) return;
 
       // Optimistic update - remove from queue
       setLocalQueue((prev) => prev.slice(1));

--- a/components/ui/bubble-pills-background.tsx
+++ b/components/ui/bubble-pills-background.tsx
@@ -162,6 +162,7 @@ function BubblePillsBackgroundInner() {
       const available = NAME_POOL.filter((n) => !usedNames.has(n));
       const pool = available.length > 0 ? available : NAME_POOL;
       const name = pool[Math.floor(Math.random() * pool.length)];
+      if (!name) return prev;
       const startX = 20 + Math.random() * (SCREEN_WIDTH - 140);
       const rotation = (Math.random() - 0.5) * 12;
       const isLike = Math.random() > 0.5;

--- a/components/ui/confetti.tsx
+++ b/components/ui/confetti.tsx
@@ -28,7 +28,7 @@ function generatePieces(themeColors: string[]): ConfettiPiece[] {
     x: Math.random() * SCREEN_WIDTH,
     width: 6 + Math.random() * 4,
     height: 8 + Math.random() * 6,
-    color: themeColors[Math.floor(Math.random() * themeColors.length)],
+    color: themeColors[Math.floor(Math.random() * themeColors.length)] ?? '#FF8FAB',
     delay: Math.random() * 600,
     duration: 2500 + Math.random() * 1000,
     rotation: Math.random() * 720,

--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -269,8 +269,8 @@ export const auditPopularityYears = internalQuery({
       perYear.push({
         year,
         recordsTaken: records.length,
-        topRank: ranks[0],
-        bottomRank: ranks[ranks.length - 1],
+        topRank: ranks[0] ?? 0,
+        bottomRank: ranks[ranks.length - 1] ?? 0,
       });
     }
 

--- a/convex/names.ts
+++ b/convex/names.ts
@@ -34,7 +34,7 @@ export const seedNames = internalMutation({
         meaning: nameData.meaning,
         phonetic: nameData.phonetic,
         length: nameData.name.length,
-        firstLetter: nameData.name[0].toUpperCase(),
+        firstLetter: nameData.name.charAt(0).toUpperCase(),
         sortKey: Math.random(),
         createdAt: now,
       });
@@ -295,6 +295,7 @@ export const populateOriginStats = internalMutation({
     const now = Date.now();
     for (const [key, increment] of Object.entries(pageTally)) {
       const [origin, gender] = key.split('|');
+      if (origin === undefined || gender === undefined) continue;
       const existing = await ctx.db
         .query('nameOriginStats')
         .withIndex('by_origin_gender', (q) => q.eq('origin', origin).eq('gender', gender))

--- a/convex/partners.ts
+++ b/convex/partners.ts
@@ -15,7 +15,8 @@ function generateShareCode(): string {
   crypto.getRandomValues(bytes);
   let code = '';
   for (let i = 0; i < SHARE_CODE_LENGTH; i++) {
-    code += SHARE_CODE_ALPHABET.charAt(bytes[i] % SHARE_CODE_ALPHABET.length);
+    const byte = bytes[i] ?? 0;
+    code += SHARE_CODE_ALPHABET.charAt(byte % SHARE_CODE_ALPHABET.length);
   }
   return code;
 }
@@ -114,7 +115,8 @@ async function enforceRateLimit(ctx: MutationCtx, userId: Id<'users'>): Promise<
   if (newAttempts > RATE_MAX_ATTEMPTS) {
     const nextLockoutCount = record.lockoutCount + 1;
     const lockoutMs =
-      LOCKOUT_DURATIONS_MS[Math.min(nextLockoutCount - 1, LOCKOUT_DURATIONS_MS.length - 1)];
+      LOCKOUT_DURATIONS_MS[Math.min(nextLockoutCount - 1, LOCKOUT_DURATIONS_MS.length - 1)] ??
+      60 * 60 * 1000;
     await ctx.db.patch(record._id, {
       attempts: newAttempts,
       lockoutCount: nextLockoutCount,

--- a/convex/popularity.ts
+++ b/convex/popularity.ts
@@ -409,25 +409,35 @@ export const getNamePopularitySummary = query({
       else records = m.length >= f.length ? m : f;
     }
 
+    const emptyResult = {
+      currentRank: null,
+      trend: null as 'rising' | 'falling' | 'steady' | null,
+      peakYear: null as number | null,
+      peakRank: null as number | null,
+      sparklinePoints: [] as number[],
+      totalRankedNames: 0,
+    };
+
     if (records.length === 0) {
-      return {
-        currentRank: null,
-        trend: null as 'rising' | 'falling' | 'steady' | null,
-        peakYear: null as number | null,
-        peakRank: null as number | null,
-        sparklinePoints: [] as number[],
-      };
+      return emptyResult;
     }
 
     // Sort by year ascending
     records.sort((a, b) => a.year - b.year);
 
-    // Current rank: most recent year's rank
+    // records is non-empty here, but indexed access is still `T | undefined`
+    // under noUncheckedIndexedAccess — pull the endpoints once, with a guard.
     const mostRecent = records[records.length - 1];
+    const first = records[0];
+    if (!mostRecent || !first) {
+      return emptyResult; // unreachable: records.length > 0
+    }
+
+    // Current rank: most recent year's rank
     const currentRank = mostRecent.rank;
 
     // Peak year: year with lowest (best) rank
-    const peak = records.reduce((best, r) => (r.rank < best.rank ? r : best), records[0]);
+    const peak = records.reduce((best, r) => (r.rank < best.rank ? r : best), first);
     const peakYear = peak.year;
 
     // Trend: compare most recent rank to rank 5 years prior

--- a/convex/selections.ts
+++ b/convex/selections.ts
@@ -253,9 +253,11 @@ async function checkForMatchAndCreate(
   let survivingMatchId = matchId;
   if (afterInsert.length > 1) {
     afterInsert.sort((a, b) => a._creationTime - b._creationTime);
-    survivingMatchId = afterInsert[0]._id;
+    const survivor = afterInsert[0];
+    if (survivor) survivingMatchId = survivor._id;
     for (let i = 1; i < afterInsert.length; i++) {
-      await ctx.db.delete(afterInsert[i]._id);
+      const dup = afterInsert[i];
+      if (dup) await ctx.db.delete(dup._id);
     }
     // A concurrent writer beat us to it — they already surfaced the match toast.
     if (survivingMatchId !== matchId) {
@@ -313,7 +315,8 @@ export const recordSelection = mutation({
     existingRows.sort((a, b) => a._creationTime - b._creationTime);
     const existingSelection = existingRows[0] ?? null;
     for (let i = 1; i < existingRows.length; i++) {
-      await ctx.db.delete(existingRows[i]._id);
+      const dup = existingRows[i];
+      if (dup) await ctx.db.delete(dup._id);
     }
 
     const now = Date.now();
@@ -393,9 +396,10 @@ export const recordSelection = mutation({
       afterInsert.sort((a, b) => a._creationTime - b._creationTime);
       const survivor = afterInsert[0];
       for (let i = 1; i < afterInsert.length; i++) {
-        await ctx.db.delete(afterInsert[i]._id);
+        const dup = afterInsert[i];
+        if (dup) await ctx.db.delete(dup._id);
       }
-      if (survivor._id !== selectionId) {
+      if (survivor && survivor._id !== selectionId) {
         // A concurrent call already recorded this swipe and did its own
         // counting. Don't increment lifetime/counters again.
         return { selectionId: survivor._id, match: null };

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -69,7 +69,8 @@ export const createOrUpdateUser = mutation({
     existingRows.sort((a, b) => a._creationTime - b._creationTime);
     const existingUser = existingRows[0] ?? null;
     for (let i = 1; i < existingRows.length; i++) {
-      await ctx.db.delete(existingRows[i]._id);
+      const dup = existingRows[i];
+      if (dup) await ctx.db.delete(dup._id);
     }
 
     const now = Date.now();
@@ -113,10 +114,12 @@ export const createOrUpdateUser = mutation({
       .collect();
     if (afterInsert.length > 1) {
       afterInsert.sort((a, b) => a._creationTime - b._creationTime);
+      const survivor = afterInsert[0];
       for (let i = 1; i < afterInsert.length; i++) {
-        await ctx.db.delete(afterInsert[i]._id);
+        const dup = afterInsert[i];
+        if (dup) await ctx.db.delete(dup._id);
       }
-      return afterInsert[0]._id;
+      if (survivor) return survivor._id;
     }
 
     return userId;

--- a/hooks/use-purchases.ts
+++ b/hooks/use-purchases.ts
@@ -55,10 +55,11 @@ export function usePurchases() {
   }, []);
 
   const purchasePremium = useCallback(async () => {
-    if (packages.length === 0) return false;
+    const pkg = packages[0];
+    if (!pkg) return false;
 
     try {
-      const { customerInfo } = await Purchases.purchasePackage(packages[0]);
+      const { customerInfo } = await Purchases.purchasePackage(pkg);
       const hasPremium = customerInfo.entitlements.active[ENTITLEMENT_ID] !== undefined;
 
       if (hasPremium) {

--- a/scripts/enrich-names.ts
+++ b/scripts/enrich-names.ts
@@ -89,7 +89,8 @@ async function enrichBatch(
       messages: [{ role: 'user', content: buildPrompt(batch) }],
     });
 
-    const text = response.content[0].type === 'text' ? response.content[0].text : '';
+    const firstBlock = response.content[0];
+    const text = firstBlock?.type === 'text' ? firstBlock.text : '';
 
     // Extract JSON array from response (handle potential markdown wrapping)
     const jsonMatch = text.match(/\[[\s\S]*\]/);

--- a/scripts/extract-ssa-names.ts
+++ b/scripts/extract-ssa-names.ts
@@ -41,6 +41,7 @@ function extractNames() {
 
     for (const line of lines) {
       const [name, gender] = line.split(',');
+      if (!name) continue;
       if (gender === 'M') maleEntries.push(name);
       else if (gender === 'F') femaleEntries.push(name);
     }

--- a/scripts/process-ssa-data.ts
+++ b/scripts/process-ssa-data.ts
@@ -36,6 +36,7 @@ function processYearFile(
 
   for (const line of lines) {
     const [name, gender, countStr] = line.split(',');
+    if (!name || !gender || !countStr) continue;
     const count = parseInt(countStr, 10);
 
     if (!validNames.has(name)) {

--- a/scripts/seed-popularity.ts
+++ b/scripts/seed-popularity.ts
@@ -40,7 +40,8 @@ async function seedPopularity() {
   const totalBatches = Math.ceil(records.length / BATCH_SIZE);
 
   const startBatchArg = process.argv.find((a) => a.startsWith('--start='));
-  const startBatch = startBatchArg ? parseInt(startBatchArg.split('=')[1], 10) : 1;
+  const startValue = startBatchArg?.split('=')[1];
+  const startBatch = startValue ? parseInt(startValue, 10) : 1;
   const startIndex = (startBatch - 1) * BATCH_SIZE;
 
   const isProd = process.argv.includes('--prod');

--- a/scripts/update-ranks.ts
+++ b/scripts/update-ranks.ts
@@ -19,7 +19,8 @@ function runWithRetry(command: string): string {
 
 async function updateRanks() {
   const yearArg = process.argv.find((a) => a.startsWith('--year='));
-  const year = yearArg ? parseInt(yearArg.split('=')[1], 10) : 2023;
+  const yearValue = yearArg?.split('=')[1];
+  const year = yearValue ? parseInt(yearValue, 10) : 2023;
   const prod = process.argv.includes('--prod');
   const deploymentFlag = prod ? ' --prod' : '';
   const target = prod ? 'PRODUCTION' : 'dev';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "noUncheckedIndexedAccess": true,
     "paths": {
       "@/*": ["./*"]
     }


### PR DESCRIPTION
## What
Enables `noUncheckedIndexedAccess` in `tsconfig.json` (alongside the existing `strict: true`) so `array[i]` / `obj[key]` type as `T | undefined`, surfacing a class of latent undefined bugs at compile time — the #180 HEIC `base64!` crash was one instance.

Fixes all **45 resulting findings** with real guards (no `as` casts introduced).

## Findings by category
- **convex dedup loops** (`selections.ts`, `users.ts`) — guard `rows[i]` / survivor before delete/return on the `.length > 1` concurrent-write paths (the most meaningful ones)
- **endpoint access after `length === 0` guards** (`popularity.ts`, `admin.ts`) — pull `records[0]` / `records[length-1]` once, with fallbacks
- **CSV `split` destructures** (`scripts/*`) — `continue` on malformed rows
- **random-index palette/name picks** (`confetti`, `bubble-pills`, `welcome-splash`, `voice-settings`) — fallback or skip-spawn guard
- **CSPRNG byte + lockout table** (`partners.ts`) — `?? 0` / `?? 60min`
- **first element of picker/API results** (`use-purchases`, `enrich-names`, `swipe-card-stack`) — explicit guards

## Notes
- `getNamePopularitySummary`'s empty branch now returns `totalRankedNames: 0` (was omitted, leaving a ragged union the consumer reached into) — strictly more correct
- `process-ssa-data` now skips truly malformed CSV rows instead of pushing `NaN`
- Also ignores `.mcp.json` (local MCP config)
- No `convex/_generated` changes (API surface unchanged)

## Acceptance
- [x] `noUncheckedIndexedAccess: true` in tsconfig
- [x] `npx tsc --noEmit` passes
- [x] No new `as` casts — real undefined handling
- [x] Future regressions caught by CI typecheck (#146)

## Verification
- `tsc --noEmit` ✓ clean (with flag on)
- `convex codegen` ✓
- `npm run lint` ✓ (0 errors; only pre-existing warnings)

Closes #187

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)