### PR TITLE
fix: stop TTS on voice change + fix System Default preview indicator (#188, #189)

### DIFF
--- a/components/settings/voice-settings-section.tsx
+++ b/components/settings/voice-settings-section.tsx
@@ -23,6 +23,11 @@ const ALLOWED_VOICES = ['Samantha', 'Karen', 'Daniel', 'Moira', 'Tessa', 'Rishi'
 // Sample names to preview voice
 const SAMPLE_NAMES = ['Emma', 'Oliver', 'Sophia', 'Liam', 'Charlotte'];
 
+// Sentinel preview key for the System Default row. Its voice identifier is
+// `null`, so null alone can't tell "previewing System Default" apart from
+// "nothing playing" — track System Default previews under this key instead (#189).
+const SYSTEM_DEFAULT_PREVIEW_KEY = '__system_default__';
+
 function getRandomSampleName(): string {
   return SAMPLE_NAMES[Math.floor(Math.random() * SAMPLE_NAMES.length)] ?? 'Emma';
 }
@@ -86,6 +91,14 @@ export function VoiceSettingsSection() {
 
   const handleSelectVoice = useCallback(
     async (identifier: string | null) => {
+      // Stop any in-flight preview so the user doesn't hear the previous voice
+      // finish after they've already picked a new one (#188).
+      try {
+        await Speech.stop();
+      } catch {
+        // best effort — stopping playback is non-critical
+      }
+      setPreviewingVoice(null);
       await setVoiceIdentifier(identifier);
       trackEvent(Events.VOICE_CHANGED, { voice_id: identifier ?? 'system_default' });
       setIsExpanded(false);
@@ -111,7 +124,7 @@ export function VoiceSettingsSection() {
       const voiceId = identifier || undefined;
       const sampleName = getRandomSampleName();
 
-      setPreviewingVoice(identifier);
+      setPreviewingVoice(identifier ?? SYSTEM_DEFAULT_PREVIEW_KEY);
       Speech.speak(sampleName, {
         voice: voiceId,
         rate: 0.9,
@@ -164,7 +177,7 @@ export function VoiceSettingsSection() {
             <VoiceOption
               label="System Default"
               isSelected={voiceIdentifier === null}
-              isPreviewing={previewingVoice === null && previewingVoice !== undefined}
+              isPreviewing={previewingVoice === SYSTEM_DEFAULT_PREVIEW_KEY}
               onSelect={() => handleSelectVoice(null)}
               onPreview={() => handlePreviewVoice(null)}
             />


### PR DESCRIPTION
Two related TTS bugs in `components/settings/voice-settings-section.tsx`, fixed together.

## #189 — System Default preview indicator always lit
`previewingVoice` (`string | null`) overloaded `null` to mean both "System Default voice" and "nothing playing", so:
- `isPreviewing={previewingVoice === null && previewingVoice !== undefined}` was **always true** (it's never `undefined`)
- previewing System Default called `setPreviewingVoice(null)`, indistinguishable from idle → no feedback

**Fix:** track System Default previews under a dedicated `SYSTEM_DEFAULT_PREVIEW_KEY` sentinel. The indicator now reflects actual playback, and regular voices keep using `previewingVoice === voice.identifier` (identifiers never collide with the sentinel).

## #188 — TTS keeps playing the old voice on change
Selecting a voice mid-preview left the previous voice speaking. **Fix:** `handleSelectVoice` now `Speech.stop()`s (best effort) and clears the preview state before persisting the new voice.

## Acceptance
- [x] System Default indicator only lit while System Default is actively previewing
- [x] Selecting a voice while previewing stops playback immediately
- [ ] Manual: tap System Default preview → indicator on → finishes → off; tap voice A preview → mid-utterance pick voice B → A stops (needs device/simulator with TTS)

## Verification
- `tsc --noEmit` ✓ clean
- `npm run lint` ✓ (voice-settings-section.tsx clean)

Closes #188
Closes #189

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)