### PR TITLE
fix: single-fire origin toggle + debounce filter saves (#190, #191)

### DIFF
--- a/app/(tabs)/explore/filters.tsx
+++ b/app/(tabs)/explore/filters.tsx
@@ -58,20 +58,47 @@ export default function Filters() {
     [updateFilters],
   );
 
+  // Debounce the mutation so rapidly toggling N origins is ~1 write, not N
+  // (#190). Local state still updates immediately, so the live name count below
+  // stays instant — only the persisted write is coalesced.
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const queueSave = useCallback(
+    (gender: GenderFilter, origin: string[] | null) => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = setTimeout(() => {
+        saveTimerRef.current = null;
+        saveFilters(gender, origin);
+      }, 400);
+    },
+    [saveFilters],
+  );
+
+  // Flush a pending save when leaving the screen so a quick exit (back button)
+  // doesn't drop the last change.
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current);
+        saveTimerRef.current = null;
+        saveFilters(genderRef.current, originRef.current);
+      }
+    };
+  }, [saveFilters]);
+
   const handleGenderChange = useCallback(
     (value: GenderFilter) => {
       setGenderFilter(value);
-      saveFilters(value, originRef.current);
+      queueSave(value, originRef.current);
     },
-    [saveFilters],
+    [queueSave],
   );
 
   const handleOriginChange = useCallback(
     (value: string[] | null) => {
       setOriginFilter(value);
-      saveFilters(genderRef.current, value);
+      queueSave(genderRef.current, value);
     },
-    [saveFilters],
+    [queueSave],
   );
 
   // Live names count based on current filter state

--- a/components/search/origin-toggle-row.tsx
+++ b/components/search/origin-toggle-row.tsx
@@ -14,7 +14,13 @@ export function OriginToggleRow({ origin, count, isActive, onToggle }: OriginTog
   const { colors } = useTheme();
 
   return (
-    <Pressable onPress={onToggle} style={[styles.row, { shadowColor: colors.secondary }]}>
+    <Pressable
+      onPress={onToggle}
+      accessibilityRole="switch"
+      accessibilityState={{ checked: isActive }}
+      accessibilityLabel={`${origin}, ${count.toLocaleString()} ${count === 1 ? 'name' : 'names'}`}
+      style={[styles.row, { shadowColor: colors.secondary }]}
+    >
       <View style={styles.textContainer}>
         <Text style={[styles.name, isActive && styles.nameActive]}>
           {getOriginFlag(origin)} {origin}
@@ -23,13 +29,18 @@ export function OriginToggleRow({ origin, count, isActive, onToggle }: OriginTog
           {count.toLocaleString()} {count === 1 ? 'name' : 'names'}
         </Text>
       </View>
-      <Switch
-        value={isActive}
-        onValueChange={onToggle}
-        trackColor={{ false: '#E5DDD0', true: colors.primary }}
-        thumbColor="#FFFFFF"
-        ios_backgroundColor="#E5DDD0"
-      />
+      {/* Visual indicator only. The row Pressable owns the tap; without this the
+          Switch's own onValueChange fired alongside the row press, double-firing
+          onToggle and reverting the change (#191). pointerEvents="none" lets
+          taps on the switch fall through to the Pressable. */}
+      <View pointerEvents="none">
+        <Switch
+          value={isActive}
+          trackColor={{ false: '#E5DDD0', true: colors.primary }}
+          thumbColor="#FFFFFF"
+          ios_backgroundColor="#E5DDD0"
+        />
+      </View>
     </Pressable>
   );
 }


### PR DESCRIPTION
Two related bugs in the explore-filters flow, fixed together.

## #191 — origin toggle double-fires and reverts
`origin-toggle-row.tsx` wrapped the whole row in a `Pressable` calling `onToggle`, while the inner `Switch` also called `onToggle` via `onValueChange`. Tapping the switch fired both (off->on->off), so the toggle appeared to do nothing.

**Fix:** the `Switch` becomes a visual indicator only (`pointerEvents="none"`, no `onValueChange`) so the row owns the single tap. Moved `accessibilityRole="switch"` + `accessibilityState`/`accessibilityLabel` onto the `Pressable` so VoiceOver still announces it as a switch.

## #190 — one updateFilters write per tap
`explore/filters.tsx` fired `updateFilters` immediately on every gender/origin tap — toggling 10 origins = 10 mutations, each invalidating every query that read the user row.

**Fix:** debounce the write (~400ms) and flush any pending save on unmount (back button). Local state updates immediately, so the live name count stays instant — only the persisted write is coalesced.

## Acceptance
- [x] Tapping the row anywhere (text or switch) toggles exactly once
- [x] Origin/gender toggles fire updateFilters at most ~once per 400ms
- [x] Pending writes flushed on navigating away
- [x] Live name count still updates on every tap (local state)
- [ ] Manual: rapidly toggle origins, tap switch repeatedly (needs simulator)

## Verification
- tsc --noEmit clean
- npm run lint clean (both files)

Closes #190
Closes #191

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)