### PR TITLE
fix: respect Reduce Motion + cap BubblePills spawning (#192, #182)

### DIFF
--- a/components/onboarding/multiplayer-intro.tsx
+++ b/components/onboarding/multiplayer-intro.tsx
@@ -14,21 +14,31 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { Ionicons } from '@expo/vector-icons';
 import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
+import { useA11yPreferences } from '@/hooks/use-a11y-preferences';
 
 const { width } = Dimensions.get('window');
 
 const LOOP_DURATION = 5000;
 const MATCH_GREEN = '#4ADE80';
+// Mid-timeline "hold" frame (cards together, green borders, banner shown) used
+// as the static composition under Reduce Motion.
+const STATIC_FRAME = 0.5;
 
 export function MultiplayerIntro({ isActive }: { isActive: boolean }) {
   const { colors } = useTheme();
+  const { reduceMotion } = useA11yPreferences();
   const progress = useSharedValue(0);
 
   useEffect(() => {
     if (!isActive) return;
+    // Reduce Motion: hold the matched frame instead of looping (#192).
+    if (reduceMotion) {
+      progress.value = STATIC_FRAME;
+      return;
+    }
     progress.value = 0;
     progress.value = withRepeat(withTiming(1, { duration: LOOP_DURATION }), -1, false);
-  }, [isActive]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isActive, reduceMotion]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // ── Card animations ──────────────────────────────────────────────
   // Timeline (5s): Slide together 0-10% | Border fades green 10-18% |

--- a/components/ui/bubble-pills-background.tsx
+++ b/components/ui/bubble-pills-background.tsx
@@ -12,6 +12,7 @@ import { useIsFocused } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import { Fonts } from '@/constants/theme';
 import { SWIPE_COLORS } from '@/constants/swipe';
+import { useA11yPreferences } from '@/hooks/use-a11y-preferences';
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 
@@ -44,6 +45,11 @@ const PILL_SPAWN_MAX = 1000;
 const INITIAL_SPAWN_MIN = 1200;
 const INITIAL_SPAWN_MAX = 1800;
 const INITIAL_PILL_COUNT = 5;
+// Cap TOTAL lifetime spawns, not just simultaneous pills (#182). Without this
+// the spawner runs forever while the empty state is focused, holding the GPU at
+// sustained load (shadows on animated views). After the cap, pills already on
+// screen finish rising and the background settles quiet.
+const TOTAL_SPAWN_CAP = INITIAL_PILL_COUNT * 4;
 const PILL_RISE_DURATION = 8000;
 const PILL_FADE_DURATION = 1800;
 const BADGE_DELAY = 300;
@@ -110,11 +116,9 @@ function BubblePill({
           left: config.startX,
           bottom: BOTTOM_ZONE,
           borderColor: badgeColor,
-          borderWidth: 1,
-          shadowColor: badgeColor,
-          shadowOffset: { width: 0, height: 0 },
-          shadowOpacity: 0.45,
-          shadowRadius: 7,
+          // #182: a colored border replaces the per-pill shadow — shadows on
+          // animated transforms force per-frame off-screen compositing on iOS.
+          borderWidth: 1.5,
         },
         pillStyle,
       ]}
@@ -140,7 +144,9 @@ function BubblePill({
 
 export function BubblePillsBackground() {
   const isFocused = useIsFocused();
-  if (!isFocused) return null;
+  const { reduceMotion } = useA11yPreferences();
+  // Purely ambient decoration — skip entirely under Reduce Motion (#192).
+  if (!isFocused || reduceMotion) return null;
   return <BubblePillsBackgroundInner />;
 }
 
@@ -177,6 +183,7 @@ function BubblePillsBackgroundInner() {
   const spawnCount = useRef(0);
 
   const scheduleNextSpawn = useCallback(() => {
+    if (spawnCount.current >= TOTAL_SPAWN_CAP) return; // stop after the initial wave (#182)
     const isInitial = spawnCount.current < INITIAL_PILL_COUNT;
     const min = isInitial ? INITIAL_SPAWN_MIN : PILL_SPAWN_MIN;
     const max = isInitial ? INITIAL_SPAWN_MAX : PILL_SPAWN_MAX;

--- a/components/ui/confetti.tsx
+++ b/components/ui/confetti.tsx
@@ -8,6 +8,7 @@ import Animated, {
   Easing,
 } from 'react-native-reanimated';
 import { useTheme } from '@/contexts/theme-context';
+import { useA11yPreferences } from '@/hooks/use-a11y-preferences';
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 const PIECE_COUNT = 20;
@@ -96,6 +97,7 @@ interface ConfettiProps {
 
 export function Confetti({ visible }: ConfettiProps) {
   const { colors } = useTheme();
+  const { reduceMotion } = useA11yPreferences();
 
   const confettiColors = useMemo(
     () => [colors.primary, colors.secondary, '#FBBF24', '#34D399', '#60A5FA'],
@@ -104,7 +106,9 @@ export function Confetti({ visible }: ConfettiProps) {
 
   const pieces = useMemo(() => generatePieces(confettiColors), [confettiColors]);
 
-  if (!visible) return null;
+  // Skip the falling-pieces animation under Reduce Motion (#192). The
+  // celebration modal itself still shows; only the confetti is suppressed.
+  if (!visible || reduceMotion) return null;
 
   return (
     <Animated.View style={styles.container} pointerEvents="none">

--- a/components/ui/match-animation.tsx
+++ b/components/ui/match-animation.tsx
@@ -12,18 +12,28 @@ import Animated, {
 import { Ionicons } from '@expo/vector-icons';
 import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
+import { useA11yPreferences } from '@/hooks/use-a11y-preferences';
 
 const LOOP_DURATION = 5000;
 const MATCH_GREEN = '#4ADE80';
+// Mid-timeline "hold" frame (cards together, green borders, banner shown) used
+// as the static composition under Reduce Motion.
+const STATIC_FRAME = 0.5;
 
 export function MatchAnimation() {
   const { colors } = useTheme();
+  const { reduceMotion } = useA11yPreferences();
   const progress = useSharedValue(0);
 
   useEffect(() => {
+    // Reduce Motion: hold the matched frame instead of looping (#192).
+    if (reduceMotion) {
+      progress.value = STATIC_FRAME;
+      return;
+    }
     progress.value = 0;
     progress.value = withRepeat(withTiming(1, { duration: LOOP_DURATION }), -1, false);
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [reduceMotion]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Timeline (5s): Slide together 0-10% | Border fades green 10-18% |
   //   Banner pop 18-24% | Hold 24-70% | Dismiss 70-82% | Rest 82-100%


### PR DESCRIPTION
Two related animation/perf issues, fixed together (they overlap in `bubble-pills-background.tsx`).

## #192 — respect Reduce Motion
Nothing in the app consulted `AccessibilityInfo.isReduceMotionEnabled`, so continuous/attention-grabbing animations ran regardless. Gate them via the existing `useA11yPreferences` hook:
- **bubble-pills-background** — ambient decoration → render nothing
- **confetti** — skip the falling pieces (the celebration modal still shows)
- **match-animation** + **multiplayer-intro** — hold a static "matched" frame (progress pinned mid-timeline) instead of looping the 5s animation

The **swipe-card** hint shake is already covered: `showSwipeHint = hintEligible && !needsButtons`, and `needsButtons = screenReader || reduceMotion`, so the shake never starts under Reduce Motion — no change needed there.

## #182 — cap BubblePills spawning
`BubblePillsBackground` scheduled new spawns indefinitely while focused, holding the GPU at sustained load on long-lived empty states (swipe-end, "no matches yet"). 
- Cap **total lifetime** spawns at `INITIAL_PILL_COUNT * 4` so it settles into a quiet state after the initial wave (pills already on screen finish rising)
- Drop the per-pill **animated shadow** (shadows on animated transforms are an iOS compositing footgun) in favour of a slightly heavier colored border

## Acceptance
- #192: continuous loops absent/static under Reduce Motion; swipe still works; consumed in bubble-pills, confetti, match-animation, multiplayer-intro
- #182: total spawns capped; no new spawns after the wave; reduce-motion users see no pills
- [ ] Manual: enable Reduce Motion → empty states/celebration are static; leave swipe-empty 5 min → no sustained GPU/heat (needs device)

## Verification
- `tsc --noEmit` clean
- `npm run lint` clean (touched files)

Closes #182
Closes #192

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)