### PR TITLE
fix: make SSO redirect URL explicit and documented (#176)

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -12,6 +12,7 @@ import { StyledInput } from '@/components/ui/styled-input';
 import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { Events, trackEvent } from '@/lib/analytics';
+import { SSO_REDIRECT_URL } from '@/lib/sso';
 
 WebBrowser.maybeCompleteAuthSession();
 
@@ -139,8 +140,12 @@ export default function SignIn() {
     setError('');
 
     try {
+      // redirectUrl must be in Clerk Dashboard → Native applications → Allowed
+      // redirect URLs. A "redirect url mismatch" error means it's missing there
+      // (see docs/clerk-setup.md).
       const { createdSessionId, setActive: ssoSetActive } = await startSSOFlow({
         strategy: 'oauth_google',
+        redirectUrl: SSO_REDIRECT_URL,
       });
 
       if (createdSessionId && ssoSetActive) {

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -12,6 +12,7 @@ import { StyledInput } from '@/components/ui/styled-input';
 import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { trackEvent, Events } from '@/lib/analytics';
+import { SSO_REDIRECT_URL } from '@/lib/sso';
 
 function getClerkError(err: unknown, fallback: string): string {
   const clerkError = err as { errors?: { message: string }[] };
@@ -91,8 +92,12 @@ export default function SignUp() {
     setError('');
 
     try {
+      // redirectUrl must be in Clerk Dashboard → Native applications → Allowed
+      // redirect URLs. A "redirect url mismatch" error means it's missing there
+      // (see docs/clerk-setup.md).
       const { createdSessionId, setActive: ssoSetActive } = await startSSOFlow({
         strategy: 'oauth_google',
+        redirectUrl: SSO_REDIRECT_URL,
       });
 
       if (createdSessionId && ssoSetActive) {

--- a/docs/clerk-setup.md
+++ b/docs/clerk-setup.md
@@ -1,0 +1,40 @@
+# Clerk dashboard checklist
+
+Bambino's auth (email/password + Google SSO + Apple SSO) depends on a few
+settings that live in the **Clerk Dashboard**, not in this repo. They're easy to
+forget when rotating Clerk apps or migrating instances — and the resulting
+errors are misleading. Run through this when setting up a new Clerk instance.
+
+## Native applications → Allowed redirect URLs
+
+Must include:
+
+```
+bambino://sso-callback
+```
+
+This is the value passed as `redirectUrl` to `startSSOFlow` (see
+`lib/sso.ts` → `SSO_REDIRECT_URL`, consumed in `app/(auth)/sign-in.tsx` and
+`app/(auth)/sign-up.tsx`).
+
+**Symptom if missing:** Google SSO fails with a **"redirect url mismatch"**
+error — misleading, because the code is correct; the dashboard allowlist is the
+problem.
+
+## Google OAuth
+
+- A Google OAuth client must be configured for the Clerk instance (SSO
+  connection enabled for Google).
+- Until Google's consent screen is verified, Google caps the project at 100
+  logins — submit for verification before promoting to the App Store.
+
+## Apple SSO
+
+- Apple Services ID configured (Sign in with Apple connection enabled).
+- The app ships the `com.apple.developer.applesignin` entitlement and the
+  `expo-apple-authentication` plugin (see `app.config.ts`).
+
+## JWT (Convex)
+
+- `CLERK_JWT_ISSUER_DOMAIN` is set in the Convex dashboard for JWT validation
+  (see `convex/auth.config.ts`).

--- a/lib/sso.ts
+++ b/lib/sso.ts
@@ -1,0 +1,20 @@
+import * as AuthSession from 'expo-auth-session';
+
+/**
+ * Explicit redirect URL for Clerk's OAuth (Google) SSO flow — resolves to
+ * `bambino://sso-callback` in dev-client / standalone builds.
+ *
+ * ⚠️ This value MUST be listed in the Clerk Dashboard under
+ * Native applications → Allowed redirect URLs. If SSO starts failing with a
+ * (misleading) "redirect url mismatch" error after rotating Clerk apps or
+ * migrating instances, a missing entry here is the first thing to check.
+ * See docs/clerk-setup.md.
+ *
+ * Passing it explicitly to `startSSOFlow` (rather than relying on Clerk's
+ * internal default) keeps the value grep-able and pinned to the dashboard
+ * allowlist.
+ */
+export const SSO_REDIRECT_URL = AuthSession.makeRedirectUri({
+  scheme: 'bambino',
+  path: 'sso-callback',
+});


### PR DESCRIPTION
## What
`startSSOFlow` (Google SSO) was called without an explicit `redirectUrl`, so the value Clerk used was invisible in the code — despite a hard dependency on the Clerk Dashboard allowlist. Rotating Clerk apps / migrating instances produces a misleading **"redirect url mismatch"** with nothing in the repo pointing at the cause.

## Changes
- **`lib/sso.ts`** — `SSO_REDIRECT_URL` via `AuthSession.makeRedirectUri({ scheme: 'bambino', path: 'sso-callback' })`, a single grep-able source resolving to `bambino://sso-callback`
- Pass it explicitly in `sign-in.tsx` and `sign-up.tsx`, with a doc comment at each call site
- **`docs/clerk-setup.md`** — dashboard checklist (redirect URL, Google OAuth + 100-login cap, Apple SSO, Convex JWT issuer)

## ⚠️ Behavior / risk
The explicit value (`bambino://sso-callback`) matches the known-good Clerk allowlist entry and is the documented Clerk-Expo pattern, so this should be **behavior-preserving**. But it changes what's sent to Clerk, and the OAuth round-trip can't be verified headlessly.

**Required before relying on this:** smoke-test Google sign-in **and** sign-up on a clean dev-client/simulator — confirm the flow completes with no "redirect url mismatch". If it mismatches, the dashboard allowlist needs `bambino://sso-callback` (or revert this PR).

## Acceptance
- [x] `redirectUrl` passed explicitly in both flows
- [x] Doc comment at each call site references the dashboard requirement
- [x] `docs/clerk-setup.md` lists the checklist
- [ ] Manual: SSO completes on a clean simulator (see above)

## Verification
- `tsc --noEmit` clean
- `npm run lint` clean (touched files)

Closes #176

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)