### PR TITLE
fix: hydrate AsyncStorage prefs before tabs render, no cold-start flash (#177)

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -10,6 +10,8 @@ import { useStoreUser } from '@/hooks/use-store-user';
 import { usePushRegistration } from '@/hooks/use-push-registration';
 import { useOnboarding } from '@/hooks/use-onboarding';
 import { useTheme } from '@/contexts/theme-context';
+import { useSkinTone } from '@/contexts/skin-tone-context';
+import { useVoiceSettings } from '@/contexts/voice-settings-context';
 import { OnboardingScreens } from '@/components/onboarding';
 import { LoadingScreen } from '@/components/ui/loading-screen';
 
@@ -29,6 +31,13 @@ export default function TabsLayout() {
     isLoading: isOnboardingLoading,
     completeOnboarding,
   } = useOnboarding();
+  // AsyncStorage-backed prefs (#177). These hydrate well before the Convex
+  // getCurrentUser query, so gating on them here adds ~0ms — it just guarantees
+  // no flash of the default skin tone before the first screen renders. (They
+  // stay inside the user-keyed providers so they still reset on user switch —
+  // #154/#175 — which is why we gate here rather than hoisting them.)
+  const { isLoading: isSkinToneLoading } = useSkinTone();
+  const { isLoading: isVoiceLoading } = useVoiceSettings();
 
   if (!isSignedIn) {
     return <Redirect href="/(auth)/sign-in" />;
@@ -38,7 +47,13 @@ export default function TabsLayout() {
   // launch the root AuthGate already showed the loading animation; for
   // sign-out + sign-in on the same device this shows the Bambino loading
   // screen instead of a blank gradient.
-  if (convexUser === undefined || convexUser === null || isOnboardingLoading) {
+  if (
+    convexUser === undefined ||
+    convexUser === null ||
+    isOnboardingLoading ||
+    isSkinToneLoading ||
+    isVoiceLoading
+  ) {
     return <LoadingScreen isLoading />;
   }
 


### PR DESCRIPTION
## What
On cold start, an AsyncStorage-backed pref could show its default for ~1 frame before hydrating (e.g. a flash of the default skin tone). This folds the SkinTone + Voice `isLoading` flags into the **existing** `LoadingScreen` gate in `app/(tabs)/_layout.tsx`, so prefs are hydrated before the first screen that uses them renders.

## Why not the issue's literal approach
The issue suggested moving all four pref providers above `AuthGate`. Investigation showed that's stale/unsafe:
- **`OnboardingProvider` is now Convex-backed** (`useQuery(api.users.getCurrentUser)`, #154) — it can't move above `ConvexProviderWithClerk`, and onboarding is already gated separately here.
- **SkinTone/Voice are intentionally inside the user-keyed `ConvexProviderWithClerk`** (#154/#175) so they reset when user A signs out and B signs in. Hoisting them would make them device-scoped and regress that.
- **Theme is already gated** in `AuthGate`.

`(tabs)/_layout.tsx` already sits inside all three providers and already holds a loading screen for the Convex user row + onboarding, so gating there is the safe, no-reorder fix with no new blank state. The AsyncStorage reads finish well before the Convex `getCurrentUser` query, so this adds ~0ms — it just guarantees no flash. Auth screens don't use these prefs, so they need no gating.

## Acceptance
- [x] Prefs hydrated before the UI that uses them renders (skin tone/voice behind the existing gate; theme via AuthGate; onboarding via its existing gate)
- [x] No provider reorder → no #154/#175 regression (user switch still resets prefs)
- [ ] Manual: set non-default skin tone, force-quit, cold launch → no default-skin-tone flash before tabs (needs simulator)

## Verification
- `tsc --noEmit` clean
- `npm run lint` clean (touched file)

Closes #177

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)