### PR TITLE
perf: memoize swipe Pan + popularity-row Tap gestures (#213)

### DIFF
--- a/components/swipe/swipe-card.tsx
+++ b/components/swipe/swipe-card.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useCallback } from 'react';
+import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import { View, Text, StyleSheet, ScrollView, LayoutChangeEvent, Alert } from 'react-native';
 import * as Speech from 'expo-speech';
 import Animated, {
@@ -135,6 +135,16 @@ export function SwipeCard({
     onSwipeRight,
     enabled: isTop && swipeEnabled,
   });
+
+  // Memoized so the popularity-row tap gesture isn't rebuilt every render (#213).
+  const popularityTapGesture = useMemo(
+    () =>
+      Gesture.Tap().onEnd(() => {
+        'worklet';
+        if (onDetailPress) runOnJS(onDetailPress)();
+      }),
+    [onDetailPress],
+  );
 
   // Animated style to fade content during swipe
   const contentOpacityStyle = useAnimatedStyle(() => {
@@ -487,12 +497,7 @@ export function SwipeCard({
           )}
 
           {/* Popularity row — pinned to bottom; tappable to open detail */}
-          <GestureDetector
-            gesture={Gesture.Tap().onEnd(() => {
-              'worklet';
-              if (onDetailPress) runOnJS(onDetailPress)();
-            })}
-          >
+          <GestureDetector gesture={popularityTapGesture}>
             <Animated.View style={[styles.popularityRow, isTop && popularityAnimatedStyle]}>
               {/* Rank tile */}
               <View style={[styles.statTile, { backgroundColor: colors.surfaceSubtle }]}>

--- a/hooks/use-swipe-gesture.ts
+++ b/hooks/use-swipe-gesture.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Gesture } from 'react-native-gesture-handler';
 import { runOnJS, SharedValue } from 'react-native-reanimated';
 import * as Haptics from 'expo-haptics';
@@ -41,31 +41,38 @@ export function useSwipeGesture({
     onSwipeRight?.();
   }, [triggerHaptic, onSwipeRight]);
 
-  const panGesture = Gesture.Pan()
-    .enabled(enabled)
-    .onUpdate((event) => {
-      'worklet';
-      updatePosition(event.translationX, event.translationY);
-    })
-    .onEnd((event) => {
-      'worklet';
-      const { translationX, velocityX } = event;
+  // Memoized so the gesture object isn't rebuilt on every render (#213). Rebuilds
+  // only when a captured dependency changes; the callbacks are useCallback-stable
+  // and `enabled` is intentionally volatile (the gesture should re-arm on toggle).
+  const panGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .enabled(enabled)
+        .onUpdate((event) => {
+          'worklet';
+          updatePosition(event.translationX, event.translationY);
+        })
+        .onEnd((event) => {
+          'worklet';
+          const { translationX, velocityX } = event;
 
-      // Check if swipe passes threshold by position or velocity
-      const shouldSwipeRight = translationX > SWIPE_THRESHOLD || velocityX > SWIPE_VELOCITY;
-      const shouldSwipeLeft = translationX < -SWIPE_THRESHOLD || velocityX < -SWIPE_VELOCITY;
+          // Check if swipe passes threshold by position or velocity
+          const shouldSwipeRight = translationX > SWIPE_THRESHOLD || velocityX > SWIPE_VELOCITY;
+          const shouldSwipeLeft = translationX < -SWIPE_THRESHOLD || velocityX < -SWIPE_VELOCITY;
 
-      if (shouldSwipeRight) {
-        swipeRight();
-        runOnJS(handleSwipeRight)();
-      } else if (shouldSwipeLeft) {
-        swipeLeft();
-        runOnJS(handleSwipeLeft)();
-      } else {
-        // Didn't pass threshold, spring back to center
-        resetPosition();
-      }
-    });
+          if (shouldSwipeRight) {
+            swipeRight();
+            runOnJS(handleSwipeRight)();
+          } else if (shouldSwipeLeft) {
+            swipeLeft();
+            runOnJS(handleSwipeLeft)();
+          } else {
+            // Didn't pass threshold, spring back to center
+            resetPosition();
+          }
+        }),
+    [enabled, updatePosition, resetPosition, swipeLeft, swipeRight, handleSwipeLeft, handleSwipeRight],
+  );
 
   return {
     panGesture,


### PR DESCRIPTION
## What
`Gesture.Pan()` (`hooks/use-swipe-gesture.ts`) and the popularity-row `Gesture.Tap()` (`components/swipe/swipe-card.tsx`) were reconstructed on every render. Wrapped both in `useMemo` so the gesture object only rebuilds when a captured dep changes.

- Pan deps: `[enabled, updatePosition, resetPosition, swipeLeft, swipeRight, handleSwipeLeft, handleSwipeRight]` — the `handle*`/`triggerHaptic` callbacks are already `useCallback`-stable; `enabled` stays volatile so the gesture re-arms on toggle.
- Tap deps: `[onDetailPress]`.

Behavior-preserving perf change — no visible/UX change intended.

## ⚠️ Verify before merge (held for review)
This is the **core swipe interaction**, so please smoke-test in the simulator:
- Swipe left/right still works and triggers like/nope + haptics
- Tapping the popularity row still opens the name detail modal

## Verification
- `tsc --noEmit` clean
- `npm run lint` clean (both files)

Closes #213

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)