### PR TITLE
fix: confetti theme-switch flicker (#215) + voice Spoken Content copy (#226)

### DIFF
--- a/components/settings/voice-settings-section.tsx
+++ b/components/settings/voice-settings-section.tsx
@@ -200,7 +200,8 @@ export function VoiceSettingsSection() {
           <View style={[styles.infoNote, { backgroundColor: colors.surfaceSubtle }]}>
             <Ionicons name="information-circle" size={20} color="#FFB86C" />
             <Text style={styles.infoNoteText}>
-              If you cannot hear the voice, make sure your device is not on silent mode.
+              If you cannot hear the voice, make sure your device is not on silent mode. On iOS,
+              also check that Spoken Content is enabled (Settings → Accessibility → Spoken Content).
             </Text>
           </View>
         </>

--- a/components/ui/confetti.tsx
+++ b/components/ui/confetti.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { StyleSheet, Dimensions } from 'react-native';
 import Animated, {
   useSharedValue,
@@ -104,7 +104,15 @@ export function Confetti({ visible }: ConfettiProps) {
     [colors.primary, colors.secondary],
   );
 
-  const pieces = useMemo(() => generatePieces(confettiColors), [confettiColors]);
+  // Generate pieces only when the modal opens (visible false→true), capturing the
+  // theme colors active at that moment. Identical look to before, but it no longer
+  // regenerates — and flickers — if the theme changes mid-celebration (#215).
+  const [pieces, setPieces] = useState<ConfettiPiece[]>(() => generatePieces(confettiColors));
+  const [wasVisible, setWasVisible] = useState(visible);
+  if (visible !== wasVisible) {
+    setWasVisible(visible);
+    if (visible) setPieces(generatePieces(confettiColors));
+  }
 
   // Skip the falling-pieces animation under Reduce Motion (#192). The
   // celebration modal itself still shows; only the confetti is suppressed.


### PR DESCRIPTION
Two small approved UI tweaks.

## #215 — confetti regenerates on mid-celebration theme switch
Pieces were a `useMemo` keyed on theme-derived `confettiColors`, so changing theme while a celebration was on screen regenerated all 20 pieces (flicker). Now pieces are generated only when the modal becomes visible (React derived-state pattern), capturing the theme colors active at that moment.

**Visually identical** in normal use (same theme-tinted colors); only the redundant mid-celebration regeneration is removed. (Kept the current colors per maintainer preference — did not switch to a fixed palette.)

## #226 — voice help copy
The info note now also tells users to enable iOS Spoken Content (Settings → Accessibility → Spoken Content), a common cause of silent TTS. Additive text only.

## Verification
- `tsc --noEmit` clean
- `npm run lint` clean (0 errors)

Closes #215
Closes #226

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)