### PR TITLE
chore: enable react-native/no-unused-styles ESLint rule (#222)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ const { defineConfig } = require('eslint/config');
 const expoConfig = require('eslint-config-expo/flat');
 const pluginPrettier = require('eslint-plugin-prettier');
 const configPrettier = require('eslint-config-prettier');
+const pluginReactNative = require('eslint-plugin-react-native');
 
 module.exports = defineConfig([
   expoConfig,
@@ -10,6 +11,14 @@ module.exports = defineConfig([
     plugins: { prettier: pluginPrettier },
     rules: {
       'prettier/prettier': ['error'],
+    },
+  },
+  {
+    // Catch StyleSheet.create entries that are never referenced (#222). 'warn'
+    // so it surfaces dead styles without blocking; CI lint can flag new ones.
+    plugins: { 'react-native': pluginReactNative },
+    rules: {
+      'react-native/no-unused-styles': 'warn',
     },
   },
   configPrettier,

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "eslint-config-expo": "~10.0.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.5",
+        "eslint-plugin-react-native": "^5.0.0",
         "prettier": "^3.8.3",
         "prettier-plugin-tailwindcss": "^0.8.0",
         "tailwindcss": "^3.4.19",
@@ -8856,6 +8857,26 @@
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
+    },
+    "node_modules/eslint-plugin-react-native": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-native/-/eslint-plugin-react-native-5.0.0.tgz",
+      "integrity": "sha512-VyWlyCC/7FC/aONibOwLkzmyKg4j9oI8fzrk9WYNs4I8/m436JuOTAFwLvEn1CVvc7La4cPfbCyspP4OYpP52Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-plugin-react-native-globals": "^0.1.1"
+      },
+      "peerDependencies": {
+        "eslint": "^3.17.0 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-react-native-globals": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-native-globals/-/eslint-plugin-react-native-globals-0.1.2.tgz",
+      "integrity": "sha512-9aEPf1JEpiTjcFAmmyw8eiIXmcNZOqaZyHO77wgm0/dWfT/oxC1SrIq8ET38pMxHYrcB6Uew+TzUVsBeczF88g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
       "version": "2.0.0-next.5",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "eslint-config-expo": "~10.0.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
+    "eslint-plugin-react-native": "^5.0.0",
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "tailwindcss": "^3.4.19",


### PR DESCRIPTION
## What
Adds `eslint-plugin-react-native` and enables `react-native/no-unused-styles: 'warn'` to catch dead `StyleSheet.create` entries.

## Compatibility verified
- The plugin loads on the project's **ESLint 9 flat config** (`eslint.config.js`) without error.
- Confirmed the rule is actually active by planting a dummy unused style → it warned (`Unused style detected: styles.zzUnusedProbe`), then reverted.
- Codebase is currently **clean** (0 unused styles flagged).

`'warn'` (not `error`) keeps it non-blocking; CI lint will surface new dead styles. Dev-dependency only — not bundled into the app, so no native rebuild needed.

## Verification
- `npm run lint` runs with the rule (0 errors, only pre-existing warnings)

Closes #222

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)