### PR TITLE
fix: move Restore Purchase from Matches empty state to Profile (#227)

### DIFF
--- a/app/(tabs)/matches.tsx
+++ b/app/(tabs)/matches.tsx
@@ -1,14 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import {
-  View,
-  Text,
-  StyleSheet,
-  FlatList,
-  Pressable,
-  Share,
-  Alert,
-  ActivityIndicator,
-} from 'react-native';
+import { View, Text, StyleSheet, FlatList, Pressable, Share, Alert } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Animated, { FadeInDown, FadeInUp } from 'react-native-reanimated';
 import { useQuery, useMutation } from 'convex/react';
@@ -21,7 +12,6 @@ import { useTheme } from '@/contexts/theme-context';
 import { useEffectivePremium } from '@/hooks/use-effective-premium';
 import { Events, trackEvent, trackScreen } from '@/lib/analytics';
 import { alertMatchMutationError } from '@/components/matches/match-error-alert';
-import { usePurchases } from '@/hooks/use-purchases';
 import { Paywall } from '@/components/paywall';
 import {
   MatchCard,
@@ -54,7 +44,6 @@ type MatchWithName = FunctionReturnType<typeof api.matches.getMatches>[number];
 export default function Matches() {
   const { colors } = useTheme();
   const { isPremium } = useEffectivePremium();
-  const { restorePurchases } = usePurchases();
   const router = useRouter();
   const [sortBy, setSortBy] = useState<MatchSortOption>('newest');
   const [searchInput, setSearchInput] = useState('');
@@ -67,7 +56,6 @@ export default function Matches() {
     message: string | undefined;
     partnerProposalName: string;
   } | null>(null);
-  const [isRestoring, setIsRestoring] = useState(false);
   const [showDeclineSheet, setShowDeclineSheet] = useState(false);
   const [reportMatchId, setReportMatchId] = useState<Id<'matches'> | null>(null);
   const [showCelebration, setShowCelebration] = useState(false);
@@ -338,32 +326,6 @@ export default function Matches() {
                   onPress={() => setShowPaywall(true)}
                 >
                   <Text style={styles.ctaButtonText}>Upgrade to Premium</Text>
-                </Pressable>
-                <Pressable
-                  style={styles.restoreButton}
-                  disabled={isRestoring}
-                  onPress={async () => {
-                    setIsRestoring(true);
-                    try {
-                      const success = await restorePurchases();
-                      if (success) {
-                        Alert.alert('Restored', 'Your premium purchase has been restored!');
-                      } else {
-                        Alert.alert(
-                          'No Purchase Found',
-                          'No previous purchase was found to restore.',
-                        );
-                      }
-                    } finally {
-                      setIsRestoring(false);
-                    }
-                  }}
-                >
-                  {isRestoring ? (
-                    <ActivityIndicator size="small" color={colors.primary} />
-                  ) : (
-                    <Text style={styles.restoreButtonText}>Restore Purchase</Text>
-                  )}
                 </Pressable>
               </View>
             )}
@@ -657,14 +619,5 @@ const styles = StyleSheet.create({
     fontSize: 15,
     fontFamily: Fonts?.title || 'Gabarito_800ExtraBold',
     color: '#fff',
-  },
-  restoreButton: {
-    paddingVertical: 8,
-    zIndex: 10,
-  },
-  restoreButtonText: {
-    fontSize: 13,
-    fontFamily: Fonts?.sans,
-    color: '#A89BB5',
   },
 });

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -25,6 +25,7 @@ import { useQuery, useMutation } from 'convex/react';
 import { Ionicons } from '@expo/vector-icons';
 import { api } from '@/convex/_generated/api';
 import { useEffectivePremium } from '@/hooks/use-effective-premium';
+import { usePurchases } from '@/hooks/use-purchases';
 import { Paywall } from '@/components/paywall';
 import { PartnerLinkModal } from '@/components/partner/partner-link-modal';
 import { NameConfirmationModal } from '@/components/partner/name-confirmation-modal';
@@ -100,6 +101,7 @@ export default function Profile() {
     partnerName: premiumPartnerName,
     gracePeriodEndsAt,
   } = useEffectivePremium();
+  const { restorePurchases } = usePurchases();
   const deleteAccount = useMutation(api.users.deleteAccount);
   const clearPushToken = useMutation(api.users.clearPushToken);
   const unlinkPartner = useMutation(api.partners.unlinkPartner);
@@ -108,6 +110,7 @@ export default function Profile() {
   const convexUser = useQuery(api.users.getCurrentUser);
   const [isLoading, setIsLoading] = useState(false);
   const [isUnlinking, setIsUnlinking] = useState(false);
+  const [isRestoring, setIsRestoring] = useState(false);
   const [showPaywall, setShowPaywall] = useState(false);
   const [showPartnerModal, setShowPartnerModal] = useState(false);
   const [showNameConfirmation, setShowNameConfirmation] = useState(false);
@@ -404,6 +407,31 @@ export default function Profile() {
               gradients={gradients}
               onPress={() => setShowPaywall(true)}
             />
+            {/* Restore Purchase lives here (account actions), moved out of the
+                Matches empty state where it was a discovery mismatch (#227). */}
+            <Pressable
+              style={styles.restoreButton}
+              disabled={isRestoring}
+              onPress={async () => {
+                setIsRestoring(true);
+                try {
+                  const success = await restorePurchases();
+                  if (success) {
+                    Alert.alert('Restored', 'Your premium purchase has been restored!');
+                  } else {
+                    Alert.alert('No Purchase Found', 'No previous purchase was found to restore.');
+                  }
+                } finally {
+                  setIsRestoring(false);
+                }
+              }}
+            >
+              {isRestoring ? (
+                <ActivityIndicator size="small" color={colors.primary} />
+              ) : (
+                <Text style={styles.restoreButtonText}>Restore Purchase</Text>
+              )}
+            </Pressable>
           </Animated.View>
         )}
 
@@ -750,6 +778,16 @@ const styles = StyleSheet.create({
   /* Premium banner */
   premiumSection: {
     marginBottom: 24,
+  },
+  restoreButton: {
+    paddingVertical: 10,
+    marginTop: 4,
+    alignItems: 'center',
+  },
+  restoreButtonText: {
+    fontSize: 13,
+    fontFamily: Fonts?.sans,
+    color: '#A89BB5',
   },
   premiumBannerWrap: {
     borderRadius: 16,


### PR DESCRIPTION
## What
Restore Purchase only existed in the **Matches empty state** for free users — a discovery anti-pattern (it doesn't belong on a feature-locked matches screen). Move it to **Profile**, alongside the upgrade banner / account actions.

- **Profile** (`app/(tabs)/profile.tsx`): add a "Restore Purchase" button under `PremiumBanner` in the `!isPremium` block, using `usePurchases().restorePurchases` with the same `Restored` / `No Purchase Found` alerts and an `ActivityIndicator` while restoring.
- **Matches** (`app/(tabs)/matches.tsx`): remove the button and all now-dead code — `isRestoring` state, `usePurchases` import + `restorePurchases`, the `ActivityIndicator` import (now unused), and the `restoreButton`/`restoreButtonText` styles. "Upgrade to Premium" stays.

## ⚠️ Held for review (UI change + device test)
- Visual: Restore Purchase now appears in Profile's premium section, gone from Matches.
- **Needs a RevenueCat restore device test**: Profile → Restore Purchase → success path (restores entitlement) and no-purchase path. (Can't be exercised headlessly.)

## Verification
- `tsc --noEmit` clean
- `npm run lint` clean (incl. the new no-unused-styles rule — confirms no dangling styles)

Closes #227

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)