### PR TITLE
fix: a11y labels/roles + 44pt filter-pill hit target (#209, #210)

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -356,7 +356,13 @@ export default function Profile() {
           entering={FadeInDown.duration(500).springify()}
           style={styles.userInfoSection}
         >
-          <Pressable onPress={handleAvatarPress} disabled={isUploading}>
+          <Pressable
+            onPress={handleAvatarPress}
+            disabled={isUploading}
+            accessibilityRole="button"
+            accessibilityLabel="Edit profile photo"
+            accessibilityState={{ disabled: isUploading }}
+          >
             {user?.hasImage ? (
               <View style={[styles.avatarRing, { borderColor: colors.primary }]}>
                 <Image source={{ uri: user.imageUrl }} style={styles.avatar} />
@@ -387,7 +393,12 @@ export default function Profile() {
             )}
           </Pressable>
 
-          <Pressable onPress={handleEditName} style={styles.nameRow}>
+          <Pressable
+            onPress={handleEditName}
+            style={styles.nameRow}
+            accessibilityRole="button"
+            accessibilityLabel="Edit name"
+          >
             <Text style={styles.userName}>{convexUser?.name || user?.fullName || 'User'}</Text>
             <Ionicons name="pencil" size={16} color="#A89BB5" />
           </Pressable>
@@ -598,7 +609,12 @@ export default function Profile() {
         >
           <Text style={styles.sectionTitle}>Other</Text>
           <View style={styles.settingsCard}>
-            <Pressable style={styles.settingsCardRow} onPress={resetOnboarding}>
+            <Pressable
+              style={styles.settingsCardRow}
+              onPress={resetOnboarding}
+              accessibilityRole="button"
+              accessibilityLabel="How It Works"
+            >
               <Ionicons
                 name="help-circle-outline"
                 size={22}
@@ -613,6 +629,8 @@ export default function Profile() {
           <View style={styles.settingsCard}>
             <Pressable
               style={styles.settingsCardRow}
+              accessibilityRole="button"
+              accessibilityLabel="Privacy Policy"
               onPress={() =>
                 WebBrowser.openBrowserAsync(
                   'https://bambino-baby.notion.site/325d3b58308281158ce6c6cbdd562734',
@@ -632,6 +650,8 @@ export default function Profile() {
           <View style={styles.settingsCard}>
             <Pressable
               style={styles.settingsCardRow}
+              accessibilityRole="button"
+              accessibilityLabel="Terms of Service"
               onPress={() =>
                 WebBrowser.openBrowserAsync(
                   'https://bambino-baby.notion.site/325d3b58308281768597f8bd57581eb7',

--- a/components/onboarding/onboarding-screens.tsx
+++ b/components/onboarding/onboarding-screens.tsx
@@ -85,10 +85,16 @@ export function OnboardingScreens({ onComplete }: OnboardingScreensProps) {
       {/* Bottom area: dots + button */}
       <View style={styles.bottomArea}>
         {/* Pagination dots */}
-        <View style={styles.dotsRow}>
+        <View
+          style={styles.dotsRow}
+          accessibilityRole="progressbar"
+          accessibilityLabel={`Page ${currentIndex + 1} of ${TOTAL_SCREENS}`}
+        >
           {Array.from({ length: TOTAL_SCREENS }).map((_, i) => (
             <View
               key={i}
+              accessibilityElementsHidden
+              importantForAccessibility="no-hide-descendants"
               style={[styles.dot, i === currentIndex ? styles.dotActive : styles.dotInactive]}
             />
           ))}

--- a/components/settings/theme-picker-section.tsx
+++ b/components/settings/theme-picker-section.tsx
@@ -50,7 +50,13 @@ function ThemeCard({
 
   return (
     <Animated.View style={[styles.themeCard, cardBorderStyle]}>
-      <Pressable style={styles.themeCardInner} onPress={onSelect}>
+      <Pressable
+        style={styles.themeCardInner}
+        onPress={onSelect}
+        accessibilityRole="radio"
+        accessibilityState={{ selected: isSelected }}
+        accessibilityLabel={`Select ${meta.name} theme`}
+      >
         <View style={styles.swatchWrap}>
           <LinearGradient
             colors={[...meta.previewColors]}

--- a/components/swipe/explore-header.tsx
+++ b/components/swipe/explore-header.tsx
@@ -20,9 +20,9 @@ export function ExploreHeader({ liked, activeFilterCount, onFilterPress }: Explo
       <Pressable
         style={[styles.filterPill, { shadowColor: colors.secondary }]}
         onPress={onFilterPress}
-        accessibilityLabel="Filters"
+        accessibilityLabel={`Filters${activeFilterCount > 0 ? `, ${activeFilterCount} active` : ''}`}
         accessibilityRole="button"
-        hitSlop={8}
+        hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
       >
         <Ionicons name="options-outline" size={16} color="#2D1B4E" />
         <Text style={styles.filterLabel}>Filters</Text>

--- a/components/swipe/swipe-card.tsx
+++ b/components/swipe/swipe-card.tsx
@@ -498,7 +498,13 @@ export function SwipeCard({
 
           {/* Popularity row — pinned to bottom; tappable to open detail */}
           <GestureDetector gesture={popularityTapGesture}>
-            <Animated.View style={[styles.popularityRow, isTop && popularityAnimatedStyle]}>
+            <Animated.View
+              style={[styles.popularityRow, isTop && popularityAnimatedStyle]}
+              accessible
+              accessibilityRole="button"
+              accessibilityLabel="Popularity and ranking"
+              accessibilityHint="Double tap to view name details"
+            >
               {/* Rank tile */}
               <View style={[styles.statTile, { backgroundColor: colors.surfaceSubtle }]}>
                 <Text style={styles.statLabel}>RANK</Text>


### PR DESCRIPTION
## #209 — accessibility labels/roles
Adds `accessibilityLabel`/`Role`/`State` to actionable elements VoiceOver previously read as bare images or unlabeled buttons:
- **profile.tsx**: avatar (button, "Edit profile photo", disabled state), edit-name row, and the How It Works / Privacy Policy / Terms of Service rows
- **theme-picker-section.tsx**: theme swatches → `role=radio` + `selected` state + "Select <name> theme"
- **onboarding-screens.tsx**: pagination dots → container `progressbar` "Page N of M", inner dots hidden from the a11y tree
- **swipe-card.tsx**: popularity row (inside `GestureDetector`) → `accessible` button + hint
- **explore-header.tsx**: filter-pill label now includes the active filter count

## #210 — filter-pill hit target
`hitSlop={8}` → `{ top: 12, bottom: 12, left: 8, right: 8 }` for a ~44pt vertical touch target.

**No visual or layout change** — labels/roles + hitSlop only.

## Verification
- `tsc --noEmit` clean
- `npm run lint` clean
- (Optional) VoiceOver: each element now announces a name/role; filter-pill tap area feels ≥44pt.

Closes #209
Closes #210

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)