### PR TITLE
perf: SVG mini-sparkline (#214) + Dynamic Type guard (#212)

### DIFF
--- a/components/swipe/mini-sparkline.tsx
+++ b/components/swipe/mini-sparkline.tsx
@@ -1,0 +1,71 @@
+import Svg, { Path } from 'react-native-svg';
+
+interface MiniSparklineProps {
+  /** Series to plot left→right; higher value = higher on screen. */
+  points: number[];
+  width?: number;
+  height?: number;
+  color: string;
+  strokeWidth?: number;
+}
+
+/**
+ * Lightweight sparkline — a single SVG <Path> — replacing the per-card
+ * react-native-gifted-charts LineChart on the swipe card (#214). The full
+ * PopularityChart still uses gifted-charts; this is just the 80×28 spark.
+ *
+ * Uses a Catmull-Rom → cubic Bézier smoothing to match gifted-charts' `curved`
+ * line look.
+ */
+export function MiniSparkline({
+  points,
+  width = 80,
+  height = 28,
+  color,
+  strokeWidth = 2,
+}: MiniSparklineProps) {
+  if (points.length < 2) return null;
+
+  const min = Math.min(...points);
+  const max = Math.max(...points);
+  const range = max - min || 1;
+
+  // Inset by half the stroke so the line isn't clipped at the top/bottom edges.
+  const pad = strokeWidth / 2;
+  const stepX = (width - pad * 2) / (points.length - 1);
+
+  const coords = points.map((v, i) => ({
+    x: pad + i * stepX,
+    y: pad + (height - pad * 2) * (1 - (v - min) / range),
+  }));
+
+  const start = coords[0];
+  if (!start) return null;
+
+  let d = `M${start.x},${start.y}`;
+  for (let i = 0; i < coords.length - 1; i++) {
+    const p1 = coords[i];
+    const p2 = coords[i + 1];
+    if (!p1 || !p2) continue;
+    const p0 = coords[i - 1] ?? p1;
+    const p3 = coords[i + 2] ?? p2;
+    const cp1x = p1.x + (p2.x - p0.x) / 6;
+    const cp1y = p1.y + (p2.y - p0.y) / 6;
+    const cp2x = p2.x - (p3.x - p1.x) / 6;
+    const cp2y = p2.y - (p3.y - p1.y) / 6;
+    d += ` C${cp1x},${cp1y} ${cp2x},${cp2y} ${p2.x},${p2.y}`;
+  }
+
+  return (
+    <Svg width={width} height={height}>
+      <Path
+        d={d}
+        stroke={color}
+        strokeWidth={strokeWidth}
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Svg>
+  );
+}

--- a/components/swipe/swipe-card.tsx
+++ b/components/swipe/swipe-card.tsx
@@ -21,7 +21,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useQuery } from 'convex/react';
 import { Doc } from '@/convex/_generated/dataModel';
 import { api } from '@/convex/_generated/api';
-import { LineChart } from 'react-native-gifted-charts';
+import { MiniSparkline } from './mini-sparkline';
 import { useCardAnimation } from '@/hooks/use-card-animation';
 import { useSwipeGesture } from '@/hooks/use-swipe-gesture';
 import { useVoiceSettings } from '@/contexts/voice-settings-context';
@@ -436,6 +436,8 @@ export function SwipeCard({
           <Text
             style={[styles.name, { fontSize: getNameFontSize(name.name) }]}
             onLayout={handleNameLayout}
+            numberOfLines={1}
+            adjustsFontSizeToFit
           >
             {name.name}
           </Text>
@@ -523,22 +525,12 @@ export function SwipeCard({
                     {popularitySummary && popularitySummary.sparklinePoints.length > 1 ? (
                       <>
                         <View style={styles.sparklineChart}>
-                          <LineChart
-                            data={popularitySummary.sparklinePoints.map((value) => ({ value }))}
+                          <MiniSparkline
+                            points={popularitySummary.sparklinePoints}
                             width={80}
                             height={28}
-                            hideDataPoints
-                            hideYAxisText
-                            hideAxesAndRules
                             color={underlineColor}
-                            thickness={2}
-                            curved
-                            initialSpacing={0}
-                            endSpacing={0}
-                            spacing={80 / Math.max(popularitySummary.sparklinePoints.length - 1, 1)}
-                            disableScroll
-                            adjustToWidth
-                            isAnimated={false}
+                            strokeWidth={2}
                           />
                         </View>
                         {popularitySummary.trend && (


### PR DESCRIPTION
## #214 — swipe-card sparkline → SVG
The 80×28 sparkline at the bottom of every swipe card used `react-native-gifted-charts` `LineChart`, mounting the chart machinery per card (the hot swipe path). Replaced with a single hand-rolled SVG `<Path>` (`components/swipe/mini-sparkline.tsx`, `react-native-svg` — already a dep), using Catmull-Rom→cubic-bézier smoothing to match the old `curved` line, same gender color + thickness.

The full `PopularityChart` (name detail / popularity screens) **still uses gifted-charts** — only the per-card spark changed.

## #212 — Dynamic Type
Added `numberOfLines={1}` + `adjustsFontSizeToFit` to the card name so it auto-shrinks at extreme iOS Dynamic Type instead of overflowing. No change at normal text sizes.

## ⚠️ Held for your visual check (simulator)
- Sparkline looks the same as the old LineChart (smooth curve, gender color, no dots).
- Card name: at Settings → Display → Text Size max (and a long name), it fits on one line; normal sizes look unchanged.

## Verification
- `tsc --noEmit` clean
- `npm run lint` clean
- No dependency change (react-native-svg already present; gifted-charts retained for PopularityChart).

Closes #214
Closes #212

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)