### PR TITLE
feat: in-app notifications toggle (#229)

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -33,6 +33,7 @@ import {
   ThemePickerSection,
   SkinToneSection,
   VoiceSettingsSection,
+  NotificationsSection,
   FeedbackSection,
 } from '@/components/settings';
 import { GradientBackground } from '@/components/ui/gradient-background';
@@ -600,6 +601,7 @@ export default function Profile() {
           <ThemePickerSection />
           <SkinToneSection />
           <VoiceSettingsSection />
+          <NotificationsSection />
         </Animated.View>
 
         {/* Other */}

--- a/components/settings/index.ts
+++ b/components/settings/index.ts
@@ -1,4 +1,5 @@
 export { ThemePickerSection } from './theme-picker-section';
 export { SkinToneSection } from './skin-tone-section';
 export { VoiceSettingsSection } from './voice-settings-section';
+export { NotificationsSection } from './notifications-section';
 export { FeedbackSection } from './feedback-section';

--- a/components/settings/notifications-section.tsx
+++ b/components/settings/notifications-section.tsx
@@ -1,0 +1,84 @@
+import { View, Text, StyleSheet, Switch } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useQuery, useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { useTheme } from '@/contexts/theme-context';
+import { Fonts } from '@/constants/theme';
+import { Events, trackEvent } from '@/lib/analytics';
+
+/**
+ * In-app push-notifications toggle (#229). Writes users.pushNotificationsEnabled;
+ * absent/true = on, false = off (the send path checks this). iOS-level mute still
+ * applies independently — this is the in-app control.
+ */
+export function NotificationsSection() {
+  const { colors } = useTheme();
+  const user = useQuery(api.users.getCurrentUser);
+  const setEnabled = useMutation(api.users.setPushNotificationsEnabled);
+
+  const enabled = user?.pushNotificationsEnabled !== false;
+
+  const handleToggle = (value: boolean) => {
+    trackEvent(Events.NOTIFICATIONS_TOGGLED, { enabled: value });
+    setEnabled({ enabled: value });
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.row}>
+        <Ionicons
+          name="notifications-outline"
+          size={22}
+          color="#6B5B7B"
+          style={{ marginRight: 12 }}
+        />
+        <View style={styles.textWrap}>
+          <Text style={styles.title}>Notifications</Text>
+          <Text style={styles.subtitle}>Match & proposal alerts from your partner</Text>
+        </View>
+        <Switch
+          value={enabled}
+          onValueChange={handleToggle}
+          disabled={user === undefined}
+          trackColor={{ false: '#E5DDD0', true: colors.primary }}
+          thumbColor="#FFFFFF"
+          ios_backgroundColor="#E5DDD0"
+          accessibilityLabel="Toggle notifications"
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: '#ffffff',
+    borderRadius: 16,
+    padding: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 2,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  textWrap: {
+    flex: 1,
+    marginRight: 12,
+  },
+  title: {
+    fontSize: 18,
+    fontFamily: Fonts?.sans,
+    fontWeight: '600',
+    color: '#2D1B4E',
+  },
+  subtitle: {
+    fontSize: 14,
+    fontFamily: Fonts?.sans,
+    color: '#6B5B7B',
+    marginTop: 2,
+  },
+});

--- a/convex/notifications.ts
+++ b/convex/notifications.ts
@@ -16,6 +16,8 @@ export const getRecipientPushToken = internalQuery({
     return {
       token: user.pushToken,
       platform: user.pushTokenPlatform ?? null,
+      // Absent = enabled; only an explicit false opts out (#229).
+      enabled: user.pushNotificationsEnabled !== false,
     };
   },
 });
@@ -28,13 +30,21 @@ export const sendPushNotification = internalAction({
     data: v.optional(v.any()),
   },
   handler: async (ctx, args): Promise<{ sent: boolean; reason?: string }> => {
-    const recipient: { token: string; platform: 'ios' | 'android' | null } | null =
-      await ctx.runQuery(internal.notifications.getRecipientPushToken, {
-        userId: args.userId as Id<'users'>,
-      });
+    const recipient: {
+      token: string;
+      platform: 'ios' | 'android' | null;
+      enabled: boolean;
+    } | null = await ctx.runQuery(internal.notifications.getRecipientPushToken, {
+      userId: args.userId as Id<'users'>,
+    });
 
     if (!recipient) {
       return { sent: false, reason: 'no_token' };
+    }
+
+    // Respect the user's in-app notifications toggle (#229).
+    if (!recipient.enabled) {
+      return { sent: false, reason: 'disabled' };
     }
 
     try {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -32,6 +32,8 @@ export default defineSchema({
     originFilter: v.optional(v.array(v.string())),
     pushToken: v.optional(v.string()),
     pushTokenPlatform: v.optional(v.union(v.literal('ios'), v.literal('android'))),
+    // Absent = enabled; only an explicit false opts out of push (#229).
+    pushNotificationsEnabled: v.optional(v.boolean()),
     createdAt: v.number(),
     updatedAt: v.number(),
   })

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -304,6 +304,19 @@ export const setOnboardingCompleted = mutation({
   },
 });
 
+/** In-app toggle for push notifications (#229). Absent = enabled; only an
+ *  explicit false suppresses sends (enforced in notifications.sendPushNotification). */
+export const setPushNotificationsEnabled = mutation({
+  args: { enabled: v.boolean() },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUserOrThrow(ctx);
+    await ctx.db.patch(user._id, {
+      pushNotificationsEnabled: args.enabled,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
 /** Drop the device's push token from this user's row. Called on sign-out
  *  to prevent cross-user notifications on shared devices (#172). */
 export const clearPushToken = mutation({

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -72,6 +72,7 @@ export const Events = {
   THEME_CHANGED: 'theme_changed',
   SKIN_TONE_CHANGED: 'skin_tone_changed',
   VOICE_CHANGED: 'voice_changed',
+  NOTIFICATIONS_TOGGLED: 'notifications_toggled',
   FILTERS_CHANGED: 'filters_changed',
 
   // Paywall & purchases


### PR DESCRIPTION
## What
Adds an in-app toggle to disable Bambino push notifications (separate from iOS-level mute). Absent/true = enabled, explicit false = off.

- **schema** (`convex/schema.ts`): `users.pushNotificationsEnabled` (optional boolean)
- **mutation** (`convex/users.ts`): `setPushNotificationsEnabled({ enabled })`
- **send-time check** (`convex/notifications.ts`): `getRecipientPushToken` returns an `enabled` flag; `sendPushNotification` returns `{ sent: false, reason: 'disabled' }` when off (default still sends)
- **UI**: `NotificationsSection` (RN `Switch`) added to Profile → Settings, reading `getCurrentUser().pushNotificationsEnabled ?? true`

Default behavior unchanged — existing users (field absent) stay enabled.

## ⚠️ Held for your review (new visible UI + behavior)
- New "Notifications" toggle row in Profile → Settings.
- Quick device check: toggle off → no match/proposal push arrives (send returns `reason:'disabled'`); toggle on → push resumes. Persists across app launches.

## Verification
- `convex codegen` clean
- `tsc --noEmit` clean
- `npm run lint` clean

Closes #229

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)