### PR TITLE
fix: notifications toggle — premium-only + partner-centered copy + optimistic flip (#229 follow-up)

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -601,7 +601,9 @@ export default function Profile() {
           <ThemePickerSection />
           <SkinToneSection />
           <VoiceSettingsSection />
-          <NotificationsSection />
+          {/* Notifications are partner match/proposal alerts — only relevant to
+              premium users, who are the ones that can link a partner (#229). */}
+          {isPremium && <NotificationsSection />}
         </Animated.View>
 
         {/* Other */}

--- a/components/settings/notifications-section.tsx
+++ b/components/settings/notifications-section.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, Switch } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useQuery, useMutation } from 'convex/react';
@@ -16,11 +17,20 @@ export function NotificationsSection() {
   const user = useQuery(api.users.getCurrentUser);
   const setEnabled = useMutation(api.users.setPushNotificationsEnabled);
 
-  const enabled = user?.pushNotificationsEnabled !== false;
+  const serverEnabled = user?.pushNotificationsEnabled !== false;
+  // Optimistic override so the switch flips instantly instead of waiting for the
+  // Convex round-trip; cleared once the server value catches up, reverted on error.
+  const [optimistic, setOptimistic] = useState<boolean | null>(null);
+  const enabled = optimistic ?? serverEnabled;
+
+  useEffect(() => {
+    if (optimistic !== null && serverEnabled === optimistic) setOptimistic(null);
+  }, [serverEnabled, optimistic]);
 
   const handleToggle = (value: boolean) => {
+    setOptimistic(value);
     trackEvent(Events.NOTIFICATIONS_TOGGLED, { enabled: value });
-    setEnabled({ enabled: value });
+    setEnabled({ enabled: value }).catch(() => setOptimistic(null));
   };
 
   return (
@@ -34,7 +44,7 @@ export function NotificationsSection() {
         />
         <View style={styles.textWrap}>
           <Text style={styles.title}>Notifications</Text>
-          <Text style={styles.subtitle}>Match & proposal alerts from your partner</Text>
+          <Text style={styles.subtitle}>Partner matches & proposals</Text>
         </View>
         <Switch
           value={enabled}


### PR DESCRIPTION
Follow-up refinements to the #229 notifications toggle, all maintainer-requested:

- **Premium-only**: the toggle now renders only for premium users (`isPremium` gate in Profile). Match/proposal alerts only matter to users who can link a partner, so free users don't see it.
- **Copy**: "Match & proposal alerts from your partner" → **"Partner matches & proposals"** — one line, partner-centered.
- **Optimistic flip**: the `Switch` was driven straight off the `getCurrentUser` query, so it only flipped after the Convex round-trip (visible lag). Added an optimistic local override that flips instantly, reconciles when the server value lands, and reverts on mutation failure.

Client-only (no Convex change) — just reload to see it.

## Verification
- `tsc --noEmit` clean
- `npm run lint` clean

Follow-up to #229.

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)