### PR TITLE
docs: rewrite README + refresh stale CLAUDE.md sections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```bash
 npm start                # Start Expo dev server
-npm run ios              # Start on iOS simulator
-npm run android          # Start on Android emulator
-npm run web              # Start web version
+npm run ios              # Build & run on iOS (dev client)
+npm run android          # Build & run on Android (dev client)
 npm run lint             # Run ESLint with Prettier
 npx convex dev           # Start Convex backend dev server (must run alongside Expo)
 npm run seed:names       # Seed baby names into Convex
@@ -26,7 +25,7 @@ npm run enrich-names     # Enrich extracted names via Claude API (needs ANTHROPI
 
 - **Expo SDK 54** with React Native 0.81 (new architecture enabled)
 - **Convex** - Backend (database, server functions, real-time sync)
-- **Clerk** - Authentication (email/password + Google SSO)
+- **Clerk** - Authentication (email/password + Google SSO + Apple SSO)
 - **NativeWind 4** - Tailwind CSS for React Native via `className` props
 - **expo-router** - File-based routing with typed routes
 - **react-native-reanimated** + **react-native-gesture-handler** - Swipe card animations
@@ -41,37 +40,45 @@ app/
   (tabs)/                  # Main app with bottom tab navigator
     dashboard.tsx          # Liked/rejected names lists
     matches.tsx            # Mutual matches with partner
-    profile.tsx            # User settings and account
-    explore/               # Search management + swipe interface
-      index.tsx            # Search list
-      new.tsx              # Create new search
-      [id]/index.tsx       # Swipe card interface
-      [id]/edit.tsx        # Edit search filters
+    profile.tsx            # User settings, account, partner linking
+    explore/               # Swipe interface
+      index.tsx            # Swipe card stack
+      filters.tsx          # Gender/origin filters
 components/                # UI components organized by feature
-  swipe/                   # Card stack, swipe buttons, search header
+  swipe/                   # Card stack, swipe buttons, header
   dashboard/               # Liked/rejected name cards, headers
-  matches/                 # Match cards, celebration modal
+  matches/                 # Match cards, proposals, celebration modal
   name-detail/             # Name detail modal, gender badge
-  search/                  # Gender filter, origin picker, join modal
+  partner/                 # Share code, link/unlink UI
+  search/                  # Gender filter, origin picker
   popularity/              # Charts, sparklines, rank badges
   onboarding/              # First-time user screens
-  settings/                # Voice settings
+  push/                    # Push notification priming
+  settings/                # Theme picker, voice settings
+  ui/                      # Shared primitives (loading screen, offline banner)
+  paywall.tsx              # RevenueCat premium paywall
 contexts/
-  search-context.tsx       # Active search ID (persisted to AsyncStorage)
+  theme-context.tsx        # Candy theme (persisted to AsyncStorage)
   voice-settings-context.tsx  # TTS voice preference (persisted to AsyncStorage)
+  skin-tone-context.tsx    # Emoji skin tone (persisted to AsyncStorage)
+  onboarding-context.tsx   # Onboarding completion state
 convex/
-  schema.ts                # Database schema (7 tables)
+  schema.ts                # Database schema (8 tables)
   auth.config.ts           # Clerk JWT configuration
-  users.ts                 # User sync with Clerk
-  searches.ts              # Search CRUD + share codes
+  users.ts                 # User sync with Clerk + filters + share codes
   selections.ts            # Swipe decisions + queue management
-  matches.ts               # Mutual match detection
+  matches.ts               # Mutual match detection + proposals
+  partners.ts              # Partner linking via share code
+  premium.ts               # RevenueCat premium status
   names.ts                 # Name lookup + seeding
   popularity.ts            # Historical popularity queries
+  notifications.ts         # Push notification registration
+  feedback.ts              # In-app feedback submissions
 constants/
-  theme.ts                 # Colors (light/dark) and platform-specific fonts
+  theme.ts                 # Candy themes, colors, platform-specific fonts
   swipe.ts                 # Card dimensions, gesture thresholds, animation config
-hooks/                     # useActiveSearch, useStoreUser, useCardAnimation, useSwipeGesture, useOnboarding
+hooks/                     # useStoreUser, useCardAnimation, useSwipeGesture, useOnboarding, usePurchases, useEffectivePremium
+lib/                       # Shared utilities (analytics, formatting, SSO, convex errors)
 scripts/                   # Data processing and seeding (seed-names, seed-popularity, process-ssa-data)
 ```
 
@@ -79,33 +86,38 @@ scripts/                   # Data processing and seeding (seed-names, seed-popul
 
 ```
 GestureHandlerRootView
-  ErrorBoundary
+  ErrorBoundary (bare fallback)
     ClerkProvider
-      ClerkLoaded
-        ConvexProviderWithClerk
-          VoiceSettingsProvider
-            SearchProvider
-              Slot (expo-router)
+      ThemeProvider
+        ErrorBoundary (themed)
+          AuthGate
+            ConvexProviderWithClerk (keyed on Clerk user.id)
+              SkinToneProvider
+                VoiceSettingsProvider
+                  OnboardingProvider
+                    Slot (expo-router) + OfflineBanner
 ```
 
 ### Convex Backend
 
-**Schema tables:** `users`, `names`, `namePopularity`, `searches`, `searchMembers`, `selections`, `matches`
+**Schema tables:** `users`, `names`, `namePopularity`, `selections`, `matches`, `nameOriginStats`, `shareCodeAttempts`, `feedbackRateLimits`
+
+**Data model:** Each user has a single global liked/rejected list (filtered by gender/origin on the `users` record); there is no per-search model. Partners link at the account level via an 8-character share code, and mutual likes create `matches` (stored with canonical `user1Id < user2Id` ordering).
 
 **Data fetching pattern:** Use `useQuery` and `useMutation` from `convex/react` with function references from `@/convex/_generated/api`:
 
 ```ts
-const searches = useQuery(api.searches.getUserSearches);
-const createSearch = useMutation(api.searches.createSearch);
+const partner = useQuery(api.partners.getPartnerInfo);
+const updateFilters = useMutation(api.users.updateFilters);
 ```
 
 Auth is handled via Clerk JWT tokens passed to Convex automatically by `ConvexProviderWithClerk`. Server functions access the authenticated user via `ctx.auth.getUserIdentity()`.
 
 ### State Management
 
-- **Convex** - All persistent data (names, searches, selections, matches)
-- **AsyncStorage** - Local preferences (active search ID, voice settings)
-- **React Context** - `SearchContext` (active search), `VoiceSettingsContext` (TTS voice)
+- **Convex** - All persistent data (names, selections, matches, partner links)
+- **AsyncStorage** - Local preferences (candy theme, voice settings, skin tone)
+- **React Context** - `ThemeContext`, `VoiceSettingsContext`, `SkinToneContext`, `OnboardingContext`
 
 ### Styling Pattern
 

--- a/README.md
+++ b/README.md
@@ -1,50 +1,175 @@
-# Welcome to your Expo app 👋
+# Bambino
 
-This is an [Expo](https://expo.dev) project created with [`create-expo-app`](https://www.npmjs.com/package/create-expo-app).
+An [Expo](https://expo.dev) React Native app for baby-name discovery. Partners swipe on names Tinder-style — like, reject, or skip — and when both partners like the same name it becomes a **match**. Likes, matches, and partner sync are backed by [Convex](https://convex.dev) in real time.
 
-## Get started
+Each user has a single global list of liked/rejected names (filtered by gender/origin) and links to a partner at the account level via a share code.
 
-1. Install dependencies
+> This README is the practical getting-started reference. For the full architecture breakdown, see [`CLAUDE.md`](./CLAUDE.md).
+
+## Tech stack
+
+- **Expo SDK** `~54.0.34` / **React Native** `0.81.5` / **React** `19.1.0` (new architecture enabled)
+- **expo-router** `~6.0.23` — file-based, typed routes
+- **Convex** `~1.39.1` — backend: database, server functions, real-time sync
+- **Clerk** (`@clerk/clerk-expo` `^2.19.37`) — auth: email/password + Google SSO + Apple SSO
+- **NativeWind** `^4.2.4` — Tailwind CSS via `className`
+- **reanimated** `~4.1.1` + **gesture-handler** `~2.31.2` — swipe card animations
+- **RevenueCat** (`react-native-purchases` `^9.12.0`) — premium / in-app purchases
+- **PostHog** `~4.45.16` (analytics) + **Sentry** `~7.13.0` (error tracking) — production only
+- **expo-speech** `~14.0.8` — voice/TTS name pronunciation; **gifted-charts** + **svg** — popularity charts
+
+## Getting started
+
+The app needs **two processes running together**: the Convex dev server and the Expo dev server.
+
+1. **Install dependencies**
 
    ```bash
    npm install
    ```
 
-2. Start the app
+2. **Configure environment** — copy the template and fill in your keys:
 
    ```bash
-   npx expo start
+   cp .env.example .env
    ```
 
-In the output, you'll find options to open the app in a
+   Clerk and Convex keys are required to boot; RevenueCat / PostHog / Sentry are optional in dev (analytics and error tracking are disabled when `__DEV__`). See [Environment variables](#environment-variables).
 
-- [development build](https://docs.expo.dev/develop/development-builds/introduction/)
-- [Android emulator](https://docs.expo.dev/workflow/android-studio-emulator/)
-- [iOS simulator](https://docs.expo.dev/workflow/ios-simulator/)
-- [Expo Go](https://expo.dev/go), a limited sandbox for trying out app development with Expo
+3. **Set the Convex JWT issuer** (one-time, in the Convex dashboard or CLI):
 
-You can start developing by editing the files inside the **app** directory. This project uses [file-based routing](https://docs.expo.dev/router/introduction).
+   ```bash
+   npx convex env set CLERK_JWT_ISSUER_DOMAIN https://your-clerk-issuer
+   ```
 
-## Get a fresh project
+4. **Run both servers** (separate terminals):
 
-When you're ready, run:
+   ```bash
+   npx convex dev        # backend — keep running
+   npm run ios           # or `npm start`, then choose a target
+   ```
 
-```bash
-npm run reset-project
+This is an iOS-focused app and uses a dev build (not Expo Go), so `npm run ios` / `npm run android` build a native dev client.
+
+## Environment variables
+
+App-side vars live in `.env` (all prefixed `EXPO_PUBLIC_`, from `.env.example`). Never commit real values.
+
+| Variable | Purpose |
+| --- | --- |
+| `EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY` | Clerk authentication (required) |
+| `EXPO_PUBLIC_CONVEX_URL` | Convex backend URL (required) |
+| `EXPO_PUBLIC_REVENUECAT_API_KEY` | RevenueCat in-app purchases |
+| `EXPO_PUBLIC_POSTHOG_API_KEY` | PostHog analytics (prod) |
+| `EXPO_PUBLIC_POSTHOG_HOST` | PostHog host (e.g. `https://us.i.posthog.com`) |
+| `EXPO_PUBLIC_SENTRY_DSN` | Sentry error tracking (prod) |
+
+Backend-side, set in the Convex dashboard:
+
+| Variable | Purpose |
+| --- | --- |
+| `CLERK_JWT_ISSUER_DOMAIN` | Validates Clerk JWTs passed to Convex |
+
+`APP_ENV` (`development` | `production`) in `app.config.ts` gates Sentry/PostHog and the push/`aps-environment` configuration.
+
+## Scripts
+
+| Script | What it does |
+| --- | --- |
+| `npm start` | Start the Expo dev server |
+| `npm run ios` | Build & run on iOS (dev client) |
+| `npm run android` | Build & run on Android (dev client) |
+| `npm run lint` | ESLint (with Prettier) |
+
+Data scripts (see [Data pipeline](#data-pipeline)):
+
+| Script | What it does |
+| --- | --- |
+| `npm run process:ssa` | Process raw SSA data files |
+| `npm run extract-names` | Extract candidate names from SSA data |
+| `npm run enrich-names` | Enrich names via Claude API (needs `ANTHROPIC_API_KEY`) |
+| `npm run seed:names` | Seed names into Convex |
+| `npm run seed:popularity` | Seed historical popularity data |
+| `npm run update:ranks` | Recompute current ranks |
+| `npm run backfill:ranks` | Backfill ranks on existing names |
+| `npm run backfill:tiers` | Backfill popularity tiers |
+| `npm run populate:origin-stats` | Precompute (origin, gender) name counts |
+| `npm run backfill:selection-origin-gender` | Backfill origin/gender on selections |
+| `npm run update:name-origin` | Update name origins |
+
+## Architecture
+
+File-based routing under `app/` (`(auth)` for sign-in/up, `(tabs)` for the main app: dashboard, matches, profile, explore). UI lives in `components/`, the Convex backend in `convex/`, React context providers in `contexts/`, custom hooks in `hooks/`, theme/swipe/origin config in `constants/`, shared utilities in `lib/`, and data-processing scripts in `scripts/`.
+
+Provider stack (`app/_layout.tsx` → `AuthGate`):
+
+```
+GestureHandlerRootView
+└─ ErrorBoundary (bare fallback)
+   └─ ClerkProvider
+      └─ ThemeProvider
+         └─ ErrorBoundary (themed)
+            └─ AuthGate
+               └─ ConvexProviderWithClerk (keyed on Clerk user.id)
+                  └─ SkinToneProvider
+                     └─ VoiceSettingsProvider
+                        └─ OnboardingProvider
+                           └─ Slot (+ OfflineBanner)
 ```
 
-This command will move the starter code to the **app-example** directory and create a blank **app** directory where you can start developing.
+The Convex provider and user-scoped contexts are keyed on `user.id` so signing out and back in resets in-memory state (no flash of the previous user's data). **See [`CLAUDE.md`](./CLAUDE.md) for the full breakdown.**
 
-## Learn more
+## Convex schema / data model
 
-To learn more about developing your project with Expo, look at the following resources:
+Source of truth: [`convex/schema.ts`](./convex/schema.ts).
 
-- [Expo documentation](https://docs.expo.dev/): Learn fundamentals, or go into advanced topics with our [guides](https://docs.expo.dev/guides).
-- [Learn Expo tutorial](https://docs.expo.dev/tutorial/introduction/): Follow a step-by-step tutorial where you'll create a project that runs on Android, iOS, and the web.
+| Table | Purpose |
+| --- | --- |
+| `users` | Clerk-synced accounts; filters (`genderFilter`/`originFilter`), swipe counters, `shareCode`/`partnerId`, premium and push fields |
+| `names` | Baby-name catalog: gender, origin, meaning, current rank, popularity tier, sort keys |
+| `namePopularity` | Historical SSA rank/count by name + gender + year |
+| `selections` | Per-user swipe decisions (like / reject / skip) |
+| `matches` | Mutual likes, stored with canonical `user1Id < user2Id` ordering; proposal & favorite state |
+| `nameOriginStats` | Precomputed (origin, gender) name counts |
+| `shareCodeAttempts` | Rate limiting for partner-link attempts |
+| `feedbackRateLimits` | Throttle for in-app feedback submissions |
 
-## Join the community
+**Model:** one global liked/rejected list per user plus gender/origin filters. Partners link at the account level via an 8-character share code (confusable characters removed). Match detection checks a partner's likes against the current user's via an index over `selections`.
 
-Join our community of developers creating universal apps.
+## Data pipeline
 
-- [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
-- [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.
+Baby-name data originates from the US SSA dataset and is processed into Convex in order:
+
+1. `npm run process:ssa` — process the raw SSA files
+2. `npm run extract-names` — extract candidate names
+3. `npm run enrich-names` — enrich (meaning, origin, etc.) via the Claude API (`ANTHROPIC_API_KEY` required)
+4. `npm run seed:names` — load names into Convex
+5. `npm run seed:popularity` — load historical popularity
+6. Maintenance as needed: `update:ranks`, `backfill:ranks`, `backfill:tiers`, `populate:origin-stats`
+
+## Features
+
+- **Swipe loop** — like / reject / skip, filtered by gender and origin
+- **Matches** — partner's mutual like creates a match in real time
+- **Partner linking** — connect at the account level via share code
+- **Match proposals & favorites** — propose a chosen name, mark favorites, add notes
+- **Premium (RevenueCat)** — unlimited swipes and partner linking; premium propagates to a linked partner
+- **Popularity** — historical SSA rank charts and sparklines per name
+- **Themes** — candy themes (pink/mint/blue/yellow)
+- **Voice/TTS** — name pronunciation via expo-speech
+- **Skin tone** — selectable emoji skin tone
+- **Push notifications** — match alerts (premium, partner-centered)
+- **Onboarding** — first-run flow, completion stored per account
+- **In-app feedback** — bug/feature/general submissions
+
+## Deployment (EAS)
+
+- Build & submit with [EAS](https://docs.expo.dev/eas/) (`eas build` / `eas submit`); the EAS project id is in `app.config.ts`.
+- `APP_ENV=production` flips Sentry/PostHog and the push environment to prod.
+- Bundle id / package: `xyz.bambinobaby.app` (iOS and Android).
+- Deploy the Convex backend to production with `npx convex deploy`.
+
+## More
+
+- [`CLAUDE.md`](./CLAUDE.md) — full architecture and conventions
+- [`PLAN.md`](./PLAN.md) — development roadmap and task status


### PR DESCRIPTION
## Summary
- Replace the untouched `create-expo-app` README boilerplate with a project-specific reference: overview, tech stack, getting started (the two-process Convex + Expo requirement), env vars, scripts, brief architecture, Convex schema, SSA data pipeline, features, and EAS deployment.
- Refresh `CLAUDE.md` where it had drifted from the code — it still described the removed multi-search model (`searches`/`searchMembers`, `SearchProvider`/`SearchContext`, `explore/[id]` routes) and a stale provider stack.
- Update CLAUDE.md to the current single-global-list model, real schema tables, real provider stack (`AuthGate` + Theme/SkinTone/Onboarding contexts), add Apple SSO, and drop the non-existent `npm run web` script.

## Test plan
- [x] Env var names cross-checked against `.env.example`
- [x] Scripts table cross-checked against `package.json`
- [x] Provider stack + schema verified against `app/_layout.tsx` and `convex/schema.ts`
- [x] `grep` confirms no remaining stale search-model references in CLAUDE.md
- [ ] Skim the rendered Markdown on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)