### PR TITLE
fix: silence two production Sentry errors at the source (BAMBINO-1, BAMBINO-2)

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -1,5 +1,4 @@
 import { useSignIn, useSignInWithApple, useSSO } from '@clerk/clerk-expo';
-import * as Sentry from '@sentry/react-native';
 import { useRouter } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
 import { useCallback, useState } from 'react';
@@ -12,14 +11,10 @@ import { StyledInput } from '@/components/ui/styled-input';
 import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { Events, trackEvent } from '@/lib/analytics';
+import { getClerkErrorMessage, reportClerkError } from '@/lib/clerk-errors';
 import { SSO_REDIRECT_URL } from '@/lib/sso';
 
 WebBrowser.maybeCompleteAuthSession();
-
-function getClerkError(err: unknown, fallback: string): string {
-  const clerkError = err as { errors?: { message: string }[] };
-  return clerkError.errors?.[0]?.message || fallback;
-}
 
 export default function SignIn() {
   const { signIn, setActive, isLoaded } = useSignIn();
@@ -56,9 +51,9 @@ export default function SignIn() {
         router.replace('/');
       }
     } catch (err: unknown) {
-      const message = getClerkError(err, 'Sign in failed');
+      const message = getClerkErrorMessage(err, 'Sign in failed');
       setError(message);
-      Sentry.captureException(err, { tags: { flow: 'sign_in', method: 'email' } });
+      reportClerkError(err, { flow: 'sign_in', method: 'email' });
       trackEvent(Events.SIGN_IN_FAILED, { method: 'email', reason: message });
     } finally {
       setIsLoading(false);
@@ -83,8 +78,8 @@ export default function SignIn() {
       });
       setResetFlow('code');
     } catch (err: unknown) {
-      setError(getClerkError(err, 'Failed to send reset code'));
-      Sentry.captureException(err, { tags: { flow: 'forgot_password' } });
+      setError(getClerkErrorMessage(err, 'Failed to send reset code'));
+      reportClerkError(err, { flow: 'forgot_password' });
     } finally {
       setIsLoading(false);
     }
@@ -106,8 +101,8 @@ export default function SignIn() {
         setResetFlow('new-password');
       }
     } catch (err: unknown) {
-      setError(getClerkError(err, 'Invalid code'));
-      Sentry.captureException(err, { tags: { flow: 'reset_password_verify' } });
+      setError(getClerkErrorMessage(err, 'Invalid code'));
+      reportClerkError(err, { flow: 'reset_password_verify' });
     } finally {
       setIsLoading(false);
     }
@@ -127,8 +122,8 @@ export default function SignIn() {
         router.replace('/');
       }
     } catch (err: unknown) {
-      setError(getClerkError(err, 'Failed to reset password'));
-      Sentry.captureException(err, { tags: { flow: 'reset_password' } });
+      setError(getClerkErrorMessage(err, 'Failed to reset password'));
+      reportClerkError(err, { flow: 'reset_password' });
     } finally {
       setIsLoading(false);
     }
@@ -154,9 +149,9 @@ export default function SignIn() {
         router.replace('/');
       }
     } catch (err: unknown) {
-      const message = getClerkError(err, 'Google sign in failed');
+      const message = getClerkErrorMessage(err, 'Google sign in failed');
       setError(message);
-      Sentry.captureException(err, { tags: { flow: 'sign_in', method: 'google' } });
+      reportClerkError(err, { flow: 'sign_in', method: 'google' });
       trackEvent(Events.SIGN_IN_FAILED, { method: 'google', reason: message });
     } finally {
       setIsLoading(false);
@@ -180,9 +175,9 @@ export default function SignIn() {
     } catch (err: unknown) {
       const appleError = err as { code?: string };
       if (appleError.code === 'ERR_REQUEST_CANCELED') return;
-      const message = getClerkError(err, 'Apple sign in failed');
+      const message = getClerkErrorMessage(err, 'Apple sign in failed');
       setError(message);
-      Sentry.captureException(err, { tags: { flow: 'sign_in', method: 'apple' } });
+      reportClerkError(err, { flow: 'sign_in', method: 'apple' });
       trackEvent(Events.SIGN_IN_FAILED, { method: 'apple', reason: message });
     } finally {
       setIsLoading(false);

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -1,5 +1,4 @@
 import { useSignInWithApple, useSignUp, useSSO } from '@clerk/clerk-expo';
-import * as Sentry from '@sentry/react-native';
 import { useRouter } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
 import { useCallback, useState } from 'react';
@@ -12,12 +11,8 @@ import { StyledInput } from '@/components/ui/styled-input';
 import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { trackEvent, Events } from '@/lib/analytics';
+import { getClerkErrorMessage, reportClerkError } from '@/lib/clerk-errors';
 import { SSO_REDIRECT_URL } from '@/lib/sso';
-
-function getClerkError(err: unknown, fallback: string): string {
-  const clerkError = err as { errors?: { message: string }[] };
-  return clerkError.errors?.[0]?.message || fallback;
-}
 
 WebBrowser.maybeCompleteAuthSession();
 
@@ -52,9 +47,9 @@ export default function SignUp() {
       await signUp.prepareEmailAddressVerification({ strategy: 'email_code' });
       setPendingVerification(true);
     } catch (err: unknown) {
-      const message = getClerkError(err, 'Sign up failed');
+      const message = getClerkErrorMessage(err, 'Sign up failed');
       setError(message);
-      Sentry.captureException(err, { tags: { flow: 'sign_up', method: 'email' } });
+      reportClerkError(err, { flow: 'sign_up', method: 'email' });
       trackEvent(Events.SIGN_UP_FAILED, { method: 'email', reason: message });
     } finally {
       setIsLoading(false);
@@ -77,9 +72,9 @@ export default function SignUp() {
         router.replace('/');
       }
     } catch (err: unknown) {
-      const message = getClerkError(err, 'Verification failed');
+      const message = getClerkErrorMessage(err, 'Verification failed');
       setError(message);
-      Sentry.captureException(err, { tags: { flow: 'sign_up_verify', method: 'email' } });
+      reportClerkError(err, { flow: 'sign_up_verify', method: 'email' });
       trackEvent(Events.SIGN_UP_FAILED, { method: 'email', reason: message });
     } finally {
       setIsLoading(false);
@@ -106,9 +101,9 @@ export default function SignUp() {
         router.replace('/');
       }
     } catch (err: unknown) {
-      const message = getClerkError(err, 'Google sign up failed');
+      const message = getClerkErrorMessage(err, 'Google sign up failed');
       setError(message);
-      Sentry.captureException(err, { tags: { flow: 'sign_up', method: 'google' } });
+      reportClerkError(err, { flow: 'sign_up', method: 'google' });
       trackEvent(Events.SIGN_UP_FAILED, { method: 'google', reason: message });
     } finally {
       setIsLoading(false);
@@ -132,9 +127,9 @@ export default function SignUp() {
     } catch (err: unknown) {
       const appleError = err as { code?: string };
       if (appleError.code === 'ERR_REQUEST_CANCELED') return;
-      const message = getClerkError(err, 'Apple sign up failed');
+      const message = getClerkErrorMessage(err, 'Apple sign up failed');
       setError(message);
-      Sentry.captureException(err, { tags: { flow: 'sign_up', method: 'apple' } });
+      reportClerkError(err, { flow: 'sign_up', method: 'apple' });
       trackEvent(Events.SIGN_UP_FAILED, { method: 'apple', reason: message });
     } finally {
       setIsLoading(false);

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -281,7 +281,21 @@ export const setPushToken = mutation({
     if (!EXPO_PUSH_TOKEN_REGEX.test(args.token)) {
       throw new Error('Invalid push token format');
     }
-    const user = await getCurrentUserOrThrow(ctx);
+    // Best-effort background write. Push registration round-trips to Expo for
+    // a token before calling this, and that window is wide enough for the
+    // Convex/Clerk JWT to lapse transiently (token rotation, app backgrounded,
+    // a fresh review session). A null identity (or a row that hasn't synced
+    // yet) is recoverable, not exceptional: skip silently and let the next
+    // cold-start re-register. Throwing here surfaced as a generic Convex
+    // "Server Error" and spammed Sentry (BAMBINO-1). Mirrors the tolerant
+    // read in the getCurrentUser query above.
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return;
+    const user = await ctx.db
+      .query('users')
+      .withIndex('by_clerk_id', (q) => q.eq('clerkId', identity.subject))
+      .first();
+    if (!user) return;
     await ctx.db.patch(user._id, {
       pushToken: args.token,
       pushTokenPlatform: args.platform,

--- a/lib/clerk-errors.ts
+++ b/lib/clerk-errors.ts
@@ -1,0 +1,67 @@
+import * as Sentry from '@sentry/react-native';
+
+/** A single entry in a Clerk API error response (`err.errors[]`). */
+interface ClerkAPIError {
+  code?: string;
+  message?: string;
+  longMessage?: string;
+}
+
+interface ClerkErrorLike {
+  errors?: ClerkAPIError[];
+}
+
+/**
+ * Clerk error `code`s that represent expected user-input validation failures —
+ * the user already sees a friendly message for these, so they're noise in
+ * Sentry, not bugs to monitor.
+ *
+ * Keyed on Clerk's stable `code` rather than the (localizable, reworded)
+ * message text. Deliberately omits `form_param_unknown` — that's the
+ * `first_name is not a valid parameter` SSO/config error (BAMBINO-2), a real
+ * problem we want to stay visible until the Clerk dashboard is fixed.
+ */
+const EXPECTED_CLERK_ERROR_CODES = new Set<string>([
+  'form_identifier_not_found', // "Couldn't find your account."
+  'form_password_incorrect', // wrong password
+  'form_password_pwned', // breached password rejected at sign-up
+  'form_identifier_exists', // email already registered (sign-up)
+  'form_code_incorrect', // wrong email verification / reset code
+  'verification_failed', // bad/too-many verification attempts
+  'verification_expired', // code expired
+  'form_param_format_invalid', // malformed email/identifier
+  'authorization_invalid', // "You are not authorized to perform this request"
+  'session_exists', // already signed in
+]);
+
+function firstClerkError(err: unknown): ClerkAPIError | undefined {
+  return (err as ClerkErrorLike)?.errors?.[0];
+}
+
+/**
+ * Extract a clean, user-presentable message from an unknown Clerk error,
+ * falling back to `fallback` when the shape isn't recognized.
+ */
+export function getClerkErrorMessage(err: unknown, fallback: string): string {
+  const clerkError = firstClerkError(err);
+  return clerkError?.message || clerkError?.longMessage || fallback;
+}
+
+/**
+ * True when the error is an expected user-input validation failure (see
+ * `EXPECTED_CLERK_ERROR_CODES`) — i.e. UX feedback, not something to report.
+ */
+export function isExpectedClerkError(err: unknown): boolean {
+  const code = firstClerkError(err)?.code;
+  return code ? EXPECTED_CLERK_ERROR_CODES.has(code) : false;
+}
+
+/**
+ * Report a Clerk error to Sentry, but only when it's genuinely unexpected.
+ * Expected validation failures (wrong/unknown email, bad code, etc.) are
+ * dropped so they stop polluting the error stream (BAMBINO-2).
+ */
+export function reportClerkError(err: unknown, tags: Record<string, string>): void {
+  if (isExpectedClerkError(err)) return;
+  Sentry.captureException(err, { tags });
+}


### PR DESCRIPTION
## Summary
- **BAMBINO-1 (`setPushToken` "Server Error", 6 events / 4 users incl. the App Review account):** the mutation threw a plain `Error` whenever the Convex/Clerk identity was transiently null — which happens because push registration round-trips to Expo for a token *before* calling the mutation, a window wide enough for the JWT to lapse (rotation / app backgrounded / fresh review session). That surfaced as a generic Convex *"Server Error"* and was reported to Sentry. It's a best-effort background write, so it now **no-ops when the caller can't be resolved** and re-registers on the next cold start (mirrors the tolerant `getCurrentUser` query). `Fixes BAMBINO-1`.
- **BAMBINO-2 noise:** the auth screens called `Sentry.captureException` unconditionally, so expected validation failures (unknown email, wrong code, etc.) were logged as monitored exceptions. New `lib/clerk-errors.ts` denylists those by **stable Clerk error code** and only reports the unexpected ones; `getClerkErrorMessage` replaces the duplicated inline helper in both screens.
- The `first_name is not a valid parameter` SSO error (also in BAMBINO-2) is intentionally **kept visible** (`form_param_unknown` is not denylisted). Its real fix is enabling **Name** in the Clerk dashboard (done) — a server-side config change, **no new build / App Review resubmission**.

## Test plan
- [x] `npm run lint` — 0 errors (only pre-existing warnings, none in touched files)
- [x] `npx tsc --noEmit` — exit 0, no type errors
- [ ] Convex: invoking `setPushToken` with no valid identity/row no-ops without error; signed-in happy path still patches `pushToken`
- [ ] Device: sign in with an unknown email → friendly message shown, `SIGN_IN_FAILED` tracked, **no new Sentry event**
- [ ] Device: Apple + Google SSO sign-up complete with no `first_name` error after the Clerk Name toggle
- [ ] Monitor Sentry ~1 day, then manually resolve BAMBINO-2 once no new events appear

> Note: the auth-screen changes ship with the next build; the Convex change deploys server-side. No new build is being cut as part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)