### PR TITLE
ci: auto-deploy Convex to prod on merge to master

### DIFF
--- a/.github/workflows/convex-deploy.yml
+++ b/.github/workflows/convex-deploy.yml
@@ -1,12 +1,26 @@
 name: Convex deploy (prod)
 
 on:
+  # Auto-deploy prod whenever backend code lands on master, so prod stays in
+  # sync with the app. Prevents a build shipping ahead of the backend — e.g.
+  # build 10 called users:setOnboardingCompleted before it existed in prod.
+  push:
+    branches: [master]
+    paths:
+      - "convex/**"
+  # Manual hotfix / redeploy of an arbitrary ref.
   workflow_dispatch:
     inputs:
       ref:
         description: "Branch, tag, or commit SHA to deploy (defaults to master)"
         required: false
         default: "master"
+
+# Never run two prod deploys at once; queue them so a later merge can't race
+# an in-flight deploy.
+concurrency:
+  group: convex-deploy-prod
+  cancel-in-progress: false
 
 jobs:
   deploy:
@@ -28,7 +42,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.inputs.ref }}
+          # workflow_dispatch supplies an explicit ref; push events leave the
+          # input empty, so fall back to the pushed commit.
+          ref: ${{ github.event.inputs.ref || github.sha }}
 
       - name: Setup Node
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Why

Production was ~10 days behind \`master\`. \`convex-deploy.yml\` (prod) was **\`workflow_dispatch\`-only** and decoupled from both merges and the app build, so the production Convex backend only updated when someone remembered to run it manually.

Build 10 was built manually (CLI \`eas build\` + \`eas submit\`, bypassing CI) from a \`master\` that called \`users:setOnboardingCompleted\` — a function that **did not exist in prod**. Every call failed with `Could not find public function`, which \`completeOnboarding\` swallowed into Sentry. Result: onboarding's "Get Started" looked completely dead, trapping new users in an onboarding loop. The same gap also left the notifications toggle, content reporting, and partner preview broken in prod.

Root cause confirmed via the Convex prod logs + function spec (the function was absent; a manual prod deploy fixed it in place).

## What

- Add a `push` trigger on `master` filtered to `convex/**` so any backend change **auto-deploys to prod on merge** — prod now always tracks `master`, independent of how (or whether) the app build is kicked off.
- Keep `workflow_dispatch` for manual hotfix/redeploy of an arbitrary ref.
- Add a workflow-level `concurrency` group so two prod deploys can't race.
- Fall back to `github.sha` for the checkout ref on `push` events (the dispatch `ref` input is empty then).

The workflow file itself isn't under `convex/**`, so merging this PR won't trigger a deploy.

## Follow-ups (not in this PR)
- Harden `completeOnboarding` so a backend error surfaces/retries instead of silently dying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)