### PR TITLE
fix: surface feedback/report errors to users via ConvexError

### DIFF
--- a/components/matches/report-message-sheet.tsx
+++ b/components/matches/report-message-sheet.tsx
@@ -86,8 +86,16 @@ export function ReportMessageSheet({ visible, matchId, onClose }: ReportMessageS
       setShowSuccess(true);
       successTimer.current = setTimeout(resetAndClose, 1800);
     } catch (err) {
-      setErrorMessage('Could not send your report. Please try again.');
-      Sentry.captureException(err, { tags: { flow: 'content_report' } });
+      const { code, message } = decodeConvexError(
+        err,
+        'Could not send your report. Please try again.',
+      );
+      setErrorMessage(message);
+      // Expected structured failures (e.g. rate limit) skip Sentry; only
+      // unstructured/infra errors are reported. Mirrors match-error-alert.ts.
+      if (!code) {
+        Sentry.captureException(err, { tags: { flow: 'content_report' } });
+      }
     } finally {
       setIsSubmitting(false);
     }

--- a/components/settings/feedback-section.tsx
+++ b/components/settings/feedback-section.tsx
@@ -5,6 +5,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useAction } from 'convex/react';
 import * as Sentry from '@sentry/react-native';
 import { api } from '@/convex/_generated/api';
+import { decodeConvexError } from '@/lib/convex-errors';
 import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { GradientButton } from '@/components/ui/gradient-button';
@@ -54,8 +55,14 @@ export function FeedbackSection() {
         setMessage('');
       }, 2000);
     } catch (err) {
-      setErrorMessage('Something went wrong. Try again.');
-      Sentry.captureException(err, { tags: { flow: 'feedback_submit' } });
+      const { code, message } = decodeConvexError(err, 'Something went wrong. Try again.');
+      setErrorMessage(message);
+      // Structured failures (validation, rate limit) are expected user flow, not
+      // bugs — only report unstructured/infra errors (Slack delivery failed,
+      // missing webhook) to Sentry. Mirrors components/matches/match-error-alert.ts.
+      if (!code) {
+        Sentry.captureException(err, { tags: { flow: 'feedback_submit' } });
+      }
     } finally {
       setIsSubmitting(false);
     }

--- a/convex/errors.ts
+++ b/convex/errors.ts
@@ -39,7 +39,10 @@ export type ConvexErrorCode =
   | 'PROPOSAL_NOT_PENDING'
   // selections.ts
   | 'SELECTION_NOT_FOUND'
-  | 'BULK_LIMIT_EXCEEDED';
+  | 'BULK_LIMIT_EXCEEDED'
+  // feedback.ts (also reuses UNAUTHENTICATED, USER_NOT_FOUND, RATE_LIMITED,
+  // MESSAGE_TOO_LONG, NOTES_TOO_LONG, MATCH_NOT_FOUND, NOT_AUTHORIZED above)
+  | 'MESSAGE_EMPTY';
 
 export interface ConvexErrorData {
   code: ConvexErrorCode;

--- a/convex/feedback.ts
+++ b/convex/feedback.ts
@@ -1,6 +1,7 @@
 import { v } from 'convex/values';
 import { action, internalMutation, internalQuery } from './_generated/server';
 import { internal } from './_generated/api';
+import { convexError } from './errors';
 
 const CATEGORY_LABELS: Record<string, string> = {
   bug: 'Bug Report',
@@ -58,7 +59,7 @@ export const checkAndRecordFeedbackRateLimit = internalMutation({
       .withIndex('by_clerk_id', (q) => q.eq('clerkId', args.clerkId))
       .first();
     if (!user) {
-      throw new Error('User not found');
+      throw convexError('USER_NOT_FOUND', 'User not found');
     }
 
     const now = Date.now();
@@ -68,7 +69,9 @@ export const checkAndRecordFeedbackRateLimit = internalMutation({
       .first();
 
     if (record && now - record.lastSubmittedAt < FEEDBACK_RATE_WINDOW_MS) {
-      throw new Error('Please wait a minute before sending more feedback.');
+      throw convexError('RATE_LIMITED', 'Please wait a minute before sending more feedback.', {
+        retryAfterMs: FEEDBACK_RATE_WINDOW_MS - (now - record.lastSubmittedAt),
+      });
     }
 
     if (record) {
@@ -87,20 +90,24 @@ export const submitFeedback = action({
   handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) {
-      throw new Error('Not authenticated');
+      throw convexError('UNAUTHENTICATED', 'Not authenticated');
     }
 
     const trimmed = args.message.trim();
     if (!trimmed) {
-      throw new Error('Message cannot be empty');
+      throw convexError('MESSAGE_EMPTY', 'Message cannot be empty');
     }
     // #171: length cap.
     if (trimmed.length > MAX_FEEDBACK_LENGTH) {
-      throw new Error(`Feedback must be ${MAX_FEEDBACK_LENGTH} characters or fewer.`);
+      throw convexError('MESSAGE_TOO_LONG', `Feedback must be ${MAX_FEEDBACK_LENGTH} characters or fewer.`);
     }
 
     const webhookUrl = process.env.SLACK_FEEDBACK_WEBHOOK_URL;
     if (!webhookUrl) {
+      // Operational misconfiguration (not user-actionable): keep this a plain
+      // Error so Convex redacts it to "Server Error" on the wire and it stays
+      // loud in logs/Sentry. This was the BAMBINO feedback-webhook incident —
+      // do NOT convert to convexError().
       throw new Error('Slack webhook URL not configured');
     }
 
@@ -190,15 +197,15 @@ export const getReportTarget = internalQuery({
       .withIndex('by_clerk_id', (q) => q.eq('clerkId', args.clerkId))
       .first();
     if (!user) {
-      throw new Error('User not found');
+      throw convexError('USER_NOT_FOUND', 'User not found');
     }
 
     const match = await ctx.db.get(args.matchId);
     if (!match) {
-      throw new Error('This match is no longer available.');
+      throw convexError('MATCH_NOT_FOUND', 'This match is no longer available.');
     }
     if (match.user1Id !== user._id && match.user2Id !== user._id) {
-      throw new Error('Not authorized');
+      throw convexError('NOT_AUTHORIZED', 'Not authorized');
     }
 
     // The proposer authored the proposalMessage. Fall back to "the other
@@ -234,16 +241,19 @@ export const reportContent = action({
   handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) {
-      throw new Error('Not authenticated');
+      throw convexError('UNAUTHENTICATED', 'Not authenticated');
     }
 
     const trimmedNotes = (args.notes ?? '').trim();
     if (trimmedNotes.length > MAX_FEEDBACK_LENGTH) {
-      throw new Error(`Report notes must be ${MAX_FEEDBACK_LENGTH} characters or fewer.`);
+      throw convexError('NOTES_TOO_LONG', `Report notes must be ${MAX_FEEDBACK_LENGTH} characters or fewer.`);
     }
 
     const webhookUrl = process.env.SLACK_FEEDBACK_WEBHOOK_URL;
     if (!webhookUrl) {
+      // Operational misconfiguration (not user-actionable): keep as a plain
+      // Error so it redacts to "Server Error" and stays loud in logs/Sentry.
+      // Do NOT convert to convexError().
       throw new Error('Slack webhook URL not configured');
     }
 


### PR DESCRIPTION
## Why
`submitFeedback` / `reportContent` threw plain `Error`s, which Convex redacts to `"Server Error"` in production. The carefully-written validation and rate-limit messages never reached users, and a real submission failure surfaced in Sentry only as a redacted "Server Error".

Follow-up to the feedback-webhook incident: prod was missing `SLACK_FEEDBACK_WEBHOOK_URL` (now set), which is what generated the Sentry "Server Error".

## What
- **`convex/feedback.ts`** — user-actionable failures now throw `ConvexError` via `convexError()`:
  - rate limit → `RATE_LIMITED` (+ `retryAfterMs`)
  - empty → `MESSAGE_EMPTY` (new code)
  - too long → `MESSAGE_TOO_LONG` / `NOTES_TOO_LONG`
  - auth / not-found / not-authorized → existing codes
- **Operational faults kept as plain `Error`** (missing webhook, Slack POST failure) — they *should* stay redacted to users and loud in logs/Sentry. Commented so they aren't "migrated" later.
- **`convex/errors.ts`** — added `MESSAGE_EMPTY` to the `ConvexErrorCode` union.
- **Clients** (`feedback-section.tsx`, `report-message-sheet.tsx`) — decode and show the server message; only capture to Sentry when there's no structured code (mirrors `match-error-alert.ts`), so expected validation/rate-limit failures stop polluting Sentry.

## Verification
- `tsc --noEmit` clean (the union type-checks every code used).
- `npm run lint` 0 errors (8 pre-existing warnings in untouched files).
- Device sanity-check worth doing: a rate-limited feedback submit should now show "Please wait a minute…" — the `ConvexError` propagates out through the action's `ctx.runMutation` (standard Convex behavior the matches/partners flows already rely on).

🤖 Generated with [Claude Code](https://claude.com/claude-code)