### PR TITLE
fix: smooth swipe-screen loading state (no flashes on cold launch / post-onboarding)

### DIFF
--- a/app/(tabs)/explore/index.tsx
+++ b/app/(tabs)/explore/index.tsx
@@ -9,7 +9,7 @@ import { SwipeCardStack } from '@/components/swipe/swipe-card-stack';
 import { ExploreHeader } from '@/components/swipe/explore-header';
 import { ErrorBoundary } from '@/components/error-boundary';
 import { GradientBackground } from '@/components/ui/gradient-background';
-import { LoadingScreen, useGracefulLoading } from '@/components/ui/loading-screen';
+import { LoadingScreen } from '@/components/ui/loading-screen';
 
 export default function ExploreView() {
   const router = useRouter();
@@ -22,10 +22,17 @@ export default function ExploreView() {
     }, []),
   );
 
+  // Remount the swipe stack only when the FILTERS change — gender/origin are
+  // the sole inputs to getSwipeQueue's result set, so a fresh seed/queue is
+  // only warranted then. Deliberately excludes user.updatedAt: it's bumped by
+  // every unrelated user-row write (push-token registration on tab mount,
+  // onboarding completion, name confirmation, createOrUpdateUser), each of
+  // which would otherwise remount the stack mid-session and flash the loading
+  // screen — cards -> loading -> cards.
   const swipeQueueKey = useMemo(() => {
     if (!user) return '';
     const originKey = (user.originFilter ?? []).sort().join(',');
-    return `${user.genderFilter ?? 'both'}-${originKey}-${user.updatedAt}`;
+    return `${user.genderFilter ?? 'both'}-${originKey}`;
   }, [user]);
 
   const activeFilterCount = useMemo(() => {
@@ -36,18 +43,18 @@ export default function ExploreView() {
     return count;
   }, [user]);
 
-  const { showLoading, loadingProps } = useGracefulLoading(user !== undefined);
-
-  if (showLoading) {
-    return <LoadingScreen {...loadingProps} />;
-  }
-
+  // The tabs-layout gate (app/(tabs)/_layout.tsx) already holds the loader
+  // until getCurrentUser resolves, so `user` is a cached Doc by the time this
+  // screen mounts — no graceful-loading dance needed. Keep a cheap guard for
+  // the edge where the row briefly goes null (e.g. account deletion).
   if (!user) {
     return <LoadingScreen isLoading />;
   }
 
   return (
-    <GradientBackground>
+    // No entrance fade: this screen mounts straight out of the full-screen
+    // loader (same gradient), so fading it in re-flashes the background.
+    <GradientBackground animateEntrance={false}>
       <SafeAreaView style={styles.flexContainer} edges={['top']}>
         <ExploreHeader
           liked={stats?.liked ?? 0}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -120,9 +120,19 @@ function AuthGate({ children }: { children: React.ReactNode }) {
 
   if (themeLoading) return null;
 
-  // Always show at least one full animation cycle on app launch
+  // Always show at least one full animation cycle on app launch. Hand off
+  // without fading (fadeOnExit={false}): the tabs/swipe gates below render
+  // their own LoadingScreen, and the shared bounce clock keeps them in-phase,
+  // so an instant swap is seamless. Fading to blank here then snapping the
+  // next loader back to full opacity is the flash we're removing.
   if (!animationDone) {
-    return <LoadingScreen isLoading={!isLoaded} onFinished={() => setAnimationDone(true)} />;
+    return (
+      <LoadingScreen
+        isLoading={!isLoaded}
+        onFinished={() => setAnimationDone(true)}
+        fadeOnExit={false}
+      />
+    );
   }
 
   // Key the Convex provider + the user-scoped contexts on Clerk's user.id.

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,9 +1,18 @@
 import { SignedIn, SignedOut } from '@clerk/clerk-expo';
 import { Redirect } from 'expo-router';
 
+import { LoadingScreen } from '@/components/ui/loading-screen';
+
 export default function Index() {
+  // Paint the loader (not a blank screen) while the auth redirect resolves.
+  // index.tsx is the active route for a beat after the root AuthGate hands off
+  // and before (tabs)/_layout mounts its own loader. Rendering only <Redirect>
+  // here left the bare navigator background showing — a white flash between the
+  // two loading animations on cold launch. The shared bounce clock keeps this
+  // loader in-phase with the one before and after it, so it reads as continuous.
   return (
     <>
+      <LoadingScreen />
       <SignedIn>
         <Redirect href="/(tabs)/explore" />
       </SignedIn>

--- a/components/ui/gradient-background.tsx
+++ b/components/ui/gradient-background.tsx
@@ -9,12 +9,20 @@ interface GradientBackgroundProps {
   variant?: 'screen' | 'auth';
   style?: ViewStyle;
   children: React.ReactNode;
+  /**
+   * Fade the gradient in on mount. Defaults to true. Set false where the
+   * background is shown repeatedly across remounts (e.g. the LoadingScreen,
+   * which mounts at several sequential loading gates) — re-fading the
+   * background on each new instance reads as a flash/restart.
+   */
+  animateEntrance?: boolean;
 }
 
 export function GradientBackground({
   variant = 'screen',
   style,
   children,
+  animateEntrance = true,
 }: GradientBackgroundProps) {
   const colorScheme = useColorScheme();
   const isDark = colorScheme === 'dark';
@@ -25,7 +33,7 @@ export function GradientBackground({
 
   return (
     <AnimatedGradient
-      entering={FadeIn.duration(250)}
+      entering={animateEntrance ? FadeIn.duration(250) : undefined}
       colors={[...colors]}
       style={[{ flex: 1 }, style]}
     >

--- a/components/ui/loading-screen.tsx
+++ b/components/ui/loading-screen.tsx
@@ -1,13 +1,15 @@
-import { useEffect, useCallback, useState, useRef } from 'react';
+import { useEffect, useCallback, useState } from 'react';
 import { View, Text, Pressable, StyleSheet } from 'react-native';
 import Animated, {
   useSharedValue,
+  useDerivedValue,
   useAnimatedStyle,
   withTiming,
-  withSequence,
   withRepeat,
   Easing,
   runOnJS,
+  makeMutable,
+  type SharedValue,
 } from 'react-native-reanimated';
 import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
@@ -32,6 +34,78 @@ const letterEndTimes = LETTERS.map((_, i) => {
 });
 const CYCLE_ACTIVE = Math.max(...letterEndTimes);
 const CYCLE_DURATION = CYCLE_ACTIVE + CYCLE_GAP;
+const B_SPIN_DUR = B_BOUNCE_UP + B_BOUNCE_DOWN;
+
+// Easing closures built ONCE at module scope. They're worklets (Reanimated's
+// Easing.* are worklet-tagged), so they may be *called* inside the worklets
+// below — but must never be reconstructed per-frame.
+const easeOutCubic = Easing.out(Easing.cubic);
+const easeBounce = Easing.bounce;
+const easeInOutCubic = Easing.inOut(Easing.cubic);
+
+// A single continuous clock shared by every LoadingScreen/AnimatedLetter
+// instance for the app's lifetime. The loader mounts at several sequential
+// gates (root AuthGate -> tabs layout -> swipe-card-stack); if each instance
+// ran its own withRepeat the bounce would visibly reset to frame 0 at every
+// hand-off. Deriving all letters from one ever-running clock means a remount
+// continues the bounce in-phase instead of restarting.
+//
+// Stored on globalThis so Fast Refresh (which re-evaluates this module) reuses
+// the same mutable rather than orphaning already-mounted letters on a stale one.
+type LoadingClockGlobal = typeof globalThis & {
+  __bambinoLoadingClock?: SharedValue<number>;
+  __bambinoLoadingClockStarted?: boolean;
+};
+const clockGlobal = globalThis as LoadingClockGlobal;
+const loadingClock: SharedValue<number> =
+  clockGlobal.__bambinoLoadingClock ?? (clockGlobal.__bambinoLoadingClock = makeMutable(0));
+
+// Started lazily on the first LoadingScreen mount (not at import time) so frame
+// 0 lines up with the first moment the loader can be seen. `reverse: false` is
+// required: the phase math below assumes a 0 -> CYCLE_DURATION sawtooth that
+// jumps back to 0. The wrap is invisible (every letter sits at 0, the B at
+// 360deg === 0deg at cycle end).
+function ensureLoadingClockStarted() {
+  if (clockGlobal.__bambinoLoadingClockStarted) return;
+  clockGlobal.__bambinoLoadingClockStarted = true;
+  loadingClock.value = withRepeat(
+    withTiming(CYCLE_DURATION, { duration: CYCLE_DURATION, easing: Easing.linear }),
+    -1,
+    false,
+  );
+}
+
+// Map the linear clock (t in [0, CYCLE_DURATION)) to a letter's vertical offset,
+// reproducing the previous wait -> up -> down -> wait sequence frame-for-frame.
+// Up: BOUNCE_HEIGHT * easeOutCubic(p). Down: BOUNCE_HEIGHT * (1 - easeBounce(p))
+// — this matches withTiming's `from + (to - from) * easing(p)` interpolation
+// from BOUNCE_HEIGHT back to 0 (NOT easeBounce(1 - p), which is a different curve).
+function letterTranslateY(t: number, index: number, isFirstB: boolean): number {
+  'worklet';
+  const stagger = index * STAGGER;
+  const upDur = isFirstB ? B_BOUNCE_UP : BOUNCE_UP;
+  const downDur = isFirstB ? B_BOUNCE_DOWN : BOUNCE_DOWN;
+  const local = t - stagger;
+  if (local < 0) return 0;
+  if (local < upDur) {
+    return easeOutCubic(local / upDur) * BOUNCE_HEIGHT;
+  }
+  if (local < upDur + downDur) {
+    const p = (local - upDur) / downDur;
+    return BOUNCE_HEIGHT * (1 - easeBounce(p));
+  }
+  return 0;
+}
+
+// The first B spins 0 -> 360 over its bounce window, then holds at 360 (visually
+// identical to 0) until the cycle wraps.
+function bRotateY(t: number): number {
+  'worklet';
+  if (t < B_SPIN_DUR) {
+    return easeInOutCubic(t / B_SPIN_DUR) * 360;
+  }
+  return 360;
+}
 
 function AnimatedLetter({
   letter,
@@ -44,51 +118,11 @@ function AnimatedLetter({
   isFirstB: boolean;
   color: string;
 }) {
-  const translateY = useSharedValue(0);
-  const rotateY = useSharedValue(0);
-
-  useEffect(() => {
-    const stagger = index * STAGGER;
-    const upDur = isFirstB ? B_BOUNCE_UP : BOUNCE_UP;
-    const downDur = isFirstB ? B_BOUNCE_DOWN : BOUNCE_DOWN;
-    const waitAfter = CYCLE_DURATION - stagger - upDur - downDur;
-
-    // Each letter: wait(stagger) -> bounce up -> bounce down -> wait(remaining)
-    // Total duration per letter = CYCLE_DURATION, keeping everything in sync
-    translateY.value = withRepeat(
-      withSequence(
-        withTiming(0, { duration: stagger }),
-        withTiming(BOUNCE_HEIGHT, {
-          duration: upDur,
-          easing: Easing.out(Easing.cubic),
-        }),
-        withTiming(0, {
-          duration: downDur,
-          easing: Easing.bounce,
-        }),
-        withTiming(0, { duration: waitAfter }),
-      ),
-      -1,
-    );
-
-    if (isFirstB) {
-      const spinDur = B_BOUNCE_UP + B_BOUNCE_DOWN;
-      const spinWaitAfter = CYCLE_DURATION - spinDur;
-
-      rotateY.value = withRepeat(
-        withSequence(
-          withTiming(360, {
-            duration: spinDur,
-            easing: Easing.inOut(Easing.cubic),
-          }),
-          withTiming(360, { duration: spinWaitAfter }),
-          // Near-instant reset (visually identical: 360deg = 0deg)
-          withTiming(0, { duration: 1 }),
-        ),
-        -1,
-      );
-    }
-  }, [index, isFirstB, translateY, rotateY]);
+  const translateY = useDerivedValue(
+    () => letterTranslateY(loadingClock.value, index, isFirstB),
+    [index, isFirstB],
+  );
+  const rotateY = useDerivedValue(() => (isFirstB ? bRotateY(loadingClock.value) : 0), [isFirstB]);
 
   const animatedStyle = useAnimatedStyle(() => {
     if (isFirstB) {
@@ -109,18 +143,35 @@ function AnimatedLetter({
 }
 
 interface LoadingScreenProps {
-  /** When false, the animation completes one more cycle then fades out. */
+  /** When false, the animation completes one more cycle then exits. */
   isLoading?: boolean;
-  /** Called after the fade-out animation finishes. */
+  /** Called after the exit (fade-out, or immediately when fadeOnExit is false). */
   onFinished?: () => void;
+  /**
+   * Fade the loader's opacity to 0 before calling onFinished. Defaults to true.
+   * Set false when this loader hands off to ANOTHER loader (e.g. the root
+   * AuthGate -> the tabs/swipe gates): fading to blank then snapping the next
+   * loader back to full opacity reads as a flash. With the shared bounce clock
+   * the next loader continues in-phase, so an instant hand-off is seamless.
+   */
+  fadeOnExit?: boolean;
 }
 
 const TIMEOUT_MS = 15000;
 
-export function LoadingScreen({ isLoading = true, onFinished }: LoadingScreenProps) {
+export function LoadingScreen({
+  isLoading = true,
+  onFinished,
+  fadeOnExit = true,
+}: LoadingScreenProps) {
   const { colors } = useTheme();
   const containerOpacity = useSharedValue(1);
   const [timedOut, setTimedOut] = useState(false);
+
+  // Start the shared bounce clock on first mount (idempotent across instances).
+  useEffect(() => {
+    ensureLoadingClockStarted();
+  }, []);
 
   const handleFinished = useCallback(() => {
     onFinished?.();
@@ -128,8 +179,14 @@ export function LoadingScreen({ isLoading = true, onFinished }: LoadingScreenPro
 
   useEffect(() => {
     if (!isLoading) {
-      // Wait one full cycle so the current animation completes, then fade out
+      // Wait one full cycle so the current animation completes, then exit.
       const timeout = setTimeout(() => {
+        if (!fadeOnExit) {
+          // Hand off without fading — the next loader continues the shared
+          // clock in-phase, so an instant swap is seamless (no opacity dip).
+          handleFinished();
+          return;
+        }
         containerOpacity.value = withTiming(
           0,
           { duration: FADE_OUT, easing: Easing.out(Easing.ease) },
@@ -142,7 +199,7 @@ export function LoadingScreen({ isLoading = true, onFinished }: LoadingScreenPro
       }, CYCLE_DURATION);
       return () => clearTimeout(timeout);
     }
-  }, [isLoading, containerOpacity, handleFinished]);
+  }, [isLoading, containerOpacity, handleFinished, fadeOnExit]);
 
   useEffect(() => {
     if (!isLoading) return;
@@ -155,7 +212,7 @@ export function LoadingScreen({ isLoading = true, onFinished }: LoadingScreenPro
   }));
 
   return (
-    <GradientBackground>
+    <GradientBackground animateEntrance={false}>
       <Animated.View style={[styles.container, containerStyle]}>
         <View style={styles.letterRow}>
           {LETTERS.map((letter, index) => (
@@ -201,7 +258,6 @@ export function useGracefulLoading(isLoaded: boolean, graceMs = DEFAULT_GRACE_MS
   const [phase, setPhase] = useState<'grace' | 'loading' | 'exiting' | 'done'>(
     isLoaded ? 'done' : 'grace',
   );
-  const wasLoadedOnMount = useRef(isLoaded);
 
   // Grace period: if data arrives quickly, skip the loading screen entirely
   useEffect(() => {


### PR DESCRIPTION
## Problem

Two loading-state defects on the Explore/swipe screen, reported from the prod build:

1. **Post-onboarding "name → loading → name" flash.** After *How It Works* → *Get Started*, the swipe screen briefly showed a card, snapped back to the loader, then showed a card again.
2. **Loader "restarts" + white flash on cold launch.** The Bambino bounce animation started, then visibly reset, with a flash of white in between the two loading animations.

## Root causes

1. `swipeQueueKey` (the `<SwipeCardStack>` remount key) included `user.updatedAt`. Push-token registration runs on `TabsNavigator` mount and calls `setPushToken`, which bumps `updatedAt` → key changes → the stack remounts with a fresh seed → `serverQueue` resets to `undefined` → loader → cards again. `updatedAt` was redundant in the key (filters already drive it).
2. The full-screen `LoadingScreen` mounts at several sequential gates on cold launch (root `AuthGate` → `app/index.tsx` redirect → tabs-layout gate → swipe-stack gate). Each instance ran its **own** per-letter animation from frame 0 (visible restart), `AuthGate` **faded its loader to opacity 0** before the next mounted, and `index.tsx` rendered **only `<Redirect>`** (blank white screen) during the redirect beat.

## Changes

- **`loading-screen.tsx`** — all letters now derive position from a single app-lifetime bounce clock (module-level `makeMutable`, `globalThis`-guarded, started once) via `useDerivedValue`, so a remount continues **in-phase** instead of restarting. Worklet math reproduces the prior easing exactly. New `fadeOnExit` prop (default `true`, preserving `useGracefulLoading`'s loader→content fade). Removed dead `wasLoadedOnMount` ref.
- **`app/_layout.tsx`** — `AuthGate` hands off with `fadeOnExit={false}` (no fade-to-blank before the next loader).
- **`app/index.tsx`** — renders `<LoadingScreen>` behind the redirect so the bare white navigator background never shows.
- **`gradient-background.tsx`** — new `animateEntrance` prop (default `true`); the loader and the Explore screen opt out so the gradient doesn't re-fade-in.
- **`explore/index.tsx`** — dropped `updatedAt` from `swipeQueueKey`; removed the redundant `useGracefulLoading` gate (the tabs-layout gate already guarantees the user row is loaded), keeping a cheap `!user` guard.

## Verification

- `npm run lint` — 0 errors (only pre-existing warnings in untouched files).
- `tsc --noEmit` — clean.
- Manual, iOS device: confirmed by reporter — post-onboarding flash gone; cold launch now reads as one continuous bounce straight into the card with no white gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)