### PR TITLE
fix: theme preview underline reflects gender, not theme color

### DIFF
--- a/components/settings/theme-picker-section.tsx
+++ b/components/settings/theme-picker-section.tsx
@@ -18,6 +18,9 @@ import { Events, trackEvent } from '@/lib/analytics';
 const SPRING_CONFIG = { damping: 20, stiffness: 200 };
 const COLOR_TIMING = { duration: 350, easing: Easing.out(Easing.cubic) };
 
+// Olivia (the preview name) is female — underline matches the swipe card's gender color.
+const PREVIEW_UNDERLINE_COLOR = '#FF8FAB'; // = genderFemale in constants/theme.ts
+
 function ThemeCard({
   themeKey,
   isSelected,
@@ -78,7 +81,6 @@ function ThemeCard({
 
 function PreviewCard({ themeKey }: { themeKey: ThemeKey }) {
   const theme = CANDY_THEMES[themeKey];
-  const meta = THEME_META.find((m) => m.key === themeKey)!;
 
   const progress = useSharedValue(0);
   const contentOpacity = useSharedValue(1);
@@ -104,7 +106,7 @@ function PreviewCard({ themeKey }: { themeKey: ThemeKey }) {
       <Animated.View style={contentFade}>
         <Text style={styles.previewLabel}>Preview</Text>
         <Text style={styles.previewName}>Olivia</Text>
-        <View style={[styles.previewUnderline, { backgroundColor: meta.previewColors[0] }]} />
+        <View style={[styles.previewUnderline, { backgroundColor: PREVIEW_UNDERLINE_COLOR }]} />
         <Text style={styles.previewDescription}>A classic name meaning &quot;olive tree&quot;</Text>
         <View style={[styles.previewPill, { backgroundColor: theme.surfaceSubtle }]}>
           <Text style={styles.previewPillText}>{'\u{1F1EC}\u{1F1E7}'} English</Text>


### PR DESCRIPTION
## Summary
- The Settings → Theme preview card showed "Olivia" with an underline wired to the selected candy theme's color, so it turned yellow/green/blue/pink as you switched themes.
- On the real swipe card that underline is **gender-colored**, so a female preview name should always be pink. Pointed it at the female gender color (`#FF8FAB`, = `genderFemale` in `constants/theme.ts`) via a self-documenting constant.
- Removed the now-unused `meta` lookup in `PreviewCard` (would otherwise trip `no-unused-vars`). The card still previews the theme via its animated border and the origin pill.

## Test plan
- [x] `npm run lint` — 0 errors (no new warnings)
- [ ] Settings → expand Theme → tap through Blossom / Mint / Lagoon / Honeycomb; Olivia's underline stays pink, while the card border and "🇬🇧 English" pill still recolor with the theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)