### PR TITLE
data: audit & correct name origins and descriptions

### DIFF
--- a/convex/names.ts
+++ b/convex/names.ts
@@ -68,7 +68,6 @@ async function getActionedSelections(ctx: QueryCtx) {
     .collect();
 }
 
-
 /**
  * Sum total counts from nameOriginStats grouped by origin. When a gender
  * filter is provided, sums only matching rows. Returns Record<origin, count>.
@@ -374,6 +373,125 @@ export const backfillSelectionOriginGender = internalMutation({
 });
 
 /**
+ * Batch correction of name data (origin and/or meaning). Used by the data
+ * audit to fix AI-generated seed errors at scale. Keyed by `name` (names are
+ * globally unique in this DB). For each correction:
+ *   - Patches `meaning` if provided and different.
+ *   - If `origin` provided and different, applies the same atomic bookkeeping
+ *     as updateNameOrigin: patches the row, adjusts nameOriginStats
+ *     (decrement old / increment new), and patches every referencing
+ *     selection's denormalized origin.
+ *
+ * Idempotent: a correction whose values already match is reported `noop`.
+ * Apply in batches of ~100 to stay under Convex's per-mutation limits.
+ */
+export const applyNameCorrections = internalMutation({
+  args: {
+    corrections: v.array(
+      v.object({
+        name: v.string(),
+        origin: v.optional(v.string()),
+        meaning: v.optional(v.string()),
+      }),
+    ),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const results: Record<string, unknown>[] = [];
+
+    for (const c of args.corrections) {
+      const row = await ctx.db
+        .query('names')
+        .withIndex('by_name', (q) => q.eq('name', c.name))
+        .first();
+      if (!row) {
+        results.push({ name: c.name, status: 'not_found' });
+        continue;
+      }
+
+      const patch: { origin?: string; meaning?: string } = {};
+      if (c.meaning !== undefined && c.meaning !== row.meaning) {
+        patch.meaning = c.meaning;
+      }
+      const originChanged = c.origin !== undefined && c.origin !== row.origin;
+      if (originChanged) {
+        patch.origin = c.origin;
+      }
+
+      if (patch.origin === undefined && patch.meaning === undefined) {
+        results.push({ name: c.name, status: 'noop' });
+        continue;
+      }
+
+      await ctx.db.patch(row._id, patch);
+
+      let selectionsUpdated = 0;
+      if (originChanged) {
+        const oldOrigin = row.origin;
+        const newOrigin = c.origin as string;
+
+        const oldStat = await ctx.db
+          .query('nameOriginStats')
+          .withIndex('by_origin_gender', (q) => q.eq('origin', oldOrigin).eq('gender', row.gender))
+          .unique();
+        if (oldStat) {
+          const nextCount = oldStat.count - 1;
+          if (nextCount <= 0) {
+            await ctx.db.delete(oldStat._id);
+          } else {
+            await ctx.db.patch(oldStat._id, { count: nextCount, updatedAt: now });
+          }
+        }
+
+        const newStat = await ctx.db
+          .query('nameOriginStats')
+          .withIndex('by_origin_gender', (q) => q.eq('origin', newOrigin).eq('gender', row.gender))
+          .unique();
+        if (newStat) {
+          await ctx.db.patch(newStat._id, { count: newStat.count + 1, updatedAt: now });
+        } else {
+          await ctx.db.insert('nameOriginStats', {
+            origin: newOrigin,
+            gender: row.gender,
+            count: 1,
+            updatedAt: now,
+          });
+        }
+
+        const referencing = await ctx.db
+          .query('selections')
+          .withIndex('by_name', (q) => q.eq('nameId', row._id))
+          .collect();
+        for (const sel of referencing) {
+          await ctx.db.patch(sel._id, { origin: newOrigin });
+          selectionsUpdated++;
+        }
+      }
+
+      results.push({
+        name: c.name,
+        status: 'applied',
+        meaningChanged: patch.meaning !== undefined,
+        originChanged,
+        oldOrigin: originChanged ? row.origin : undefined,
+        newOrigin: originChanged ? c.origin : undefined,
+        selectionsUpdated,
+      });
+    }
+
+    const summary = {
+      total: results.length,
+      applied: results.filter((r) => r.status === 'applied').length,
+      noop: results.filter((r) => r.status === 'noop').length,
+      notFound: results.filter((r) => r.status === 'not_found').length,
+      meaningChanges: results.filter((r) => r.meaningChanged === true).length,
+      originChanges: results.filter((r) => r.originChanged === true).length,
+    };
+    return { summary, results };
+  },
+});
+
+/**
  * Correct a name's origin (e.g. fixing seed-data bugs). Atomically:
  *   1. Patches the names row.
  *   2. Decrements the old (origin, gender) stats row.
@@ -414,9 +532,7 @@ export const updateNameOrigin = internalMutation({
     const now = Date.now();
     const oldStat = await ctx.db
       .query('nameOriginStats')
-      .withIndex('by_origin_gender', (q) =>
-        q.eq('origin', oldOrigin).eq('gender', name.gender),
-      )
+      .withIndex('by_origin_gender', (q) => q.eq('origin', oldOrigin).eq('gender', name.gender))
       .unique();
     if (oldStat) {
       const nextCount = oldStat.count - 1;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "populate:origin-stats": "npx tsx scripts/populate-origin-stats.ts",
     "backfill:selection-origin-gender": "npx tsx scripts/backfill-selection-origin-gender.ts",
     "update:name-origin": "npx tsx scripts/update-name-origin.ts",
+    "apply:name-corrections": "npx tsx scripts/apply-name-corrections.ts",
     "extract-names": "npx tsx scripts/extract-ssa-names.ts",
     "enrich-names": "npx tsx scripts/enrich-names.ts"
   },

--- a/scripts/apply-name-corrections.ts
+++ b/scripts/apply-name-corrections.ts
@@ -1,0 +1,121 @@
+import { execSync } from 'child_process';
+import { readFileSync, writeFileSync, unlinkSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+/**
+ * Apply a batch of name-data corrections (origin and/or meaning) produced by
+ * the data audit. Calls names:applyNameCorrections in batches, which atomically
+ * updates the names row, nameOriginStats, and referencing selections for any
+ * origin change (see convex/names.ts).
+ *
+ * The corrections file is a JSON array of:
+ *   { "name": string, "origin"?: string, "meaning"?: string }
+ * Each entry must include at least one of `origin` or `meaning`.
+ *
+ * Usage:
+ *   npm run apply:name-corrections -- <correctionsFile.json>
+ *   npm run apply:name-corrections -- --prod <correctionsFile.json>
+ */
+const BATCH_SIZE = 100;
+
+interface Correction {
+  name: string;
+  origin?: string;
+  meaning?: string;
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const prod = argv.includes('--prod');
+  const positional = argv.filter((a) => a !== '--prod');
+  const file = positional[0];
+
+  if (!file) {
+    console.error('Usage: npm run apply:name-corrections -- [--prod] <correctionsFile.json>');
+    process.exit(1);
+  }
+
+  const raw: unknown = JSON.parse(readFileSync(file, 'utf-8'));
+  if (!Array.isArray(raw)) {
+    console.error('Corrections file must be a JSON array.');
+    process.exit(1);
+  }
+
+  const corrections: Correction[] = [];
+  for (const entry of raw as Correction[]) {
+    if (!entry || typeof entry.name !== 'string') {
+      console.error(`Skipping invalid entry (no name): ${JSON.stringify(entry)}`);
+      continue;
+    }
+    const c: Correction = { name: entry.name };
+    if (typeof entry.origin === 'string' && entry.origin.length > 0) c.origin = entry.origin;
+    if (typeof entry.meaning === 'string' && entry.meaning.length > 0) c.meaning = entry.meaning;
+    if (c.origin === undefined && c.meaning === undefined) {
+      console.error(`Skipping ${entry.name}: no origin or meaning provided`);
+      continue;
+    }
+    corrections.push(c);
+  }
+
+  const convexFlag = prod ? '--prod ' : '';
+  console.log(`Applying ${corrections.length} corrections to ${prod ? 'PRODUCTION' : 'dev'}...`);
+
+  const totals = {
+    applied: 0,
+    noop: 0,
+    notFound: 0,
+    meaningChanges: 0,
+    originChanges: 0,
+  };
+  const notFoundNames: string[] = [];
+
+  for (let i = 0; i < corrections.length; i += BATCH_SIZE) {
+    const batch = corrections.slice(i, i + BATCH_SIZE);
+    const batchNum = Math.floor(i / BATCH_SIZE) + 1;
+    const totalBatches = Math.ceil(corrections.length / BATCH_SIZE);
+    const tmpFile = join(tmpdir(), `bambino-corrections-${batchNum}.json`);
+
+    try {
+      writeFileSync(tmpFile, JSON.stringify({ corrections: batch }));
+      const output = execSync(
+        `npx convex run ${convexFlag}names:applyNameCorrections "$(cat ${tmpFile})"`,
+        { encoding: 'utf-8', cwd: process.cwd() },
+      );
+      const parsed = JSON.parse(output.trim());
+      const s = parsed.summary;
+      totals.applied += s.applied;
+      totals.noop += s.noop;
+      totals.notFound += s.notFound;
+      totals.meaningChanges += s.meaningChanges;
+      totals.originChanges += s.originChanges;
+      for (const r of parsed.results as { name: string; status: string }[]) {
+        if (r.status === 'not_found') notFoundNames.push(r.name);
+      }
+      console.log(
+        `  Batch ${batchNum}/${totalBatches}: applied ${s.applied}, noop ${s.noop}, ` +
+          `notFound ${s.notFound} (origins ${s.originChanges}, meanings ${s.meaningChanges})`,
+      );
+    } catch (error) {
+      console.error(`Error on batch ${batchNum}:`, error);
+      process.exit(1);
+    } finally {
+      try {
+        unlinkSync(tmpFile);
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  console.log('\nDone.');
+  console.log(
+    `Applied ${totals.applied} (origins ${totals.originChanges}, meanings ${totals.meaningChanges}), ` +
+      `noop ${totals.noop}, notFound ${totals.notFound}`,
+  );
+  if (notFoundNames.length > 0) {
+    console.log(`Not found: ${notFoundNames.join(', ')}`);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Audited all **11,444 names** for **origin accuracy** (cultural/usage basis) and **description factual accuracy** using a web-verified, adversarially-checked multi-agent review pass. Corrections were applied to production and synced to the seed source (`data/names.json`).

### Changes
- **1,155 origin reclassifications** — Spanish/Italian/French forms moved off their Germanic/Latin/Hebrew roots to the living culture a parent filters by (e.g. `Eduardo` English→Spanish, `Adolfo` Germanic→Spanish, `Adan` Hebrew→Spanish); modern coinages → English/American (`Adalyn`, `Addison`); ancient/biblical roots kept (`Alexander`→Greek, `Sarah`→Hebrew).
- **186 description fixes** — factual errors corrected (e.g. `Elara` loved by **Zeus** not Apollo; `Aamir` 'flourishing' not 'prince/ruler'; fabricated biblical/royalty claims removed from `Adael`/`Adolfo`).

### Files
- `convex/names.ts` — adds `applyNameCorrections`, an idempotent batch mutation that patches `meaning` and, for origin changes, atomically updates `nameOriginStats` + referencing `selections` (same bookkeeping as `updateNameOrigin`).
- `scripts/apply-name-corrections.ts` + `package.json` — `npm run apply:name-corrections` drives it in batches of 100.
- `data/names.json` — regenerated from corrected prod (origin/meaning only; phonetics untouched, name set unchanged).

### Production status
These corrections are **already live on prod** (`jovial-swan-552`) — applied in verified batches during the audit. The `nameOriginStats` integrity invariant (sum of counts == 11,444 == row count) holds exactly, so origin-filter counts remain correct. Merging this PR redeploys `applyNameCorrections` via `convex-deploy.yml`, reconciling the manual deploy done during the audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
