### PR TITLE
fix: opaque theme & skin-tone check badges + resolve ESLint warnings

### DIFF
--- a/components/matches/match-card.tsx
+++ b/components/matches/match-card.tsx
@@ -31,7 +31,7 @@ interface MatchCardProps {
 function MatchCardImpl({ match, currentUserId, onPress, onPropose, onWithdraw }: MatchCardProps) {
   const { colors } = useTheme();
   const { skinTone } = useSkinTone();
-  const { name, isFavorite, isChosen, proposalStatus, proposedBy, matchedAt } = match;
+  const { name, isChosen, proposalStatus, proposedBy, matchedAt } = match;
   const genderEmoji = getGenderEmoji(name.gender, skinTone);
   const relativeTime = getRelativeTime(matchedAt);
 

--- a/components/partner/name-confirmation-modal.tsx
+++ b/components/partner/name-confirmation-modal.tsx
@@ -54,7 +54,9 @@ export function NameConfirmationModal({
       setError(null);
       setIsConfirming(false);
     }
-  }, [visible, user?.firstName, user?.lastName]);
+    // Keyed on the primitive name fields (not the `user` object identity) so a
+    // new Clerk user ref doesn't re-trigger the reset. eslint-disable-line below.
+  }, [visible, user?.firstName, user?.lastName]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleConfirm = async () => {
     const trimmedFirst = firstName.trim();

--- a/components/partner/partner-link-modal.tsx
+++ b/components/partner/partner-link-modal.tsx
@@ -20,7 +20,6 @@ import { useTheme } from '@/contexts/theme-context';
 import { Events, trackEvent } from '@/lib/analytics';
 import { decodeConvexError } from '@/lib/convex-errors';
 import { AnimatedBottomSheet } from '@/components/ui/animated-bottom-sheet';
-import { StyledInput } from '@/components/ui/styled-input';
 import { NameConfirmationModal } from './name-confirmation-modal';
 
 interface PartnerLinkModalProps {

--- a/components/settings/skin-tone-section.tsx
+++ b/components/settings/skin-tone-section.tsx
@@ -186,7 +186,7 @@ const styles = StyleSheet.create({
     width: 22,
     height: 22,
     borderRadius: 11,
-    backgroundColor: 'rgba(255,255,255,0.9)',
+    backgroundColor: '#FFFFFF',
     alignItems: 'center',
     justifyContent: 'center',
     shadowColor: '#000',

--- a/components/settings/theme-picker-section.tsx
+++ b/components/settings/theme-picker-section.tsx
@@ -249,7 +249,7 @@ const styles = StyleSheet.create({
     width: 26,
     height: 26,
     borderRadius: 13,
-    backgroundColor: 'rgba(255,255,255,0.9)',
+    backgroundColor: '#FFFFFF',
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/components/ui/animated-bottom-sheet.tsx
+++ b/components/ui/animated-bottom-sheet.tsx
@@ -1,6 +1,5 @@
 import { useEffect, type ReactNode } from 'react';
 import {
-  View,
   Pressable,
   StyleSheet,
   Modal,
@@ -52,7 +51,8 @@ export function AnimatedBottomSheet({
         easing: Easing.out(Easing.cubic),
       });
     }
-  }, [visible]);
+    // backdropOpacity & sheetTranslateY are stable useSharedValue refs; omitted from deps.
+  }, [visible]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const animateOut = () => {
     Keyboard.dismiss();
@@ -88,7 +88,8 @@ export function AnimatedBottomSheet({
       backdropOpacity.value = 0;
       sheetTranslateY.value = SCREEN_HEIGHT;
     }
-  }, [visible]);
+    // backdropOpacity & sheetTranslateY are stable useSharedValue refs; omitted from deps.
+  }, [visible]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <Modal visible={visible} transparent statusBarTranslucent onRequestClose={animateOut}>

--- a/components/ui/slot-counter.tsx
+++ b/components/ui/slot-counter.tsx
@@ -76,7 +76,8 @@ function SlotDigit({ digit, digitHeight, fontSize, textStyle }: SlotDigitProps) 
       duration: 500,
       easing: Easing.out(Easing.cubic),
     });
-  }, [digit, digitHeight]);
+    // translateY is a stable useSharedValue ref; intentionally omitted from deps.
+  }, [digit, digitHeight]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [{ translateY: translateY.value }],


### PR DESCRIPTION
## Summary
- Make the theme and skin-tone selector **check badges fully opaque** (previously semi-transparent over their swatch).
- Resolve all outstanding **ESLint warnings** (unused vars + intentionally-listed effect deps) across a handful of components.

## Changes
- `fix:` opaque check badges — `theme-picker-section`, `skin-tone-section`.
- `chore:` ESLint cleanup — `match-card`, `name-confirmation-modal`, `partner-link-modal`, `animated-bottom-sheet`, `slot-counter`, and the two settings sections above.

## Verification
- `npm run lint` passes clean (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>