### PR TITLE
feat: filter-discovery nudge — banner + Filters pulse after 5 rejects

### DIFF
--- a/app/(tabs)/explore/filters.tsx
+++ b/app/(tabs)/explore/filters.tsx
@@ -22,6 +22,19 @@ export default function Filters() {
   const { colors } = useTheme();
   const user = useQuery(api.users.getCurrentUser);
   const updateFilters = useMutation(api.users.updateFilters);
+  const markFiltersOpened = useMutation(api.users.markFiltersOpened);
+
+  // First visit to this screen → show the explanatory banner. Capture the
+  // decision once, BEFORE markFiltersOpened flips the flag, so a re-read of
+  // `user` doesn't make the banner vanish on mount.
+  const [showBanner, setShowBanner] = useState(false);
+  const bannerDecided = useRef(false);
+  useEffect(() => {
+    if (bannerDecided.current || !user) return;
+    bannerDecided.current = true;
+    if (user.hasOpenedFilters !== true) setShowBanner(true);
+    void markFiltersOpened();
+  }, [user, markFiltersOpened]);
 
   const [genderFilter, setGenderFilter] = useState<GenderFilter>('both');
   // null = all origins, [] = none, [...] = specific
@@ -161,6 +174,28 @@ export default function Filters() {
 
         {/* Scrollable content */}
         <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent}>
+          {/* First-visit explainer banner */}
+          {showBanner && (
+            <View
+              style={[
+                styles.banner,
+                { backgroundColor: colors.surfaceSubtle, borderColor: colors.border },
+              ]}
+            >
+              <Text style={styles.bannerText}>
+                Filter by gender, origin, or category to see names that fit you.
+              </Text>
+              <Pressable
+                onPress={() => setShowBanner(false)}
+                accessibilityLabel="Dismiss"
+                accessibilityRole="button"
+                hitSlop={8}
+              >
+                <Ionicons name="close" size={18} color="#6B5B7B" />
+              </Pressable>
+            </View>
+          )}
+
           {/* Names counter card */}
           <View
             style={[
@@ -247,6 +282,22 @@ const styles = StyleSheet.create({
     paddingTop: 16,
     paddingBottom: 100,
     gap: 28,
+  },
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    padding: 14,
+    borderRadius: 14,
+    borderWidth: 1.5,
+  },
+  bannerText: {
+    flex: 1,
+    fontSize: 13,
+    fontFamily: Fonts?.sans,
+    color: '#2D1B4E',
+    lineHeight: 18,
   },
   counterCard: {
     flexDirection: 'row',

--- a/app/(tabs)/explore/filters.tsx
+++ b/app/(tabs)/explore/filters.tsx
@@ -179,7 +179,11 @@ export default function Filters() {
             <View
               style={[
                 styles.banner,
-                { backgroundColor: colors.surfaceSubtle, borderColor: colors.border },
+                {
+                  backgroundColor: colors.surfaceSubtle,
+                  borderColor: colors.border,
+                  shadowColor: colors.secondary,
+                },
               ]}
             >
               <Text style={styles.bannerText}>
@@ -288,9 +292,13 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
     gap: 12,
-    padding: 14,
-    borderRadius: 14,
+    padding: 16,
+    borderRadius: 16,
     borderWidth: 1.5,
+    shadowOpacity: 0.07,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 2,
   },
   bannerText: {
     flex: 1,

--- a/app/(tabs)/explore/index.tsx
+++ b/app/(tabs)/explore/index.tsx
@@ -46,18 +46,18 @@ export default function ExploreView() {
     return count;
   }, [user]);
 
-  const { nudgeVisible, registerSwipe, dismissNudge } = useFilterNudge({
+  const { bannerVisible, pulseActive, registerSwipe, onFilterPressed } = useFilterNudge({
     hasOpenedFilters: user?.hasOpenedFilters,
     filterNudgeShown: user?.filterNudgeShown,
   });
 
   const handleFilterPress = useCallback(() => {
-    if (nudgeVisible) {
+    if (pulseActive || bannerVisible) {
       trackEvent(Events.FILTER_NUDGE_TAPPED);
-      dismissNudge();
     }
+    onFilterPressed();
     router.push('/(tabs)/explore/filters');
-  }, [nudgeVisible, dismissNudge, router]);
+  }, [pulseActive, bannerVisible, onFilterPressed, router]);
 
   // The tabs-layout gate (app/(tabs)/_layout.tsx) already holds the loader
   // until getCurrentUser resolves, so `user` is a cached Doc by the time this
@@ -75,11 +75,16 @@ export default function ExploreView() {
         <ExploreHeader
           liked={stats?.liked ?? 0}
           activeFilterCount={activeFilterCount}
-          nudgeVisible={nudgeVisible}
+          pulseActive={pulseActive}
           onFilterPress={handleFilterPress}
         />
         <ErrorBoundary>
-          <SwipeCardStack key={swipeQueueKey} onSwipeResult={registerSwipe} />
+          <SwipeCardStack
+            key={swipeQueueKey}
+            onSwipeResult={registerSwipe}
+            nudgeBannerVisible={bannerVisible}
+            onNudgeBannerPress={handleFilterPress}
+          />
         </ErrorBoundary>
       </SafeAreaView>
     </GradientBackground>

--- a/app/(tabs)/explore/index.tsx
+++ b/app/(tabs)/explore/index.tsx
@@ -3,8 +3,9 @@ import { StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter, useFocusEffect } from 'expo-router';
 import { useQuery } from 'convex/react';
-import { trackScreen } from '@/lib/analytics';
+import { trackScreen, trackEvent, Events } from '@/lib/analytics';
 import { api } from '@/convex/_generated/api';
+import { useFilterNudge } from '@/hooks/use-filter-nudge';
 import { SwipeCardStack } from '@/components/swipe/swipe-card-stack';
 import { ExploreHeader } from '@/components/swipe/explore-header';
 import { ErrorBoundary } from '@/components/error-boundary';
@@ -45,6 +46,19 @@ export default function ExploreView() {
     return count;
   }, [user]);
 
+  const { nudgeVisible, registerSwipe, dismissNudge } = useFilterNudge({
+    hasOpenedFilters: user?.hasOpenedFilters,
+    filterNudgeShown: user?.filterNudgeShown,
+  });
+
+  const handleFilterPress = useCallback(() => {
+    if (nudgeVisible) {
+      trackEvent(Events.FILTER_NUDGE_TAPPED);
+      dismissNudge();
+    }
+    router.push('/(tabs)/explore/filters');
+  }, [nudgeVisible, dismissNudge, router]);
+
   // The tabs-layout gate (app/(tabs)/_layout.tsx) already holds the loader
   // until getCurrentUser resolves, so `user` is a cached Doc by the time this
   // screen mounts — no graceful-loading dance needed. Keep a cheap guard for
@@ -61,10 +75,11 @@ export default function ExploreView() {
         <ExploreHeader
           liked={stats?.liked ?? 0}
           activeFilterCount={activeFilterCount}
-          onFilterPress={() => router.push('/(tabs)/explore/filters')}
+          nudgeVisible={nudgeVisible}
+          onFilterPress={handleFilterPress}
         />
         <ErrorBoundary>
-          <SwipeCardStack key={swipeQueueKey} />
+          <SwipeCardStack key={swipeQueueKey} onSwipeResult={registerSwipe} />
         </ErrorBoundary>
       </SafeAreaView>
     </GradientBackground>

--- a/components/swipe/explore-header.tsx
+++ b/components/swipe/explore-header.tsx
@@ -2,7 +2,6 @@ import { useEffect } from 'react';
 import { Text, StyleSheet, Pressable, View } from 'react-native';
 import Animated, {
   FadeInDown,
-  FadeIn,
   useSharedValue,
   useAnimatedStyle,
   withRepeat,
@@ -19,25 +18,26 @@ import { useA11yPreferences } from '@/hooks/use-a11y-preferences';
 interface ExploreHeaderProps {
   liked: number;
   activeFilterCount: number;
-  nudgeVisible: boolean;
+  // Pulses the Filters pill while the discovery nudge is active. Persists until
+  // the user opens Filters (cleared by the parent's onFilterPress handler).
+  pulseActive: boolean;
   onFilterPress: () => void;
 }
 
 export function ExploreHeader({
   liked,
   activeFilterCount,
-  nudgeVisible,
+  pulseActive,
   onFilterPress,
 }: ExploreHeaderProps) {
   const router = useRouter();
   const { colors } = useTheme();
   const { reduceMotion } = useA11yPreferences();
 
-  // Pulse the Filters pill while the discovery nudge is showing. Reduce Motion
-  // users get no animation — just the static tooltip below.
+  // Reduce Motion users get no animation — the banner still conveys the nudge.
   const pulse = useSharedValue(1);
   useEffect(() => {
-    if (nudgeVisible && !reduceMotion) {
+    if (pulseActive && !reduceMotion) {
       pulse.value = withRepeat(
         withSequence(withTiming(1.06, { duration: 600 }), withTiming(1, { duration: 600 })),
         -1,
@@ -48,76 +48,45 @@ export function ExploreHeader({
       pulse.value = withTiming(1, { duration: 200 });
     }
     return () => cancelAnimation(pulse);
-  }, [nudgeVisible, reduceMotion, pulse]);
+  }, [pulseActive, reduceMotion, pulse]);
 
   const pulseStyle = useAnimatedStyle(() => ({ transform: [{ scale: pulse.value }] }));
 
   return (
-    <View style={styles.wrapper}>
-      <Animated.View entering={FadeInDown.duration(400).springify()} style={styles.container}>
-        <Animated.View style={pulseStyle}>
-          <Pressable
-            style={[styles.filterPill, { shadowColor: colors.secondary }]}
-            onPress={onFilterPress}
-            accessibilityLabel={`Filters${activeFilterCount > 0 ? `, ${activeFilterCount} active` : ''}`}
-            accessibilityRole="button"
-            hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
-          >
-            <Ionicons name="options-outline" size={16} color="#2D1B4E" />
-            <Text style={styles.filterLabel}>Filters</Text>
-            {activeFilterCount > 0 && (
-              <View style={[styles.filterBadge, { backgroundColor: colors.primary }]}>
-                <Text style={styles.filterBadgeText}>{activeFilterCount}</Text>
-              </View>
-            )}
-          </Pressable>
-        </Animated.View>
-
+    <Animated.View entering={FadeInDown.duration(400).springify()} style={styles.container}>
+      <Animated.View style={pulseStyle}>
         <Pressable
-          style={[styles.likedButton, { shadowColor: colors.secondary }]}
-          onPress={() => router.push('/(tabs)/dashboard')}
-          accessibilityLabel="Liked names"
+          style={[styles.filterPill, { shadowColor: colors.secondary }]}
+          onPress={onFilterPress}
+          accessibilityLabel={`Filters${activeFilterCount > 0 ? `, ${activeFilterCount} active` : ''}`}
           accessibilityRole="button"
-          hitSlop={8}
+          hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
         >
-          <Text style={styles.likedText}>{liked}</Text>
-          <Ionicons name="heart" size={16} color={colors.primary} />
+          <Ionicons name="options-outline" size={16} color="#2D1B4E" />
+          <Text style={styles.filterLabel}>Filters</Text>
+          {activeFilterCount > 0 && (
+            <View style={[styles.filterBadge, { backgroundColor: colors.primary }]}>
+              <Text style={styles.filterBadgeText}>{activeFilterCount}</Text>
+            </View>
+          )}
         </Pressable>
       </Animated.View>
 
-      {nudgeVisible && (
-        <Animated.View
-          entering={FadeIn.duration(250)}
-          style={styles.tooltipAnchor}
-          pointerEvents="box-none"
-        >
-          <Pressable
-            style={[
-              styles.tooltip,
-              {
-                backgroundColor: colors.secondaryLight,
-                borderColor: colors.primary,
-                shadowColor: colors.primary,
-              },
-            ]}
-            onPress={onFilterPress}
-            accessibilityRole="button"
-            accessibilityLiveRegion="polite"
-            accessibilityLabel="Not feeling these? Adjust your filters"
-          >
-            <Text style={styles.tooltipText}>Not feeling these? Adjust your filters</Text>
-          </Pressable>
-        </Animated.View>
-      )}
-    </View>
+      <Pressable
+        style={[styles.likedButton, { shadowColor: colors.secondary }]}
+        onPress={() => router.push('/(tabs)/dashboard')}
+        accessibilityLabel="Liked names"
+        accessibilityRole="button"
+        hitSlop={8}
+      >
+        <Text style={styles.likedText}>{liked}</Text>
+        <Ionicons name="heart" size={16} color={colors.primary} />
+      </Pressable>
+    </Animated.View>
   );
 }
 
 const styles = StyleSheet.create({
-  wrapper: {
-    position: 'relative',
-    zIndex: 10,
-  },
   container: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -173,27 +142,5 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '600',
     color: '#6B5B7B',
-  },
-  tooltipAnchor: {
-    position: 'absolute',
-    top: 48,
-    left: 16,
-  },
-  tooltip: {
-    borderWidth: 2,
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    borderRadius: 14,
-    maxWidth: 260,
-    shadowOpacity: 0.18,
-    shadowRadius: 12,
-    shadowOffset: { width: 0, height: 4 },
-    elevation: 6,
-  },
-  tooltipText: {
-    fontSize: 13,
-    fontFamily: Fonts?.sans,
-    fontWeight: '600',
-    color: '#2D1B4E',
   },
 });

--- a/components/swipe/explore-header.tsx
+++ b/components/swipe/explore-header.tsx
@@ -92,7 +92,14 @@ export function ExploreHeader({
           pointerEvents="box-none"
         >
           <Pressable
-            style={styles.tooltip}
+            style={[
+              styles.tooltip,
+              {
+                backgroundColor: colors.secondaryLight,
+                borderColor: colors.primary,
+                shadowColor: colors.primary,
+              },
+            ]}
             onPress={onFilterPress}
             accessibilityRole="button"
             accessibilityLiveRegion="polite"
@@ -173,21 +180,20 @@ const styles = StyleSheet.create({
     left: 16,
   },
   tooltip: {
-    backgroundColor: '#2D1B4E',
+    borderWidth: 2,
     paddingHorizontal: 12,
     paddingVertical: 8,
-    borderRadius: 12,
+    borderRadius: 14,
     maxWidth: 260,
-    shadowColor: '#2D1B4E',
-    shadowOpacity: 0.2,
-    shadowRadius: 8,
-    shadowOffset: { width: 0, height: 3 },
-    elevation: 4,
+    shadowOpacity: 0.18,
+    shadowRadius: 12,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 6,
   },
   tooltipText: {
     fontSize: 13,
     fontFamily: Fonts?.sans,
     fontWeight: '600',
-    color: '#fff',
+    color: '#2D1B4E',
   },
 });

--- a/components/swipe/explore-header.tsx
+++ b/components/swipe/explore-header.tsx
@@ -1,53 +1,116 @@
+import { useEffect } from 'react';
 import { Text, StyleSheet, Pressable, View } from 'react-native';
-import Animated, { FadeInDown } from 'react-native-reanimated';
+import Animated, {
+  FadeInDown,
+  FadeIn,
+  useSharedValue,
+  useAnimatedStyle,
+  withRepeat,
+  withSequence,
+  withTiming,
+  cancelAnimation,
+} from 'react-native-reanimated';
 import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
+import { useA11yPreferences } from '@/hooks/use-a11y-preferences';
 
 interface ExploreHeaderProps {
   liked: number;
   activeFilterCount: number;
+  nudgeVisible: boolean;
   onFilterPress: () => void;
 }
 
-export function ExploreHeader({ liked, activeFilterCount, onFilterPress }: ExploreHeaderProps) {
+export function ExploreHeader({
+  liked,
+  activeFilterCount,
+  nudgeVisible,
+  onFilterPress,
+}: ExploreHeaderProps) {
   const router = useRouter();
   const { colors } = useTheme();
+  const { reduceMotion } = useA11yPreferences();
+
+  // Pulse the Filters pill while the discovery nudge is showing. Reduce Motion
+  // users get no animation — just the static tooltip below.
+  const pulse = useSharedValue(1);
+  useEffect(() => {
+    if (nudgeVisible && !reduceMotion) {
+      pulse.value = withRepeat(
+        withSequence(withTiming(1.06, { duration: 600 }), withTiming(1, { duration: 600 })),
+        -1,
+        true,
+      );
+    } else {
+      cancelAnimation(pulse);
+      pulse.value = withTiming(1, { duration: 200 });
+    }
+    return () => cancelAnimation(pulse);
+  }, [nudgeVisible, reduceMotion, pulse]);
+
+  const pulseStyle = useAnimatedStyle(() => ({ transform: [{ scale: pulse.value }] }));
 
   return (
-    <Animated.View entering={FadeInDown.duration(400).springify()} style={styles.container}>
-      <Pressable
-        style={[styles.filterPill, { shadowColor: colors.secondary }]}
-        onPress={onFilterPress}
-        accessibilityLabel={`Filters${activeFilterCount > 0 ? `, ${activeFilterCount} active` : ''}`}
-        accessibilityRole="button"
-        hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
-      >
-        <Ionicons name="options-outline" size={16} color="#2D1B4E" />
-        <Text style={styles.filterLabel}>Filters</Text>
-        {activeFilterCount > 0 && (
-          <View style={[styles.filterBadge, { backgroundColor: colors.primary }]}>
-            <Text style={styles.filterBadgeText}>{activeFilterCount}</Text>
-          </View>
-        )}
-      </Pressable>
+    <View style={styles.wrapper}>
+      <Animated.View entering={FadeInDown.duration(400).springify()} style={styles.container}>
+        <Animated.View style={pulseStyle}>
+          <Pressable
+            style={[styles.filterPill, { shadowColor: colors.secondary }]}
+            onPress={onFilterPress}
+            accessibilityLabel={`Filters${activeFilterCount > 0 ? `, ${activeFilterCount} active` : ''}`}
+            accessibilityRole="button"
+            hitSlop={{ top: 12, bottom: 12, left: 8, right: 8 }}
+          >
+            <Ionicons name="options-outline" size={16} color="#2D1B4E" />
+            <Text style={styles.filterLabel}>Filters</Text>
+            {activeFilterCount > 0 && (
+              <View style={[styles.filterBadge, { backgroundColor: colors.primary }]}>
+                <Text style={styles.filterBadgeText}>{activeFilterCount}</Text>
+              </View>
+            )}
+          </Pressable>
+        </Animated.View>
 
-      <Pressable
-        style={[styles.likedButton, { shadowColor: colors.secondary }]}
-        onPress={() => router.push('/(tabs)/dashboard')}
-        accessibilityLabel="Liked names"
-        accessibilityRole="button"
-        hitSlop={8}
-      >
-        <Text style={styles.likedText}>{liked}</Text>
-        <Ionicons name="heart" size={16} color={colors.primary} />
-      </Pressable>
-    </Animated.View>
+        <Pressable
+          style={[styles.likedButton, { shadowColor: colors.secondary }]}
+          onPress={() => router.push('/(tabs)/dashboard')}
+          accessibilityLabel="Liked names"
+          accessibilityRole="button"
+          hitSlop={8}
+        >
+          <Text style={styles.likedText}>{liked}</Text>
+          <Ionicons name="heart" size={16} color={colors.primary} />
+        </Pressable>
+      </Animated.View>
+
+      {nudgeVisible && (
+        <Animated.View
+          entering={FadeIn.duration(250)}
+          style={styles.tooltipAnchor}
+          pointerEvents="box-none"
+        >
+          <Pressable
+            style={styles.tooltip}
+            onPress={onFilterPress}
+            accessibilityRole="button"
+            accessibilityLiveRegion="polite"
+            accessibilityLabel="Not feeling these? Adjust your filters"
+          >
+            <Text style={styles.tooltipText}>Not feeling these? Adjust your filters</Text>
+          </Pressable>
+        </Animated.View>
+      )}
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  wrapper: {
+    position: 'relative',
+    zIndex: 10,
+  },
   container: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -103,5 +166,28 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: '600',
     color: '#6B5B7B',
+  },
+  tooltipAnchor: {
+    position: 'absolute',
+    top: 48,
+    left: 16,
+  },
+  tooltip: {
+    backgroundColor: '#2D1B4E',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 12,
+    maxWidth: 260,
+    shadowColor: '#2D1B4E',
+    shadowOpacity: 0.2,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 3 },
+    elevation: 4,
+  },
+  tooltipText: {
+    fontSize: 13,
+    fontFamily: Fonts?.sans,
+    fontWeight: '600',
+    color: '#fff',
   },
 });

--- a/components/swipe/filter-nudge-banner.tsx
+++ b/components/swipe/filter-nudge-banner.tsx
@@ -1,0 +1,118 @@
+import { useEffect } from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  Easing,
+} from 'react-native-reanimated';
+import { Ionicons } from '@expo/vector-icons';
+import { Fonts } from '@/constants/theme';
+import { useTheme } from '@/contexts/theme-context';
+
+// Drop-down distance — mirrors MatchToast so the two banners share the same
+// motion and resting position over the top of the card stack.
+export const FILTER_NUDGE_BANNER_HEIGHT = 72;
+
+interface FilterNudgeBannerProps {
+  visible: boolean;
+  onPress: () => void;
+}
+
+/**
+ * One-time "Adjust your filters" nudge banner. Visually matches MatchToast (the
+ * app's established top drop-down callout) but is fully controlled by `visible`
+ * — the parent drops it in on the trigger swipe and removes it on the next
+ * swipe, so there's no internal auto-dismiss timer. Kept mounted (translated
+ * off-screen when hidden) so the exit animation plays smoothly.
+ */
+export function FilterNudgeBanner({ visible, onPress }: FilterNudgeBannerProps) {
+  const { colors } = useTheme();
+  const translateY = useSharedValue(-(FILTER_NUDGE_BANNER_HEIGHT + 20));
+  const opacity = useSharedValue(0);
+
+  useEffect(() => {
+    if (visible) {
+      translateY.value = withTiming(0, { duration: 400, easing: Easing.out(Easing.cubic) });
+      opacity.value = withTiming(1, { duration: 300 });
+    } else {
+      translateY.value = withTiming(-(FILTER_NUDGE_BANNER_HEIGHT + 20), {
+        duration: 300,
+        easing: Easing.in(Easing.cubic),
+      });
+      opacity.value = withTiming(0, { duration: 200 });
+    }
+  }, [visible, translateY, opacity]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.value }],
+    opacity: opacity.value,
+  }));
+
+  return (
+    <Animated.View
+      style={[styles.container, animatedStyle]}
+      pointerEvents={visible ? 'auto' : 'none'}
+    >
+      <Pressable
+        style={[
+          styles.banner,
+          {
+            borderColor: colors.primary,
+            backgroundColor: colors.secondaryLight,
+            shadowColor: colors.primary,
+          },
+        ]}
+        onPress={onPress}
+        accessibilityRole="button"
+        accessibilityLiveRegion="polite"
+        accessibilityLabel="Not feeling these? Tap to adjust your filters"
+      >
+        <Ionicons name="options-outline" size={20} color={colors.tabActive} />
+        <View style={styles.content}>
+          <Text style={[styles.title, { color: colors.tabActive }]}>Not feeling these?</Text>
+          <Text style={styles.subtitle}>Tap to adjust your filters</Text>
+        </View>
+        <Ionicons name="chevron-forward" size={18} color="#A89BB5" />
+      </Pressable>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  // Matches MatchToast's container + toast styling so the two read as one family.
+  container: {
+    position: 'absolute',
+    top: -36,
+    left: 6,
+    right: 6,
+    zIndex: 10,
+  },
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    borderRadius: 16,
+    borderWidth: 3,
+    paddingVertical: 12,
+    paddingHorizontal: 18,
+    shadowOpacity: 0.25,
+    shadowRadius: 24,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 8,
+  },
+  content: {
+    flex: 1,
+  },
+  title: {
+    fontFamily: Fonts?.title || 'Gabarito_800ExtraBold',
+    fontWeight: '800',
+    fontSize: 16,
+  },
+  subtitle: {
+    fontFamily: Fonts?.sans,
+    fontSize: 12,
+    color: '#6B5B7B',
+    marginTop: 1,
+  },
+});

--- a/components/swipe/swipe-card-stack.tsx
+++ b/components/swipe/swipe-card-stack.tsx
@@ -21,7 +21,13 @@ import { useA11yPreferences } from '@/hooks/use-a11y-preferences';
 import { usePushPriming } from '@/hooks/use-push-priming';
 import { usePushRequestPermission } from '@/hooks/use-push-registration';
 
-export function SwipeCardStack() {
+interface SwipeCardStackProps {
+  // Fired once per successfully-recorded swipe. Used by the filter-discovery
+  // nudge to count consecutive rejects; the stack itself stays nudge-agnostic.
+  onSwipeResult?: (type: 'like' | 'reject') => void;
+}
+
+export function SwipeCardStack({ onSwipeResult }: SwipeCardStackProps) {
   const router = useRouter();
 
   // Stable per mount. getSwipeQueue is reactive: every recordSelection
@@ -176,6 +182,7 @@ export function SwipeCardStack() {
         }
 
         trackEvent(Events.NAME_SWIPED, { direction: selectionType });
+        onSwipeResult?.(selectionType);
 
         // Check if we got a match
         if (result.match && result.match.name) {
@@ -193,7 +200,7 @@ export function SwipeCardStack() {
         setShowErrorToast(true);
       }
     },
-    [recordSelection],
+    [recordSelection, onSwipeResult],
   );
 
   // Check for empty state

--- a/components/swipe/swipe-card-stack.tsx
+++ b/components/swipe/swipe-card-stack.tsx
@@ -11,6 +11,7 @@ import { SwipeCard } from './swipe-card';
 import { SwipeActionButtons, SWIPE_ACTION_BUTTONS_HEIGHT } from './swipe-action-buttons';
 import { EmptyState } from './empty-state';
 import { MatchToast } from '@/components/matches/match-toast';
+import { FilterNudgeBanner } from './filter-nudge-banner';
 import { ErrorToast } from '@/components/ui/error-toast';
 import { NameDetailModal } from '@/components/name-detail/name-detail-modal';
 import { Paywall } from '@/components/paywall';
@@ -25,9 +26,17 @@ interface SwipeCardStackProps {
   // Fired once per successfully-recorded swipe. Used by the filter-discovery
   // nudge to count consecutive rejects; the stack itself stays nudge-agnostic.
   onSwipeResult?: (type: 'like' | 'reject') => void;
+  // Filter-discovery nudge banner. Controlled by the parent: shown on the
+  // trigger swipe, removed on the next swipe.
+  nudgeBannerVisible?: boolean;
+  onNudgeBannerPress?: () => void;
 }
 
-export function SwipeCardStack({ onSwipeResult }: SwipeCardStackProps) {
+export function SwipeCardStack({
+  onSwipeResult,
+  nudgeBannerVisible = false,
+  onNudgeBannerPress,
+}: SwipeCardStackProps) {
   const router = useRouter();
 
   // Stable per mount. getSwipeQueue is reactive: every recordSelection
@@ -249,6 +258,9 @@ export function SwipeCardStack({ onSwipeResult }: SwipeCardStackProps) {
           reduceMotion={reduceMotion}
         />
       )}
+
+      {/* Filter-discovery nudge banner (same drop-down family as MatchToast) */}
+      <FilterNudgeBanner visible={nudgeBannerVisible} onPress={onNudgeBannerPress ?? (() => {})} />
 
       {/* Subsequent match toast */}
       <MatchToast

--- a/constants/swipe.ts
+++ b/constants/swipe.ts
@@ -6,6 +6,10 @@ const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 export const SWIPE_THRESHOLD = 120; // px to trigger action
 export const SWIPE_VELOCITY = 800; // velocity threshold for quick swipes
 
+// Filter-discovery nudge: consecutive rejects (no like in between) that trigger
+// the one-time "Adjust your filters" nudge on the swipe screen.
+export const FILTER_NUDGE_REJECT_THRESHOLD = 5;
+
 // Layout heights (approximate safe area + header + tab bar)
 export const HEADER_HEIGHT = 64; // Compact header row
 export const TAB_BAR_HEIGHT = 80; // Bottom tab bar

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -16,6 +16,13 @@ export default defineSchema({
     // the same device doesn't re-trigger onboarding, and a fresh device
     // doesn't skip it. (#154)
     onboardingCompleted: v.optional(v.boolean()),
+    // Filter-discovery nudge (one-time). hasOpenedFilters: true once the user
+    // has ever opened the Filters screen — disqualifies the swipe-screen nudge
+    // and retires its first-visit banner. filterNudgeShown: true once the nudge
+    // has been shown. On the user row (not AsyncStorage) so "show once" means
+    // once per user across devices/reinstalls, like onboardingCompleted.
+    hasOpenedFilters: v.optional(v.boolean()),
+    filterNudgeShown: v.optional(v.boolean()),
     // Running counters for getSelectionStats (#183). Kept in sync by every
     // mutation that inserts/deletes/changes a selection. Backfilled lazily
     // on first counter-touching mutation per user.

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -321,6 +321,33 @@ export const setOnboardingCompleted = mutation({
   },
 });
 
+/** Mark that the user has opened the Filters screen at least once. Disqualifies
+ *  the filter-discovery nudge and retires its first-visit banner. Idempotent. */
+export const markFiltersOpened = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const user = await getCurrentUserOrThrow(ctx);
+    if (user.hasOpenedFilters === true) return;
+    await ctx.db.patch(user._id, {
+      hasOpenedFilters: true,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+/** Mark that the one-time filter-discovery nudge has been shown. Idempotent. */
+export const markFilterNudgeShown = mutation({
+  args: {},
+  handler: async (ctx) => {
+    const user = await getCurrentUserOrThrow(ctx);
+    if (user.filterNudgeShown === true) return;
+    await ctx.db.patch(user._id, {
+      filterNudgeShown: true,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
 /** In-app toggle for push notifications (#229). Absent = enabled; only an
  *  explicit false suppresses sends (enforced in notifications.sendPushNotification). */
 export const setPushNotificationsEnabled = mutation({

--- a/hooks/use-filter-nudge.ts
+++ b/hooks/use-filter-nudge.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { trackEvent, Events } from '@/lib/analytics';
+import { FILTER_NUDGE_REJECT_THRESHOLD } from '@/constants/swipe';
+
+interface UseFilterNudgeArgs {
+  // From the getCurrentUser doc. undefined while the user query is loading.
+  hasOpenedFilters: boolean | undefined;
+  filterNudgeShown: boolean | undefined;
+}
+
+interface UseFilterNudge {
+  nudgeVisible: boolean;
+  registerSwipe: (type: 'like' | 'reject') => void;
+  dismissNudge: () => void;
+}
+
+// How long the tooltip lingers before auto-dismissing.
+const AUTO_DISMISS_MS = 6000;
+
+/**
+ * One-time "Adjust your filters" nudge. Counts consecutive rejects (a like
+ * resets the count) and reveals the tooltip when the user has hit the threshold
+ * without ever opening Filters and without having seen the nudge before.
+ *
+ * Two guarantees combine: `firedThisSessionRef` blocks a second reveal within
+ * the session (synchronous, no round-trip), and `markFilterNudgeShown` persists
+ * the flag on the user row so it never reappears on any device. Eligibility
+ * flags are read via a ref so `registerSwipe` keeps a stable identity and never
+ * forces the swipe stack to re-render mid-session.
+ */
+export function useFilterNudge({
+  hasOpenedFilters,
+  filterNudgeShown,
+}: UseFilterNudgeArgs): UseFilterNudge {
+  const markFilterNudgeShown = useMutation(api.users.markFilterNudgeShown).withOptimisticUpdate(
+    (store) => {
+      const current = store.getQuery(api.users.getCurrentUser, {});
+      if (current) {
+        store.setQuery(api.users.getCurrentUser, {}, { ...current, filterNudgeShown: true });
+      }
+    },
+  );
+
+  const [nudgeVisible, setNudgeVisible] = useState(false);
+  const consecutiveRejectsRef = useRef(0);
+  const firedThisSessionRef = useRef(false);
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Latest eligibility flags, read inside the stable registerSwipe callback.
+  const flagsRef = useRef({ hasOpenedFilters, filterNudgeShown });
+  flagsRef.current = { hasOpenedFilters, filterNudgeShown };
+
+  const clearTimer = useCallback(() => {
+    if (dismissTimerRef.current) {
+      clearTimeout(dismissTimerRef.current);
+      dismissTimerRef.current = null;
+    }
+  }, []);
+
+  const dismissNudge = useCallback(() => {
+    clearTimer();
+    setNudgeVisible(false);
+  }, [clearTimer]);
+
+  const registerSwipe = useCallback(
+    (type: 'like' | 'reject') => {
+      if (type === 'like') {
+        consecutiveRejectsRef.current = 0;
+        return;
+      }
+      consecutiveRejectsRef.current += 1;
+      const { hasOpenedFilters: opened, filterNudgeShown: shown } = flagsRef.current;
+      if (
+        consecutiveRejectsRef.current < FILTER_NUDGE_REJECT_THRESHOLD ||
+        firedThisSessionRef.current ||
+        opened === true ||
+        shown === true
+      ) {
+        return;
+      }
+      firedThisSessionRef.current = true;
+      setNudgeVisible(true);
+      trackEvent(Events.FILTER_NUDGE_SHOWN);
+      void markFilterNudgeShown();
+      dismissTimerRef.current = setTimeout(() => {
+        dismissTimerRef.current = null;
+        setNudgeVisible(false);
+      }, AUTO_DISMISS_MS);
+    },
+    [markFilterNudgeShown],
+  );
+
+  // Clear any pending timer if the hook unmounts.
+  useEffect(() => clearTimer, [clearTimer]);
+
+  return { nudgeVisible, registerSwipe, dismissNudge };
+}

--- a/hooks/use-filter-nudge.ts
+++ b/hooks/use-filter-nudge.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useMutation } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { trackEvent, Events } from '@/lib/analytics';
@@ -11,22 +11,26 @@ interface UseFilterNudgeArgs {
 }
 
 interface UseFilterNudge {
-  nudgeVisible: boolean;
+  // Drop-down banner over the card stack. Shown on the trigger swipe, removed
+  // on the next swipe.
+  bannerVisible: boolean;
+  // Filters-pill pulse. Shown on the trigger swipe, persists until the user
+  // presses Filters (onFilterPressed).
+  pulseActive: boolean;
   registerSwipe: (type: 'like' | 'reject') => void;
-  dismissNudge: () => void;
+  onFilterPressed: () => void;
 }
-
-// How long the tooltip lingers before auto-dismissing.
-const AUTO_DISMISS_MS = 6000;
 
 /**
  * One-time "Adjust your filters" nudge. Counts consecutive rejects (a like
- * resets the count) and reveals the tooltip when the user has hit the threshold
- * without ever opening Filters and without having seen the nudge before.
+ * resets the count) and, once the user hits the threshold without ever opening
+ * Filters and without having seen the nudge, drops in a banner and starts the
+ * Filters-pill pulse.
  *
- * Two guarantees combine: `firedThisSessionRef` blocks a second reveal within
- * the session (synchronous, no round-trip), and `markFilterNudgeShown` persists
- * the flag on the user row so it never reappears on any device. Eligibility
+ * The two cues dismiss differently: the banner clears on the very next swipe,
+ * while the pulse keeps going until the user actually opens Filters. Both fire
+ * at most once per user — `firedThisSessionRef` blocks a repeat within the
+ * session and `markFilterNudgeShown` persists it across devices. Eligibility
  * flags are read via a ref so `registerSwipe` keeps a stable identity and never
  * forces the swipe stack to re-render mid-session.
  */
@@ -43,33 +47,44 @@ export function useFilterNudge({
     },
   );
 
-  const [nudgeVisible, setNudgeVisible] = useState(false);
+  const [bannerVisible, setBannerVisible] = useState(false);
+  const [pulseActive, setPulseActive] = useState(false);
+
   const consecutiveRejectsRef = useRef(0);
   const firedThisSessionRef = useRef(false);
-  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Synchronous mirror of bannerVisible so registerSwipe can tell whether the
+  // banner is already showing (and should be dismissed) without depending on
+  // the async state value.
+  const bannerVisibleRef = useRef(false);
 
   // Latest eligibility flags, read inside the stable registerSwipe callback.
   const flagsRef = useRef({ hasOpenedFilters, filterNudgeShown });
   flagsRef.current = { hasOpenedFilters, filterNudgeShown };
 
-  const clearTimer = useCallback(() => {
-    if (dismissTimerRef.current) {
-      clearTimeout(dismissTimerRef.current);
-      dismissTimerRef.current = null;
-    }
+  const setBanner = useCallback((value: boolean) => {
+    bannerVisibleRef.current = value;
+    setBannerVisible(value);
   }, []);
 
-  const dismissNudge = useCallback(() => {
-    clearTimer();
-    setNudgeVisible(false);
-  }, [clearTimer]);
+  const onFilterPressed = useCallback(() => {
+    setPulseActive(false);
+    setBanner(false);
+  }, [setBanner]);
 
   const registerSwipe = useCallback(
     (type: 'like' | 'reject') => {
+      // Any swipe AFTER the banner appeared dismisses it (it was shown on a
+      // prior swipe). The trigger swipe below won't hit this because the banner
+      // isn't visible yet at this point.
+      if (bannerVisibleRef.current) {
+        setBanner(false);
+      }
+
       if (type === 'like') {
         consecutiveRejectsRef.current = 0;
         return;
       }
+
       consecutiveRejectsRef.current += 1;
       const { hasOpenedFilters: opened, filterNudgeShown: shown } = flagsRef.current;
       if (
@@ -80,20 +95,15 @@ export function useFilterNudge({
       ) {
         return;
       }
+
       firedThisSessionRef.current = true;
-      setNudgeVisible(true);
+      setBanner(true);
+      setPulseActive(true);
       trackEvent(Events.FILTER_NUDGE_SHOWN);
       void markFilterNudgeShown();
-      dismissTimerRef.current = setTimeout(() => {
-        dismissTimerRef.current = null;
-        setNudgeVisible(false);
-      }, AUTO_DISMISS_MS);
     },
-    [markFilterNudgeShown],
+    [markFilterNudgeShown, setBanner],
   );
 
-  // Clear any pending timer if the hook unmounts.
-  useEffect(() => clearTimer, [clearTimer]);
-
-  return { nudgeVisible, registerSwipe, dismissNudge };
+  return { bannerVisible, pulseActive, registerSwipe, onFilterPressed };
 }

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -75,6 +75,10 @@ export const Events = {
   NOTIFICATIONS_TOGGLED: 'notifications_toggled',
   FILTERS_CHANGED: 'filters_changed',
 
+  // Filter discovery nudge
+  FILTER_NUDGE_SHOWN: 'filter_nudge_shown',
+  FILTER_NUDGE_TAPPED: 'filter_nudge_tapped',
+
   // Paywall & purchases
   PAYWALL_SHOWN: 'paywall_shown',
   PURCHASE_ATTEMPTED: 'purchase_attempted',


### PR DESCRIPTION
## Summary
- Helps first-time users discover **Filters**: after **5 consecutive rejects** with no like — and only if they've never opened Filters — a drop-down banner (same family as the match toast) appears and the Filters pill pulses.
- The **banner** clears on the next swipe; the **pulse** persists until the user opens Filters. Fires **once per user, ever** via two flags on the Convex `users` row (`hasOpenedFilters`, `filterNudgeShown`), so it survives reinstalls/second devices like onboarding does.
- Opening Filters for the first time also shows a one-line **explainer banner** on the Filters screen.
- Respects **Reduce Motion** (no pulse, banner still shown + announced via a live region). No emojis; copy and styling matched to existing app conventions (`MatchToast`, `counterCard`).

## Implementation notes
- `convex/schema.ts` + `convex/users.ts`: two optional booleans + idempotent `markFiltersOpened` / `markFilterNudgeShown` mutations (additive; existing rows stay valid).
- `hooks/use-filter-nudge.ts`: consecutive-reject counter (a like resets it), eligibility gating, `bannerVisible` + `pulseActive` with separate dismissal. Within-session guard via a ref; cross-device guard via the persisted flag (optimistic update).
- `components/swipe/filter-nudge-banner.tsx`: new drop-down banner mirroring `MatchToast`.
- `swipe-card-stack.tsx` emits `onSwipeResult`; `explore-header.tsx` pulses the pill; `explore/index.tsx` wires it together; `explore/filters.tsx` adds the first-visit banner.

## Test plan
- [ ] Reject 5 in a row (no like) on an eligible account → banner drops in + Filters pill pulses
- [ ] A like before the 5th reject resets the streak (no nudge)
- [ ] Banner clears on the next swipe; pulse keeps going until Filters is tapped
- [ ] Tap Filters (or the banner) → navigates; first-visit banner shows on the Filters screen; dismiss (X) works
- [ ] Return and reject 5 more → nudge does NOT reappear (once-per-user)
- [ ] Reduce Motion on → no pulse, banner still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)