### PR TITLE
copy: plain-language matching explanation + partner-app requirement

### DIFF
--- a/app/(tabs)/matches.tsx
+++ b/app/(tabs)/matches.tsx
@@ -315,8 +315,8 @@ export default function Matches() {
             </Text>
             <Text style={styles.emptyDescription}>
               {isFreeUser
-                ? 'Upgrade to connect with your partner and discover the baby names you both love.'
-                : 'Share your partner code and start discovering the names you both love. Matches appear when you both swipe right!'}
+                ? 'You and your partner each swipe on names, and the ones you both like become matches. You’ll each need the app, and one Premium plan covers you both.'
+                : 'Your partner needs to download Bambino too, then enter your code to link up. Once you’re connected, any name you both like shows up here.'}
             </Text>
             <MatchAnimation key={focusCount} />
             {isFreeUser && (
@@ -407,7 +407,7 @@ export default function Matches() {
             <Text style={styles.emptyDescription}>
               {isSearching
                 ? `No names match "${submittedSearch}"`
-                : "When you and your partner both love the same name — it's a match! Keep swiping to find your favourites."}
+                : 'A match is any name you and your partner both swipe right on. Keep swiping — they’ll show up here.'}
             </Text>
             {!isSearching && (
               <Pressable

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -75,7 +75,7 @@ function PremiumBanner({
           </View>
           <View style={styles.premiumTextWrap}>
             <Text style={styles.premiumTitle}>Go Premium</Text>
-            <Text style={styles.premiumDesc}>Unlimited likes & partner linking</Text>
+            <Text style={styles.premiumDesc}>Unlimited likes + partner matching</Text>
           </View>
           <LinearGradient
             colors={gradients.buttonPrimary as [string, string]}
@@ -219,7 +219,7 @@ export default function Profile() {
     if (partnerInfo?.shareCode) {
       try {
         await Share.share({
-          message: `Join me on Bambino! Use my partner code: ${partnerInfo.shareCode}`,
+          message: `I'm using Bambino to pick a baby name — join me! Download the app, then enter my code to link up: ${partnerInfo.shareCode}`,
         });
         trackEvent(Events.PARTNER_CODE_SHARED);
       } catch (error) {
@@ -532,7 +532,7 @@ export default function Profile() {
               <View style={styles.noPartner}>
                 {partnerInfo?.shareCode && (
                   <>
-                    <Text style={styles.shareCodeLabel}>Your Share Code</Text>
+                    <Text style={styles.shareCodeLabel}>Your Partner Code</Text>
                     <View style={styles.shareCodeWrap}>
                       <Text style={[styles.shareCode, { color: colors.primary }]}>
                         {partnerInfo.shareCode}
@@ -578,6 +578,10 @@ export default function Profile() {
                         )}
                       </Pressable>
                     </View>
+                    <Text style={styles.shareCodeHint}>
+                      Send this to your partner. They&apos;ll need Bambino installed, then they
+                      enter it under &quot;Link Partner&quot;.
+                    </Text>
                   </>
                 )}
                 <View style={styles.linkPartnerWrap}>
@@ -981,6 +985,15 @@ const styles = StyleSheet.create({
     color: '#6B5B7B',
     textTransform: 'uppercase',
     letterSpacing: 1,
+  },
+  shareCodeHint: {
+    fontFamily: Fonts?.sans,
+    fontSize: 13,
+    lineHeight: 18,
+    color: '#6B5B7B',
+    textAlign: 'center',
+    marginTop: 12,
+    paddingHorizontal: 8,
   },
   shareCode: {
     fontSize: 32,

--- a/components/onboarding/multiplayer-intro.tsx
+++ b/components/onboarding/multiplayer-intro.tsx
@@ -115,7 +115,7 @@ export function MultiplayerIntro({ isActive }: { isActive: boolean }) {
     <View style={styles.container}>
       {/* Title */}
       <Animated.Text entering={FadeIn.delay(200).duration(400)} style={styles.title}>
-        Join Your Partner
+        Matching takes two
       </Animated.Text>
 
       {/* PRO pill */}
@@ -176,8 +176,10 @@ export function MultiplayerIntro({ isActive }: { isActive: boolean }) {
             <Text style={[styles.stepNumText, { color: colors.tabActive }]}>1</Text>
           </View>
           <View style={styles.stepContent}>
-            <Text style={styles.stepTitle}>Swipe at your own pace</Text>
-            <Text style={styles.stepDesc}>Each of you browses names and likes your favorites</Text>
+            <Text style={styles.stepTitle}>You&apos;ll both need the app</Text>
+            <Text style={styles.stepDesc}>
+              Your partner downloads Bambino too, then links to you with a code.
+            </Text>
           </View>
         </View>
 
@@ -188,10 +190,8 @@ export function MultiplayerIntro({ isActive }: { isActive: boolean }) {
             <Text style={[styles.stepNumText, { color: colors.tabActive }]}>2</Text>
           </View>
           <View style={styles.stepContent}>
-            <Text style={styles.stepTitle}>Find common ground</Text>
-            <Text style={styles.stepDesc}>
-              Love the same name? It&apos;s added to your shared list
-            </Text>
+            <Text style={styles.stepTitle}>You each swipe</Text>
+            <Text style={styles.stepDesc}>On your own phones, in your own time.</Text>
           </View>
         </View>
 
@@ -202,10 +202,8 @@ export function MultiplayerIntro({ isActive }: { isActive: boolean }) {
             <Text style={[styles.stepNumText, { color: colors.tabActive }]}>3</Text>
           </View>
           <View style={styles.stepContent}>
-            <Text style={styles.stepTitle}>Pick the one</Text>
-            <Text style={styles.stepDesc}>
-              Review your matches together and choose your favorite
-            </Text>
+            <Text style={styles.stepTitle}>You both like a name? Match!</Text>
+            <Text style={styles.stepDesc}>Names you both swipe right on land in Matches.</Text>
           </View>
         </View>
       </Animated.View>

--- a/components/paywall.tsx
+++ b/components/paywall.tsx
@@ -17,14 +17,14 @@ interface PaywallProps {
 
 const TRIGGER_MESSAGES: Record<NonNullable<PaywallProps['trigger']>, string> = {
   swipe_limit: "You've used all 25 free swipes",
-  partner_limit: 'Connect with your partner',
+  partner_limit: 'Connect your partner — one plan covers you both',
   dashboard_limit: 'See all your liked names',
 };
 
 const COMPARISON_ROWS = [
   { label: 'Swipes', free: '25', premium: 'Unlimited' },
   { label: 'Liked names', free: '25', premium: 'Unlimited' },
-  { label: 'Partner', free: '\u2014', premium: 'Yes' },
+  { label: 'Partner matching', free: '\u2014', premium: 'Yes' },
 ];
 
 export function Paywall({ visible, onClose, trigger = 'swipe_limit' }: PaywallProps) {


### PR DESCRIPTION
## Summary
- Rewrites the partner/matching explanation in plain, functional language (two-people-first framing), replacing marketing-y copy ("Find common ground", "Pick the one", "discover the names you both love").
- Makes two previously-hidden facts explicit: your **partner must download Bambino too**, and **one Premium plan covers both** of you.
- Onboarding slide 3 retuned to **Link → Swipe → Match**; Matches empty states, the profile invite moment (new install caption + clearer share message), and the paywall all aligned on "matching" (the value) over "linking" (the mechanic).

Four surfaces, copy-only except one new caption line in the profile share-code section. Lint green on every commit. Design spec + plan in `docs/superpowers/` (gitignored).

## Test plan
- [ ] Onboarding slide 3: title "Matching takes two"; three steps Link → Swipe → Match; no clipping
- [ ] Matches empty states (free / premium-no-partner / linked-no-matches) read correctly; the longer two-sentence descriptions don't clip on a narrow device (iPhone SE) or with large Dynamic Type
- [ ] Profile: label reads "Your Partner Code"; the new install caption wraps cleanly below the Copy/Share/New buttons
- [ ] Share sheet message includes "Download the app, then enter my code…"
- [ ] Paywall: header "Connect your partner — one plan covers you both"; feature row "Partner matching"
- [ ] Decide caption color: keeps `#6B5B7B` (matches existing premiumDesc) vs lighter `textMuted`
- [x] npm run lint passes (verified per-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)