### PR TITLE
fix: rename onboarding "PRO" pill to "Premium"

### DIFF
--- a/components/onboarding/multiplayer-intro.tsx
+++ b/components/onboarding/multiplayer-intro.tsx
@@ -118,7 +118,7 @@ export function MultiplayerIntro({ isActive }: { isActive: boolean }) {
         Matching takes two
       </Animated.Text>
 
-      {/* PRO pill */}
+      {/* Premium pill */}
       <Animated.View entering={FadeIn.delay(300).duration(400)} style={styles.proPillWrap}>
         <LinearGradient
           colors={[colors.primaryLight, colors.secondaryLight]}
@@ -126,7 +126,7 @@ export function MultiplayerIntro({ isActive }: { isActive: boolean }) {
           start={{ x: 0, y: 0 }}
           end={{ x: 1, y: 1 }}
         >
-          <Text style={[styles.proPillText, { color: colors.tabActive }]}>{'\u2B50'} PRO</Text>
+          <Text style={[styles.proPillText, { color: colors.tabActive }]}>Premium</Text>
         </LinearGradient>
       </Animated.View>
 


### PR DESCRIPTION
## Summary
- The onboarding multiplayer slide was the only place the paid tier was called "PRO"; every other touchpoint (paywall, profile, matches) already says "Premium".
- Renames the pill to "Premium" and drops the ⭐ emoji per the no-emoji-in-badges convention.

## Test plan
- [ ] Onboarding slide 3: the gating pill reads "Premium" (no star)

🤖 Generated with [Claude Code](https://claude.com/claude-code)