### PR TITLE
fix: swipe hint — park above tiles + stop it cancelling its own fade-in

### DIFF
--- a/components/swipe/swipe-card.tsx
+++ b/components/swipe/swipe-card.tsx
@@ -705,9 +705,14 @@ const styles = StyleSheet.create({
     fontFamily: Fonts?.sans,
   },
   swipeHint: {
+    // Fill the leftover space but bottom-align the hint so it parks just
+    // above the rank/trend tiles, with the free space pooling above it
+    // (rather than centering the hint in the middle of the gap). marginBottom
+    // keeps a small, consistent gap above the tiles on every card.
     flex: 1,
-    justifyContent: 'center',
+    justifyContent: 'flex-end',
     alignItems: 'center',
+    marginBottom: 12,
   },
   popularityRow: {
     flexDirection: 'row',

--- a/components/swipe/swipe-card.tsx
+++ b/components/swipe/swipe-card.tsx
@@ -322,14 +322,28 @@ export function SwipeCard({
       onSwipeHintShown?.();
     }, 10000);
 
+    // Cleanup only clears the pending timer. It must NOT cancel the hint
+    // animations here: firing the hint calls onSwipeHintShown(), which flips
+    // the parent's `showSwipeHint` to false (the once-only guard) and re-runs
+    // this effect — cancelling in cleanup would kill the fade-in the instant
+    // it starts, leaving the hint invisible. Animation teardown is owned by
+    // the detail-open reset effect above and the unmount effect below.
     return () => {
       if (hintTimerRef.current) clearTimeout(hintTimerRef.current);
-      if (!hintActivatedRef.current) return;
-      cancelAnimation(hintOpacity);
-      cancelAnimation(hintTranslateX);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isTop, showSwipeHint, detailOpen]);
+
+  // Cancel the hint animations on unmount so the infinite wiggle doesn't
+  // outlive the card (e.g. once a swipe removes it from the stack).
+  useEffect(
+    () => () => {
+      cancelAnimation(hintOpacity);
+      cancelAnimation(hintTranslateX);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
 
   // Hide hint as soon as user starts swiping
   const hintContainerStyle = useAnimatedStyle(() => {


### PR DESCRIPTION
## Summary
- Parks the idle "swipe" hint just above the rank/trend tiles (bottom-aligned) instead of centering it in the gap, so a long description can't crush it.
- Fixes a render-timing race: showing the hint immediately flipped the parent's `showSwipeHint` off (the once-only guard), which re-ran the hint effect whose cleanup cancelled the just-started fade-in — leaving the hint invisible (or frozen faint). Animation teardown now happens only on unmount, so showing the hint no longer kills it.

## Test plan
- [ ] Idle ~10–12s on a fresh top card (Reduce Motion off): "‹ swipe ›" fades in and wiggles reliably, parked just above the tiles
- [ ] It persists until you swipe; does not reappear on later cards in the same session
- [x] npm run lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)