### PR TITLE
fix: keyboard handling on the Profile feedback form

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -346,6 +346,8 @@ export default function Profile() {
       <ScrollView
         ref={scrollRef}
         style={styles.scrollView}
+        keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="on-drag"
         contentContainerStyle={{
           paddingTop: insets.top + 16,
           paddingBottom: 120,

--- a/components/settings/feedback-section.tsx
+++ b/components/settings/feedback-section.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { View, Text, Pressable, TextInput, StyleSheet } from 'react-native';
+import { View, Text, Pressable, TextInput, StyleSheet, Keyboard } from 'react-native';
 import { useFocusEffect } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useAction } from 'convex/react';
@@ -43,6 +43,7 @@ export function FeedbackSection() {
 
   const handleSubmit = useCallback(async () => {
     if (!category || !message.trim()) return;
+    Keyboard.dismiss();
     setIsSubmitting(true);
     setErrorMessage(null);
     try {


### PR DESCRIPTION
## Summary
- Profile's ScrollView had no keyboard props (defaulted to `keyboardShouldPersistTaps="never"`), so the feedback form's "Submit Feedback" needed two taps when the keyboard was up — the first tap was consumed dismissing the keyboard — and the multiline input left no way to dismiss the keyboard.
- Adds `keyboardShouldPersistTaps="handled"` + `keyboardDismissMode="on-drag"` (the pattern already used in matches/dashboard): Submit registers on the first tap, tapping empty space dismisses, and dragging the screen dismisses.
- Dismisses the keyboard immediately on submit.

## Test plan
- [ ] Profile → Share Feedback → pick a category, type a message
- [ ] Tap "Submit Feedback" once with the keyboard up → it submits (no double-tap)
- [ ] Tap empty space or drag the screen → keyboard dismisses
- [x] npm run lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)