### PR TITLE
fix: drop hardcoded $4.99 paywall price fallback

### DIFF
--- a/components/paywall.tsx
+++ b/components/paywall.tsx
@@ -35,7 +35,10 @@ export function Paywall({ visible, onClose, trigger = 'swipe_limit' }: PaywallPr
   const [showCelebration, setShowCelebration] = useState(false);
 
   const hasPackages = packages.length > 0;
-  const price = packages[0]?.product.priceString ?? '$4.99';
+  // No hardcoded fallback: priceString is region-localized (e.g. CA$6.99),
+  // so a hardcoded "$4.99" would show a wrong US-dollar figure to non-US
+  // users until offerings load. Show no price until the real one resolves.
+  const price = packages[0]?.product.priceString;
 
   useEffect(() => {
     if (visible) trackEvent(Events.PAYWALL_SHOWN, { trigger });
@@ -138,7 +141,7 @@ export function Paywall({ visible, onClose, trigger = 'swipe_limit' }: PaywallPr
             </View>
           ) : (
             <GradientButton
-              title={`Unlock Premium - ${price}`}
+              title={price ? `Unlock Premium - ${price}` : 'Unlock Premium'}
               onPress={handlePurchase}
               loading={isPurchasing}
               disabled={isPurchasing || isLoading}


### PR DESCRIPTION
## Summary
- The paywall button used `packages[0]?.product.priceString ?? '$4.99'`. When RevenueCat's localized price hadn't loaded, it showed a hardcoded **USD** "$4.99" — so a Canadian tester saw "$4.99" on the button while the Apple sheet correctly showed the localized **CA$6.99** (same Apple price tier, different currency). Showing a US-dollar placeholder undershoots the real price for non-US users — a trust/review risk.
- Removes the fallback. The button shows "Unlock Premium" (no figure) until RevenueCat's localized `priceString` resolves, then shows the real localized price. The existing "Unable to load pricing" error state still handles genuine load failures.

## Test plan
- [ ] Paywall (non-US region, e.g. CA): button never shows a US-dollar placeholder; once offerings load it shows the localized price matching the Apple sheet
- [ ] Paywall (US): shows "$4.99" once loaded
- [ ] Offerings fail → "Unable to load pricing" error state
- [x] npm run lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)