### PR TITLE
chore: remove per-origin name counts from filter rows

### DIFF
--- a/components/search/origin-toggle-list.tsx
+++ b/components/search/origin-toggle-list.tsx
@@ -113,7 +113,6 @@ export function OriginToggleList({ value, onChange, genderFilter }: OriginToggle
             <OriginToggleRow
               key={origin}
               origin={origin}
-              count={originCounts[origin] ?? 0}
               isActive={isOriginActive(origin)}
               onToggle={() => handleToggleOrigin(origin)}
             />

--- a/components/search/origin-toggle-row.tsx
+++ b/components/search/origin-toggle-row.tsx
@@ -5,12 +5,11 @@ import { useTheme } from '@/contexts/theme-context';
 
 interface OriginToggleRowProps {
   origin: string;
-  count: number;
   isActive: boolean;
   onToggle: () => void;
 }
 
-export function OriginToggleRow({ origin, count, isActive, onToggle }: OriginToggleRowProps) {
+export function OriginToggleRow({ origin, isActive, onToggle }: OriginToggleRowProps) {
   const { colors } = useTheme();
 
   return (
@@ -18,15 +17,12 @@ export function OriginToggleRow({ origin, count, isActive, onToggle }: OriginTog
       onPress={onToggle}
       accessibilityRole="switch"
       accessibilityState={{ checked: isActive }}
-      accessibilityLabel={`${origin}, ${count.toLocaleString()} ${count === 1 ? 'name' : 'names'}`}
+      accessibilityLabel={origin}
       style={[styles.row, { shadowColor: colors.secondary }]}
     >
       <View style={styles.textContainer}>
         <Text style={[styles.name, isActive && styles.nameActive]}>
           {getOriginFlag(origin)} {origin}
-        </Text>
-        <Text style={styles.count}>
-          {count.toLocaleString()} {count === 1 ? 'name' : 'names'}
         </Text>
       </View>
       {/* Visual indicator only. The row Pressable owns the tap; without this the
@@ -70,11 +66,5 @@ const styles = StyleSheet.create({
   },
   nameActive: {
     fontWeight: '700',
-  },
-  count: {
-    fontSize: 10,
-    fontFamily: Fonts?.sans,
-    color: '#A89BB5',
-    marginTop: 2,
   },
 });


### PR DESCRIPTION
## Summary
- The Origin filter rows showed a "N names" count under each origin; the parallel Category filter rows don't, so the two lists looked inconsistent.
- Removes the count display from `OriginToggleRow` (plus the now-unused `count` prop, accessibility-label count, and `count` style), matching `CategoryToggleRow`.
- `getOriginCounts` is kept — it still derives the set of available origins; only the per-row number is dropped.

## Test plan
- [ ] Filters → Origin: each origin shows just flag + name + toggle, no "N names" line — matching the Category rows
- [x] npm run lint + tsc pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)