### PR TITLE
fix: make proposal Decline button a white secondary button

### DIFF
--- a/components/matches/proposal-banner.tsx
+++ b/components/matches/proposal-banner.tsx
@@ -78,8 +78,11 @@ export function ProposalBanner({
         >
           <Text style={styles.acceptButtonText}>Accept</Text>
         </Pressable>
-        <Pressable style={styles.declineButton} onPress={onDecline}>
-          <Text style={[styles.declineButtonText, { color: '#A89BB5' }]}>Decline</Text>
+        <Pressable
+          style={[styles.declineButton, { borderColor: colors.border }]}
+          onPress={onDecline}
+        >
+          <Text style={[styles.declineButtonText, { color: '#6B5B7B' }]}>Decline</Text>
         </Pressable>
       </View>
     </View>
@@ -142,10 +145,13 @@ const styles = StyleSheet.create({
     color: '#fff',
   },
   declineButton: {
+    flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
     paddingVertical: 12,
-    paddingHorizontal: 20,
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    borderWidth: 1.5,
   },
   declineButtonText: {
     fontSize: 15,


### PR DESCRIPTION
## Summary
- The proposal Decline button was a bare `Pressable` with muted `#A89BB5` text and no fill/border, so it looked disabled.
- Restyled to a balanced white outlined secondary button: `flex: 1` (equal width to Accept), white background, 1.5px themed border, and readable `#6B5B7B` text.

## Test plan
- [ ] Matches → incoming proposal: Decline reads as a tappable white/outlined button next to the filled Accept, not greyed-out
- [x] npm run lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)