### PR TITLE
fix: dismissable keyboard across all input surfaces

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -2,7 +2,7 @@ import { useSignIn, useSignInWithApple, useSSO } from '@clerk/clerk-expo';
 import { useRouter } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
 import { useCallback, useState } from 'react';
-import { Pressable, Text, View } from 'react-native';
+import { Keyboard, Pressable, Text, View } from 'react-native';
 import Animated, { FadeInDown, FadeInUp } from 'react-native-reanimated';
 
 import { GradientBackground } from '@/components/ui/gradient-background';
@@ -187,7 +187,11 @@ export default function SignIn() {
 
   return (
     <GradientBackground variant="auth">
-      <View className="flex-1 justify-center px-8">
+      <Pressable
+        className="flex-1 justify-center px-8"
+        onPress={() => Keyboard.dismiss()}
+        accessible={false}
+      >
         <Animated.Text
           entering={FadeInDown.duration(500).springify()}
           className="mb-2 text-center text-4xl"
@@ -375,7 +379,7 @@ export default function SignIn() {
             </Animated.View>
           </>
         )}
-      </View>
+      </Pressable>
     </GradientBackground>
   );
 }

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -2,7 +2,7 @@ import { useSignInWithApple, useSignUp, useSSO } from '@clerk/clerk-expo';
 import { useRouter } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
 import { useCallback, useState } from 'react';
-import { Pressable, Text, View } from 'react-native';
+import { Keyboard, Pressable, Text, View } from 'react-native';
 import Animated, { FadeInDown, FadeInUp } from 'react-native-reanimated';
 
 import { GradientBackground } from '@/components/ui/gradient-background';
@@ -140,7 +140,11 @@ export default function SignUp() {
   if (pendingVerification) {
     return (
       <GradientBackground variant="auth">
-        <View className="flex-1 justify-center px-8">
+        <Pressable
+          className="flex-1 justify-center px-8"
+          onPress={() => Keyboard.dismiss()}
+          accessible={false}
+        >
           <Animated.Text
             entering={FadeInDown.duration(500).springify()}
             className="mb-2 text-center text-4xl"
@@ -204,14 +208,18 @@ export default function SignUp() {
               </Text>
             </Pressable>
           </Animated.View>
-        </View>
+        </Pressable>
       </GradientBackground>
     );
   }
 
   return (
     <GradientBackground variant="auth">
-      <View className="flex-1 justify-center px-8">
+      <Pressable
+        className="flex-1 justify-center px-8"
+        onPress={() => Keyboard.dismiss()}
+        accessible={false}
+      >
         <Animated.Text
           entering={FadeInDown.duration(500).springify()}
           className="mb-2 text-center text-4xl"
@@ -328,7 +336,7 @@ export default function SignUp() {
             Privacy Policy
           </Text>
         </Text>
-      </View>
+      </Pressable>
     </GradientBackground>
   );
 }

--- a/components/ui/animated-bottom-sheet.tsx
+++ b/components/ui/animated-bottom-sheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import {
   Pressable,
   StyleSheet,
@@ -39,6 +39,20 @@ export function AnimatedBottomSheet({
 }: AnimatedBottomSheetProps) {
   const backdropOpacity = useSharedValue(0);
   const sheetTranslateY = useSharedValue(SCREEN_HEIGHT);
+  // Track keyboard visibility so a tap outside the sheet collapses the keyboard
+  // first (keeping the sheet open and any typed text), instead of closing the
+  // sheet. Without this, with a multiline input up there's no way to dismiss
+  // the keyboard to reach the action buttons it overlaps.
+  const [keyboardVisible, setKeyboardVisible] = useState(false);
+
+  useEffect(() => {
+    const showSub = Keyboard.addListener('keyboardDidShow', () => setKeyboardVisible(true));
+    const hideSub = Keyboard.addListener('keyboardDidHide', () => setKeyboardVisible(false));
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, []);
 
   useEffect(() => {
     if (visible) {
@@ -74,6 +88,16 @@ export function AnimatedBottomSheet({
     );
   };
 
+  // A tap outside the sheet collapses the keyboard if it's up (keeping the
+  // sheet open); only when the keyboard is already down does it close the sheet.
+  const handleBackdropPress = () => {
+    if (keyboardVisible) {
+      Keyboard.dismiss();
+    } else {
+      animateOut();
+    }
+  };
+
   const backdropStyle = useAnimatedStyle(() => ({
     opacity: backdropOpacity.value,
   }));
@@ -101,7 +125,7 @@ export function AnimatedBottomSheet({
 
         <Pressable
           style={{ flex: 1 }}
-          onPress={animateOut}
+          onPress={handleBackdropPress}
           accessibilityLabel="Close"
           accessibilityRole="button"
         />


### PR DESCRIPTION
## Summary
Every input surface can now dismiss the keyboard and reach the buttons it would otherwise overlap.

- **Bottom sheets** (propose, decline, partner-link, name-confirmation, report-message, match-detail) share `AnimatedBottomSheet`. Its `KeyboardAvoidingView` mismeasures inside a Modal on iOS, so a multiline input could cover the action buttons with no way to collapse the keyboard. Now a tap outside the sheet **collapses the keyboard** (keeping the sheet + typed text), and only closes the sheet once the keyboard is down. One change covers all six sheets.
- **Auth** (sign-in, sign-up) was a plain centered `View` with no dismiss path; each form is now wrapped so tapping empty space dismisses the keyboard.
- ScrollView screens (matches, dashboard, profile) already had `keyboardShouldPersistTaps` + `keyboardDismissMode`.

## Test plan
- [ ] Propose/decline sheet: type a note, tap outside → keyboard collapses, sheet + text stay, Propose/Decline reachable; tap outside again → sheet closes
- [ ] Partner-link / name-confirmation / report-message sheets: same
- [ ] Sign-in / sign-up: type in a field, tap empty space → keyboard dismisses, buttons reachable
- [x] npm run lint + tsc pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)