### PR TITLE
fix: stop the top match card "Proposed" badge being clipped

### DIFF
--- a/app/(tabs)/matches.tsx
+++ b/app/(tabs)/matches.tsx
@@ -621,6 +621,10 @@ const styles = StyleSheet.create({
     fontWeight: '700',
   },
   listContent: {
+    // Top padding so the first card's overhanging "Proposed"/"Chosen" badge
+    // (position absolute, top: -8) isn't clipped by the list's top edge —
+    // mirrors the inter-card gap every other card already has above it.
+    paddingTop: 12,
     paddingBottom: 100,
   },
   ctaContainer: {


### PR DESCRIPTION
## Summary
- The "Proposed"/"Chosen" badge on a match card is absolutely positioned at `top: -8`, overhanging the card's top edge. Every card except the first has the inter-card gap above it for the badge to sit in; the **first** card had no top padding, so its badge was clipped by the list's top edge.
- Adds `paddingTop: 12` to the matches list `contentContainerStyle` — the same room every other card already gets.

## Test plan
- [ ] Matches list with the top item proposed: the "Proposed" badge renders fully, not clipped
- [ ] Same for a chosen top item ("Chosen" badge)
- [x] npm run lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)