### PR TITLE
feat: notify + surface declined proposals to the proposer

### DIFF
--- a/app/(tabs)/matches.tsx
+++ b/app/(tabs)/matches.tsx
@@ -17,6 +17,7 @@ import {
   MatchCard,
   MatchesHeader,
   ProposalBanner,
+  DeclinedBanner,
   ProposeSheet,
   ProposalConflictSheet,
   DeclineSheet,
@@ -99,6 +100,7 @@ export default function Matches() {
   const chosenName = useQuery(api.matches.getChosenName);
   const currentUser = useQuery(api.users.getCurrentUser);
   const pendingProposal = useQuery(api.matches.getPendingProposal);
+  const declinedProposal = useQuery(api.matches.getDeclinedProposal);
 
   // Close the report sheet if the proposal it targets disappears (partner
   // withdrew/accepted, or unlinked) so it can't act on a stale match. (#185)
@@ -129,6 +131,7 @@ export default function Matches() {
   const proposeNameMutation = useMutation(api.matches.proposeName);
   const respondToProposalMutation = useMutation(api.matches.respondToProposal);
   const withdrawProposalMutation = useMutation(api.matches.withdrawProposal);
+  const dismissDeclinedProposalMutation = useMutation(api.matches.dismissDeclinedProposal);
 
   // Task 13: Trigger celebration for proposer when partner accepts
   useEffect(() => {
@@ -216,6 +219,15 @@ export default function Matches() {
     },
     [pendingProposal, respondToProposalMutation],
   );
+
+  const handleDismissDeclined = useCallback(async () => {
+    if (!declinedProposal) return;
+    try {
+      await dismissDeclinedProposalMutation({ matchId: declinedProposal._id });
+    } catch (error) {
+      alertMatchMutationError(error, 'Could not dismiss this.');
+    }
+  }, [declinedProposal, dismissDeclinedProposalMutation]);
 
   const handleWithdrawProposal = useCallback(
     async (matchId: Id<'matches'>, nameName: string) => {
@@ -480,6 +492,16 @@ export default function Matches() {
               handleWithdrawProposal(pendingProposal._id, pendingProposal.name?.name ?? '')
             }
             onReport={() => setReportMatchId(pendingProposal._id)}
+          />
+        )}
+
+        {/* Declined proposal banner — shown to the proposer */}
+        {declinedProposal && declinedProposal.name && (
+          <DeclinedBanner
+            declinerName={declinedProposal.declinerName}
+            nameName={declinedProposal.name.name}
+            message={declinedProposal.declineMessage}
+            onDismiss={handleDismissDeclined}
           />
         )}
 

--- a/components/matches/declined-banner.tsx
+++ b/components/matches/declined-banner.tsx
@@ -1,0 +1,90 @@
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { Fonts } from '@/constants/theme';
+import { useTheme } from '@/contexts/theme-context';
+
+interface DeclinedBannerProps {
+  declinerName: string;
+  nameName: string;
+  message?: string;
+  onDismiss: () => void;
+}
+
+/**
+ * Shown to the PROPOSER when their partner declines a proposed name. Neutral
+ * (not alarming) styling, with the partner's optional note and an X to
+ * dismiss — dismissing clears the proposal so the name can be proposed again.
+ */
+export function DeclinedBanner({
+  declinerName,
+  nameName,
+  message,
+  onDismiss,
+}: DeclinedBannerProps) {
+  const { colors } = useTheme();
+
+  return (
+    <View
+      style={[styles.banner, { backgroundColor: colors.surfaceSubtle, borderColor: colors.border }]}
+    >
+      <View style={styles.content}>
+        <Ionicons name="close-circle-outline" size={20} color="#6B5B7B" />
+        <View style={styles.textContainer}>
+          <Text style={styles.text}>
+            {declinerName} declined <Text style={styles.nameText}>{nameName}</Text>
+          </Text>
+          {message ? <Text style={styles.message}>&ldquo;{message}&rdquo;</Text> : null}
+        </View>
+        <Pressable
+          style={styles.dismiss}
+          onPress={onDismiss}
+          hitSlop={10}
+          accessibilityRole="button"
+          accessibilityLabel="Dismiss"
+        >
+          <Ionicons name="close" size={20} color="#6B5B7B" />
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    marginHorizontal: 16,
+    marginBottom: 12,
+    borderRadius: 16,
+    borderWidth: 1.5,
+    padding: 16,
+  },
+  content: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  textContainer: {
+    flex: 1,
+  },
+  text: {
+    fontSize: 15,
+    fontFamily: Fonts?.sans,
+    color: '#2D1B4E',
+    lineHeight: 22,
+  },
+  nameText: {
+    fontFamily: Fonts?.title || 'Gabarito_800ExtraBold',
+  },
+  message: {
+    fontSize: 13,
+    fontFamily: Fonts?.sans,
+    color: '#6B5B7B',
+    fontStyle: 'italic',
+    marginTop: 4,
+  },
+  dismiss: {
+    width: 44,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/components/matches/index.ts
+++ b/components/matches/index.ts
@@ -4,6 +4,7 @@ export { MatchDetailModal } from './match-detail-modal';
 export { MatchesHeader } from './matches-header';
 export { MatchToast } from './match-toast';
 export { ProposalBanner } from './proposal-banner';
+export { DeclinedBanner } from './declined-banner';
 export { ProposeSheet } from './propose-sheet';
 export { ProposalConflictSheet } from './proposal-conflict-sheet';
 export { DeclineSheet } from './decline-sheet';

--- a/convex/errors.ts
+++ b/convex/errors.ts
@@ -37,6 +37,7 @@ export type ConvexErrorCode =
   | 'CANNOT_RESPOND_OWN_PROPOSAL'
   | 'NOT_PROPOSER'
   | 'PROPOSAL_NOT_PENDING'
+  | 'PROPOSAL_NOT_DECLINED'
   // selections.ts
   | 'SELECTION_NOT_FOUND'
   | 'BULK_LIMIT_EXCEEDED'

--- a/convex/matches.ts
+++ b/convex/matches.ts
@@ -395,6 +395,21 @@ export const respondToProposal = mutation({
         declineMessage: args.message,
         updatedAt: now,
       });
+
+      // Notify the proposer their proposal was declined — the accept path
+      // already notifies; decline previously sent nothing, so the proposer
+      // got no signal at all.
+      if (match.proposedBy) {
+        const name = await ctx.db.get(match.nameId);
+        const responderName = user.name ?? 'Your partner';
+
+        await ctx.scheduler.runAfter(0, internal.notifications.sendPushNotification, {
+          userId: match.proposedBy,
+          title: `${responderName} declined your proposal`,
+          body: name ? `They passed on ${name.name}.` : 'They passed on your suggestion.',
+          data: { type: 'proposal_declined', matchId: args.matchId },
+        });
+      }
     }
 
     return { success: true };
@@ -481,6 +496,77 @@ export const getPendingProposal = query({
       proposerName: proposer?.name ?? 'Your partner',
       isCurrentUserProposer: pendingMatch.proposedBy === user._id,
     };
+  },
+});
+
+// The proposer's view of a proposal the partner declined. Surfaced as a
+// dismissable banner so the proposer actually learns the outcome (previously
+// the proposal just vanished from getPendingProposal with no trace).
+export const getDeclinedProposal = query({
+  args: {},
+  handler: async (ctx) => {
+    const user = await getCurrentUserOrNull(ctx);
+    if (!user) return null;
+
+    if (!user.partnerId) {
+      return null;
+    }
+
+    const matches = await getPartnershipMatches(ctx, user._id, user.partnerId);
+    // Only the proposer sees their own declined proposal — until they dismiss.
+    const declinedMatch = matches.find(
+      (m) => m.proposalStatus === 'declined' && m.proposedBy === user._id,
+    );
+
+    if (!declinedMatch) {
+      return null;
+    }
+
+    const name = await ctx.db.get(declinedMatch.nameId);
+    const decliner = await ctx.db.get(getOtherUserId(declinedMatch, user._id));
+
+    return {
+      ...declinedMatch,
+      name,
+      declinerName: decliner?.name ?? 'Your partner',
+    };
+  },
+});
+
+export const dismissDeclinedProposal = mutation({
+  args: {
+    matchId: v.id('matches'),
+  },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUserOrThrow(ctx);
+
+    const match = await ctx.db.get(args.matchId);
+    if (!match) {
+      throw convexError('MATCH_NOT_FOUND', 'Match not found');
+    }
+
+    // Only the proposer can dismiss their own declined proposal.
+    if (match.proposedBy !== user._id) {
+      throw convexError('NOT_PROPOSER', 'Only the proposer can dismiss this proposal');
+    }
+
+    if (match.proposalStatus !== 'declined') {
+      throw convexError('PROPOSAL_NOT_DECLINED', 'Proposal is not declined');
+    }
+
+    // Clear all proposal fields (same as a withdraw) so the banner goes away
+    // and either partner can propose this name again.
+    await ctx.db.patch(args.matchId, {
+      proposedBy: undefined,
+      proposedAt: undefined,
+      proposalMessage: undefined,
+      proposalStatus: undefined,
+      respondedAt: undefined,
+      declineMessage: undefined,
+      updatedAt: Date.now(),
+    });
+
+    return { success: true };
   },
 });
 


### PR DESCRIPTION
## Summary
Fixes "I declined with a message and my partner got nothing." Declining stored the `declineMessage` but (a) sent **no push notification** (accept does) and (b) was **never surfaced** — `getPendingProposal` only returns `pending`, so the proposal just vanished from the proposer's screen.

- **Notification:** the decline branch of `respondToProposal` now schedules a push to the proposer (`proposal_declined`), respecting their notifications toggle.
- **`getDeclinedProposal`** query — the proposer's view of a declined proposal + the message.
- **`dismissDeclinedProposal`** mutation — clears the proposal fields (like a withdraw), so the banner goes away and either partner can propose the name again.
- **`DeclinedBanner`** (new component) — shown to the proposer with "[Partner] declined [name]", the note, and an X to dismiss.

No schema change (all proposal fields already existed). The Convex prod auto-deploy ships the new functions on merge.

## Test plan
- [ ] Partner declines your proposal with a note → you get a push notification AND a dismissable banner showing the note
- [ ] Decline without a note → notification + banner (no note line)
- [ ] Tap X → banner clears; the name can be proposed again
- [ ] Decliner sees no banner; accept/withdraw flows unaffected
- [x] convex codegen, npm run lint, tsc all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)