### PR TITLE
chore: temp timing log in recordSelection (match-latency diagnosis)

### DIFF
--- a/convex/selections.ts
+++ b/convex/selections.ts
@@ -278,6 +278,8 @@ export const recordSelection = mutation({
     selectionType: v.union(v.literal('like'), v.literal('reject'), v.literal('skip')),
   },
   handler: async (ctx, args) => {
+    // TEMP timing instrumentation (match-latency diagnosis) — remove once done.
+    const t0 = Date.now();
     let user = await getCurrentUserOrThrow(ctx);
     // Backfill running counters BEFORE any mutation runs — otherwise the
     // backfill's post-mutation collect would double-count this write (#183).
@@ -375,6 +377,9 @@ export const recordSelection = mutation({
 
       if (args.selectionType === 'like' && user.partnerId) {
         const match = await checkForMatchAndCreate(ctx, args.nameId, user._id, user.partnerId);
+        console.log(
+          `[recordSelection] path=existing matched=${!!match} elapsedMs=${Date.now() - t0}`,
+        );
         return { selectionId: existingSelection._id, match };
       }
 
@@ -426,6 +431,7 @@ export const recordSelection = mutation({
 
     if (args.selectionType === 'like' && user.partnerId) {
       const match = await checkForMatchAndCreate(ctx, args.nameId, user._id, user.partnerId);
+      console.log(`[recordSelection] path=new matched=${!!match} elapsedMs=${Date.now() - t0}`);
       return { selectionId, match };
     }
 


### PR DESCRIPTION
## Summary
Temporary diagnostic for the "It's a Match" banner latency. Logs total **server-side** elapsed ms inside `recordSelection` on every like-with-partner swipe, tagged with `path` (new/existing) and `matched`. Lets us read the real function duration from prod logs and decide whether the delay is in the function (a bug to fix) or network/cold-start (not fixable in code).

To be reverted once we have the number.

## Test plan
- [ ] Reproduce a match swipe on TestFlight; confirm `[recordSelection] ... elapsedMs=N` appears in prod logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)