### PR TITLE
feat: optimistic match banner (no waiting on the swipe round-trip)

### DIFF
--- a/components/swipe/swipe-card-stack.tsx
+++ b/components/swipe/swipe-card-stack.tsx
@@ -6,7 +6,7 @@ import * as Sentry from '@sentry/react-native';
 import { trackEvent, Events } from '@/lib/analytics';
 import { decodeConvexError } from '@/lib/convex-errors';
 import { api } from '@/convex/_generated/api';
-import { Doc } from '@/convex/_generated/dataModel';
+import { Doc, Id } from '@/convex/_generated/dataModel';
 import { SwipeCard } from './swipe-card';
 import { SwipeActionButtons, SWIPE_ACTION_BUTTONS_HEIGHT } from './swipe-action-buttons';
 import { EmptyState } from './empty-state';
@@ -125,6 +125,22 @@ export function SwipeCardStack({
     nextName ? { name: nextName.name, gender: nextName.gender } : 'skip',
   );
 
+  // Optimistic match detection: which of the rendered top cards has the
+  // partner ALREADY liked? A right swipe on one of those is a guaranteed
+  // match, so the banner can show instantly instead of waiting for the
+  // recordSelection round-trip. Reactive + bounded to the two rendered cards.
+  const renderedNameIds = useMemo(
+    () => [topName?._id, nextName?._id].filter((id): id is Id<'names'> => !!id),
+    [topName?._id, nextName?._id],
+  );
+  const partnerLikedIds = useQuery(
+    api.selections.getPartnerLikedNames,
+    renderedNameIds.length > 0 ? { nameIds: renderedNameIds } : 'skip',
+  );
+  const partnerLikedSet = useMemo(() => new Set(partnerLikedIds ?? []), [partnerLikedIds]);
+  const partnerLikedSetRef = useRef(partnerLikedSet);
+  partnerLikedSetRef.current = partnerLikedSet;
+
   // Append newly-eligible names from the reactive query to localQueue. The
   // query re-runs on every swipe (and whenever selections change), returning
   // the current eligible set minus already-seen names; we append only the
@@ -173,6 +189,19 @@ export function SwipeCardStack({
       const currentName = queue[0];
       if (!currentName) return;
 
+      // Optimistic match: if the partner already liked this name, a right
+      // swipe is a guaranteed match — surface the banner immediately instead
+      // of waiting for the recordSelection round-trip. The server still runs
+      // below to persist the like + create the match row; we reconcile if it
+      // disagrees (rare: partner un-liked in the window, or swipe rejected).
+      const optimisticMatch =
+        selectionType === 'like' && partnerLikedSetRef.current.has(currentName._id);
+      if (optimisticMatch) {
+        setMatchToastName(currentName.name);
+        setShowMatchToast(true);
+        trackEvent(Events.MATCH_FOUND);
+      }
+
       // Optimistic update - remove from queue
       setLocalQueue((prev) => prev.slice(1));
 
@@ -187,6 +216,7 @@ export function SwipeCardStack({
         if (result && 'error' in result) {
           setShowPaywall(true);
           setLocalQueue((prev) => [currentName, ...prev]);
+          if (optimisticMatch) setShowMatchToast(false);
           return;
         }
 
@@ -195,15 +225,23 @@ export function SwipeCardStack({
 
         // Check if we got a match
         if (result.match && result.match.name) {
-          const matchName = result.match.name as Doc<'names'>;
-          setMatchToastName(matchName.name);
-          setShowMatchToast(true);
-          trackEvent(Events.MATCH_FOUND);
+          // Server confirmed it — surface now only if the optimistic check
+          // didn't already (e.g. the prediction query hadn't caught up).
+          if (!optimisticMatch) {
+            const matchName = result.match.name as Doc<'names'>;
+            setMatchToastName(matchName.name);
+            setShowMatchToast(true);
+            trackEvent(Events.MATCH_FOUND);
+          }
+        } else if (optimisticMatch) {
+          // Predicted a match but the server disagreed — retract the banner.
+          setShowMatchToast(false);
         }
       } catch (error: unknown) {
         Sentry.captureException(error);
         // Roll back the optimistic removal so the card returns to the queue.
         setLocalQueue((prev) => [currentName, ...prev]);
+        if (optimisticMatch) setShowMatchToast(false);
         const { message } = decodeConvexError(error, 'Something went wrong. Please try again.');
         setErrorToastMessage(message);
         setShowErrorToast(true);

--- a/convex/selections.ts
+++ b/convex/selections.ts
@@ -278,8 +278,6 @@ export const recordSelection = mutation({
     selectionType: v.union(v.literal('like'), v.literal('reject'), v.literal('skip')),
   },
   handler: async (ctx, args) => {
-    // TEMP timing instrumentation (match-latency diagnosis) — remove once done.
-    const t0 = Date.now();
     let user = await getCurrentUserOrThrow(ctx);
     // Backfill running counters BEFORE any mutation runs — otherwise the
     // backfill's post-mutation collect would double-count this write (#183).
@@ -377,9 +375,6 @@ export const recordSelection = mutation({
 
       if (args.selectionType === 'like' && user.partnerId) {
         const match = await checkForMatchAndCreate(ctx, args.nameId, user._id, user.partnerId);
-        console.log(
-          `[recordSelection] path=existing matched=${!!match} elapsedMs=${Date.now() - t0}`,
-        );
         return { selectionId: existingSelection._id, match };
       }
 
@@ -431,7 +426,6 @@ export const recordSelection = mutation({
 
     if (args.selectionType === 'like' && user.partnerId) {
       const match = await checkForMatchAndCreate(ctx, args.nameId, user._id, user.partnerId);
-      console.log(`[recordSelection] path=new matched=${!!match} elapsedMs=${Date.now() - t0}`);
       return { selectionId, match };
     }
 
@@ -527,6 +521,38 @@ export const getSwipeQueue = query({
     }
 
     return results;
+  },
+});
+
+/**
+ * Which of the given names has the current user's PARTNER already liked?
+ * Powers optimistic match detection on the swipe screen: if the partner
+ * already liked a queued name, the client shows the match banner the instant
+ * the user swipes right, instead of waiting for recordSelection. Reactive and
+ * bounded to the rendered cards, so it's a handful of indexed reads.
+ */
+export const getPartnerLikedNames = query({
+  args: {
+    nameIds: v.array(v.id('names')),
+  },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUserOrNull(ctx);
+    if (!user || !user.partnerId) return [];
+
+    const partnerId = user.partnerId;
+    const ids = args.nameIds.slice(0, BULK_SELECTION_LIMIT);
+
+    const results = await Promise.all(
+      ids.map(async (nameId) => {
+        const sel = await ctx.db
+          .query('selections')
+          .withIndex('by_user_name', (q) => q.eq('userId', partnerId).eq('nameId', nameId))
+          .first();
+        return sel?.selectionType === 'like' ? nameId : null;
+      }),
+    );
+
+    return results.filter((id): id is Id<'names'> => id !== null);
   },
 });
 


### PR DESCRIPTION
## Summary
The "It's a Match" banner felt slow because it `await`ed the full `recordSelection` round-trip before showing — inheriting whatever the trip cost (mobile network + Convex cold-start, which our frequent prod deploys this session kept triggering). Server-side the mutation is fast and fully indexed; the delay was the trip, not the compute.

- **New reactive query `getPartnerLikedNames(nameIds)`** — for the two rendered top cards, returns which the partner has already liked (a couple of indexed reads, reactive so it stays current as the partner swipes).
- **Optimistic banner:** a right swipe on a partner-liked card shows "It's a Match!" **immediately**. `recordSelection` still runs in the background as the authoritative match-creator (all its dedup/race handling unchanged — no data risk).
- **Reconcile:** if the server disagrees (rare: partner un-liked in the window, or swipe rejected), the banner is retracted. Matching users are always effectively-premium, so the free-swipe-limit case can't collide.
- Removes the temporary timing log (#313).

## Test plan
- [ ] Partner already liked a queued name → swiping right shows the match banner instantly
- [ ] Normal non-match right swipe → no banner; card advances
- [ ] Match still appears in the Matches list (server created the row)
- [ ] Edge: partner liked it just now (prediction not yet caught up) → banner still shows via the server result
- [x] convex codegen, lint, tsc pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)