### PR TITLE
fix: stop empty-field sign-in submits polluting Sentry (BAMBINO-2)

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -34,6 +34,10 @@ export default function SignIn() {
 
   const handleSignIn = useCallback(async () => {
     if (!isLoaded) return;
+    if (!email || !password) {
+      setError('Enter your email and password');
+      return;
+    }
 
     setIsLoading(true);
     setLoadingMethod('email');

--- a/lib/clerk-errors.ts
+++ b/lib/clerk-errors.ts
@@ -30,6 +30,8 @@ const EXPECTED_CLERK_ERROR_CODES = new Set<string>([
   'verification_failed', // bad/too-many verification attempts
   'verification_expired', // code expired
   'form_param_format_invalid', // malformed email/identifier
+  'form_param_nil', // required field left empty, e.g. "Enter password." (BAMBINO-2)
+  'form_param_missing', // required field absent from the request
   'authorization_invalid', // "You are not authorized to perform this request"
   'session_exists', // already signed in
 ]);


### PR DESCRIPTION
## Why

Sentry **BAMBINO-2** was being fed by empty-field sign-in submits. The "Sign In" button was only disabled while loading, so tapping it with a blank password called Clerk with `password: ''`, which returns a "required field empty" error (`form_param_nil`, message *"Enter password."*). The user correctly sees the inline message — but the error's Clerk `code` wasn't in `EXPECTED_CLERK_ERROR_CODES`, so `reportClerkError` forwarded it to Sentry as noise. (All unexpected Clerk errors share a capture stack, so they collapse into the one BAMBINO-2 issue.)

Traced to the App Store review session (`appreview@bambinobaby.xyz`); `handled: yes`, 0 users impacted — pure reporting noise, not a crash.

## Changes

- **`lib/clerk-errors.ts`** — add `form_param_nil` and `form_param_missing` to `EXPECTED_CLERK_ERROR_CODES` so empty-required-field validations stop being reported.
- **`app/(auth)/sign-in.tsx`** — guard `handleSignIn` to show an inline "Enter your email and password" message and skip the Clerk round-trip when fields are blank, mirroring the existing `handleForgotPassword` guard.

## Verification

- `npm run lint` passes.
- No behavior change for users: empty submit still shows an inline prompt; we just stop the wasted network call and the Sentry noise.

Co-authored-by: Claude <svc-devxp-claude@slack-corp.com>