### PR TITLE
feat: pin name count, collapsible categories, simpler filter sublabel

### DIFF
--- a/app/(tabs)/explore/filters.tsx
+++ b/app/(tabs)/explore/filters.tsx
@@ -150,12 +150,11 @@ export default function Filters() {
   }
   const displayCount = nameCount ?? lastCount.current;
 
-  // Counter sublabel
-  const isAllOrigins = originFilter === null;
-  const originCount = originFilter?.length ?? 0;
-  const counterSub = isAllOrigins
-    ? 'All origins'
-    : `${originCount} origin${originCount !== 1 ? 's' : ''} selected`;
+  // Counter sublabel — "no filters" only when nothing narrows the list:
+  // gender Both, all origins (null), and all categories (null).
+  const hasActiveFilter =
+    genderFilter !== 'both' || originFilter !== null || categoryFilter !== null;
+  const counterSub = hasActiveFilter ? 'Filters applied' : 'No filters applied';
 
   return (
     <GradientBackground>
@@ -170,6 +169,34 @@ export default function Filters() {
           </Pressable>
           <Text style={styles.title}>Filters</Text>
           <View style={styles.spacer} />
+        </View>
+
+        {/* Pinned names counter — stays visible while the filters scroll below */}
+        <View style={styles.pinnedCounter}>
+          <View
+            style={[
+              styles.counterCard,
+              {
+                backgroundColor: colors.surfaceSubtle,
+                borderColor: colors.border,
+                shadowColor: colors.secondary,
+              },
+            ]}
+          >
+            <View>
+              <Text style={styles.counterLabel}>Names available</Text>
+              <Text style={styles.counterSub}>{counterSub}</Text>
+            </View>
+            {displayCount !== undefined ? (
+              <SlotCounter
+                value={displayCount}
+                fontSize={28}
+                textStyle={[styles.counterNum, { color: colors.primary }]}
+              />
+            ) : (
+              <Text style={[styles.counterNum, { color: colors.primary }]}>—</Text>
+            )}
+          </View>
         </View>
 
         {/* Scrollable content */}
@@ -199,32 +226,6 @@ export default function Filters() {
               </Pressable>
             </View>
           )}
-
-          {/* Names counter card */}
-          <View
-            style={[
-              styles.counterCard,
-              {
-                backgroundColor: colors.surfaceSubtle,
-                borderColor: colors.border,
-                shadowColor: colors.secondary,
-              },
-            ]}
-          >
-            <View>
-              <Text style={styles.counterLabel}>Names available</Text>
-              <Text style={styles.counterSub}>{counterSub}</Text>
-            </View>
-            {displayCount !== undefined ? (
-              <SlotCounter
-                value={displayCount}
-                fontSize={28}
-                textStyle={[styles.counterNum, { color: colors.primary }]}
-              />
-            ) : (
-              <Text style={[styles.counterNum, { color: colors.primary }]}>—</Text>
-            )}
-          </View>
 
           {/* Gender filter */}
           <View style={styles.section}>
@@ -277,6 +278,11 @@ const styles = StyleSheet.create({
   },
   spacer: {
     width: 40,
+  },
+  pinnedCounter: {
+    paddingHorizontal: 20,
+    paddingTop: 8,
+    paddingBottom: 16,
   },
   scrollView: {
     flex: 1,

--- a/components/search/category-toggle-list.tsx
+++ b/components/search/category-toggle-list.tsx
@@ -1,4 +1,7 @@
-import { View, Text, Switch, StyleSheet } from 'react-native';
+import { useState } from 'react';
+import { View, Text, Switch, Pressable, StyleSheet } from 'react-native';
+import Animated, { useAnimatedStyle, withTiming } from 'react-native-reanimated';
+import { Ionicons } from '@expo/vector-icons';
 import { Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { CATEGORY_KEYS, CATEGORY_META } from '@/constants/categories';
@@ -12,10 +15,15 @@ interface CategoryToggleListProps {
 
 export function CategoryToggleList({ value, onChange }: CategoryToggleListProps) {
   const { colors } = useTheme();
+  const [collapsed, setCollapsed] = useState(false);
 
   const isAllSelected = value === null;
   const selectedSet = new Set(value ?? []);
   const selectedCount = value?.length ?? 0;
+
+  const chevronStyle = useAnimatedStyle(() => ({
+    transform: [{ rotate: withTiming(collapsed ? '0deg' : '180deg', { duration: 250 }) }],
+  }));
 
   // All ON → OFF: deselect everything. All OFF → ON: select all.
   const handleToggleAll = () => {
@@ -53,40 +61,48 @@ export function CategoryToggleList({ value, onChange }: CategoryToggleListProps)
 
   return (
     <View style={styles.container}>
-      {/* Header (always expanded — only 6 categories) */}
-      <View style={styles.header}>
-        <Text style={styles.sectionTitle}>Categories</Text>
-        <View style={[styles.badge, { backgroundColor: badgeStyle.backgroundColor }]}>
-          <Text style={[styles.badgeText, { color: badgeStyle.color }]}>{badgeText}</Text>
-        </View>
-      </View>
-
-      <View style={styles.body}>
-        {/* All Categories master row */}
-        <View style={[styles.allRow, { shadowColor: colors.secondary }]}>
-          <View>
-            <Text style={styles.allRowLabel}>All Categories</Text>
-            <Text style={styles.allRowSub}>Include every category</Text>
+      {/* Collapsible header */}
+      <Pressable style={styles.header} onPress={() => setCollapsed(!collapsed)}>
+        <View style={styles.headerLeft}>
+          <Text style={styles.sectionTitle}>Categories</Text>
+          <View style={[styles.badge, { backgroundColor: badgeStyle.backgroundColor }]}>
+            <Text style={[styles.badgeText, { color: badgeStyle.color }]}>{badgeText}</Text>
           </View>
-          <Switch
-            value={isAllSelected}
-            onValueChange={handleToggleAll}
-            trackColor={{ false: '#E5DDD0', true: colors.primary }}
-            thumbColor="#FFFFFF"
-            ios_backgroundColor="#E5DDD0"
-          />
         </View>
+        <Animated.View style={chevronStyle}>
+          <Ionicons name="chevron-down" size={16} color="#A89BB5" />
+        </Animated.View>
+      </Pressable>
 
-        {/* Individual category rows */}
-        {CATEGORY_KEYS.map((key) => (
-          <CategoryToggleRow
-            key={key}
-            label={CATEGORY_META[key].label}
-            isActive={isCategoryActive(key)}
-            onToggle={() => handleToggleCategory(key)}
-          />
-        ))}
-      </View>
+      {/* Collapsible body */}
+      {!collapsed && (
+        <View style={styles.body}>
+          {/* All Categories master row */}
+          <View style={[styles.allRow, { shadowColor: colors.secondary }]}>
+            <View>
+              <Text style={styles.allRowLabel}>All Categories</Text>
+              <Text style={styles.allRowSub}>Include every category</Text>
+            </View>
+            <Switch
+              value={isAllSelected}
+              onValueChange={handleToggleAll}
+              trackColor={{ false: '#E5DDD0', true: colors.primary }}
+              thumbColor="#FFFFFF"
+              ios_backgroundColor="#E5DDD0"
+            />
+          </View>
+
+          {/* Individual category rows */}
+          {CATEGORY_KEYS.map((key) => (
+            <CategoryToggleRow
+              key={key}
+              label={CATEGORY_META[key].label}
+              isActive={isCategoryActive(key)}
+              onToggle={() => handleToggleCategory(key)}
+            />
+          ))}
+        </View>
+      )}
     </View>
   );
 }
@@ -96,6 +112,11 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  headerLeft: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,


### PR DESCRIPTION
## Summary
- Pin the "Names available" count under the header (out of the `ScrollView`) so it stays visible while origins/categories are toggled lower down the filters screen.
- Make the **Categories** section collapsible, matching the existing **Origins** chevron pattern (defaults expanded).
- Replace the stale origins-only "All origins" sublabel with a filter-aware binary: `No filters applied` / `Filters applied` (gender *Both* + all origins + all categories = no filters).

## Test plan
- [ ] Open Explore → Filters; the count card stays pinned under the header while scrolling.
- [ ] Toggle gender / origins / categories and watch the pinned count update live.
- [ ] Tap the **Categories** header to collapse/expand; chevron animates like **Origins**.
- [ ] Sublabel reads `No filters applied` at defaults, `Filters applied` once any filter narrows the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)