### PR TITLE
feat: one-time silent-mode hint on first Listen tap

### DIFF
--- a/components/settings/voice-settings-section.tsx
+++ b/components/settings/voice-settings-section.tsx
@@ -198,7 +198,7 @@ export function VoiceSettingsSection() {
 
           {/* Info note */}
           <View style={[styles.infoNote, { backgroundColor: colors.surfaceSubtle }]}>
-            <Ionicons name="information-circle" size={20} color="#FFB86C" />
+            <Ionicons name="information-circle-outline" size={20} color="#6B5B7B" />
             <Text style={styles.infoNoteText}>
               If you cannot hear the voice, make sure your device is not on silent mode. On iOS,
               also check that Spoken Content is enabled (Settings → Accessibility → Spoken Content).

--- a/components/swipe/listen-hint-banner.tsx
+++ b/components/swipe/listen-hint-banner.tsx
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  Easing,
+  runOnJS,
+} from 'react-native-reanimated';
+import { Ionicons } from '@expo/vector-icons';
+import { Fonts } from '@/constants/theme';
+import { useTheme } from '@/contexts/theme-context';
+
+// Drop-down distance — mirrors MatchToast/FilterNudgeBanner so all three top
+// callouts share the same motion and resting position over the card stack.
+export const LISTEN_HINT_BANNER_HEIGHT = 72;
+
+// Auto-dismiss window. Slightly longer than MatchToast's 3s since this is a
+// two-line instruction the user actually needs to read.
+const AUTO_DISMISS_MS = 4500;
+
+interface ListenHintBannerProps {
+  visible: boolean;
+  onDismiss: () => void;
+}
+
+/**
+ * One-time "Can't hear it?" hint, shown the first time a user taps the Listen
+ * (pronounce) button. iOS silent mode mutes expo-speech and there's no reliable
+ * API to detect or override it (see expo/expo#10827), so we educate once rather
+ * than try to fix it. Visually matches MatchToast (the app's established top
+ * drop-down callout); auto-dismisses after a few seconds or on tap. The parent
+ * persists "seen" so it never returns.
+ */
+export function ListenHintBanner({ visible, onDismiss }: ListenHintBannerProps) {
+  const { colors } = useTheme();
+  const translateY = useSharedValue(-(LISTEN_HINT_BANNER_HEIGHT + 20));
+  const opacity = useSharedValue(0);
+  const dismissTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onDismissRef = useRef(onDismiss);
+  onDismissRef.current = onDismiss;
+
+  const animateOut = useCallback(() => {
+    if (dismissTimer.current) {
+      clearTimeout(dismissTimer.current);
+      dismissTimer.current = null;
+    }
+
+    opacity.value = withTiming(0, { duration: 200 });
+    translateY.value = withTiming(
+      -(LISTEN_HINT_BANNER_HEIGHT + 20),
+      {
+        duration: 300,
+        easing: Easing.in(Easing.cubic),
+      },
+      (finished) => {
+        if (finished) {
+          runOnJS(onDismissRef.current)();
+        }
+      },
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (visible) {
+      translateY.value = withTiming(0, {
+        duration: 400,
+        easing: Easing.out(Easing.cubic),
+      });
+      opacity.value = withTiming(1, { duration: 300 });
+
+      dismissTimer.current = setTimeout(() => {
+        animateOut();
+      }, AUTO_DISMISS_MS);
+    } else {
+      translateY.value = -(LISTEN_HINT_BANNER_HEIGHT + 20);
+      opacity.value = 0;
+    }
+
+    return () => {
+      if (dismissTimer.current) {
+        clearTimeout(dismissTimer.current);
+        dismissTimer.current = null;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible, animateOut]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.value }],
+    opacity: opacity.value,
+  }));
+
+  if (!visible) return null;
+
+  return (
+    <Animated.View style={[styles.container, animatedStyle]}>
+      <Pressable
+        style={[
+          styles.banner,
+          {
+            borderColor: colors.primary,
+            backgroundColor: colors.secondaryLight,
+            shadowColor: colors.primary,
+          },
+        ]}
+        onPress={animateOut}
+        accessibilityRole="button"
+        accessibilityLiveRegion="polite"
+        accessibilityLabel="Can't hear it? Turn off Silent Mode and turn up your volume. Tap to dismiss."
+      >
+        <Ionicons name="volume-mute-outline" size={20} color={colors.tabActive} />
+        <View style={styles.content}>
+          <Text style={[styles.title, { color: colors.tabActive }]}>{"Can't hear it?"}</Text>
+          <Text style={styles.subtitle}>Turn off Silent Mode and turn up your volume.</Text>
+        </View>
+        <Ionicons name="close" size={18} color="#A89BB5" />
+      </Pressable>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  // Matches MatchToast's container + toast styling so the callouts read as one family.
+  container: {
+    position: 'absolute',
+    top: -36,
+    left: 6,
+    right: 6,
+    zIndex: 10,
+  },
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    borderRadius: 16,
+    borderWidth: 3,
+    paddingVertical: 12,
+    paddingHorizontal: 18,
+    shadowOpacity: 0.25,
+    shadowRadius: 24,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 8,
+  },
+  content: {
+    flex: 1,
+  },
+  title: {
+    fontFamily: Fonts?.title || 'Gabarito_800ExtraBold',
+    fontWeight: '800',
+    fontSize: 16,
+  },
+  subtitle: {
+    fontFamily: Fonts?.sans,
+    fontSize: 12,
+    color: '#6B5B7B',
+    marginTop: 1,
+  },
+});

--- a/components/swipe/swipe-card-stack.tsx
+++ b/components/swipe/swipe-card-stack.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useQuery, useMutation } from 'convex/react';
 import { useRouter, useFocusEffect } from 'expo-router';
 import * as Sentry from '@sentry/react-native';
@@ -12,6 +13,7 @@ import { SwipeActionButtons, SWIPE_ACTION_BUTTONS_HEIGHT } from './swipe-action-
 import { EmptyState } from './empty-state';
 import { MatchToast } from '@/components/matches/match-toast';
 import { FilterNudgeBanner } from './filter-nudge-banner';
+import { ListenHintBanner } from './listen-hint-banner';
 import { ErrorToast } from '@/components/ui/error-toast';
 import { NameDetailModal } from '@/components/name-detail/name-detail-modal';
 import { Paywall } from '@/components/paywall';
@@ -31,6 +33,10 @@ interface SwipeCardStackProps {
   nudgeBannerVisible?: boolean;
   onNudgeBannerPress?: () => void;
 }
+
+// One-time flag: the silent-mode listen hint is shown on the user's first-ever
+// tap of the Listen button, then never again.
+const LISTEN_HINT_SEEN_KEY = 'bambino_listen_hint_seen';
 
 export function SwipeCardStack({
   onSwipeResult,
@@ -106,8 +112,20 @@ export function SwipeCardStack({
   );
   const [hintEligible, setHintEligible] = useState(true);
   const [showPushPriming, setShowPushPriming] = useState(false);
+  const [showListenHint, setShowListenHint] = useState(false);
 
   const { shouldPrime, markAsked, markDismissed } = usePushPriming();
+
+  // Show the silent-mode hint once, the first time the user taps Listen.
+  const handleListenPress = useCallback(async () => {
+    try {
+      if (await AsyncStorage.getItem(LISTEN_HINT_SEEN_KEY)) return;
+      setShowListenHint(true);
+      await AsyncStorage.setItem(LISTEN_HINT_SEEN_KEY, 'true');
+    } catch {
+      // Non-fatal: if storage is unavailable, just skip the hint.
+    }
+  }, []);
   const requestPermission = usePushRequestPermission();
   const { needsButtons, reduceMotion } = useA11yPreferences();
 
@@ -282,6 +300,7 @@ export function SwipeCardStack({
             onSwipeLeft={() => handleSelection('reject')}
             onSwipeRight={() => handleSelection('like')}
             onDetailPress={() => setShowDetailModal(true)}
+            onListenPress={index === 0 ? handleListenPress : undefined}
           />
         ))}
       </View>
@@ -299,6 +318,9 @@ export function SwipeCardStack({
 
       {/* Filter-discovery nudge banner (same drop-down family as MatchToast) */}
       <FilterNudgeBanner visible={nudgeBannerVisible} onPress={onNudgeBannerPress ?? (() => {})} />
+
+      {/* One-time silent-mode hint on first Listen tap (same drop-down family) */}
+      <ListenHintBanner visible={showListenHint} onDismiss={() => setShowListenHint(false)} />
 
       {/* Subsequent match toast */}
       <MatchToast

--- a/components/swipe/swipe-card.tsx
+++ b/components/swipe/swipe-card.tsx
@@ -42,6 +42,9 @@ interface SwipeCardProps {
   onSwipeRight?: () => void;
   onSwipeComplete?: (direction: 'left' | 'right') => void;
   onDetailPress?: () => void;
+  /** Fired when the user taps the Listen (pronounce) button to start speech.
+   *  The parent uses this to show the one-time silent-mode hint. */
+  onListenPress?: () => void;
   swipeEnabled?: boolean;
   detailOpen?: boolean;
   /** Override the default card height. Used when accessibility buttons need
@@ -97,6 +100,7 @@ export function SwipeCard({
   onSwipeRight,
   onSwipeComplete,
   onDetailPress,
+  onListenPress,
   swipeEnabled = true,
   detailOpen = false,
   cardHeight,
@@ -370,6 +374,9 @@ export function SwipeCard({
         return;
       }
 
+      // First-listen silent-mode hint (parent shows it once, then persists).
+      onListenPress?.();
+
       const voice = await getBestVoice();
       setIsSpeaking(true);
       Speech.speak(name.name, {
@@ -385,7 +392,7 @@ export function SwipeCard({
       setIsSpeaking(false);
       Alert.alert('Speech Unavailable', 'Unable to pronounce this name right now.');
     }
-  }, [name.name, getBestVoice]);
+  }, [name.name, getBestVoice, onListenPress]);
 
   return (
     <GestureDetector gesture={panGesture}>


### PR DESCRIPTION
## Summary
- On the first-ever tap of the Listen (pronounce) button, drop down a one-time banner — **"Can't hear it? Turn off Silent Mode and turn up your volume."** — styled to match the existing match/filter top callouts. The name still plays; the hint is purely educational.
- Why a hint and not a fix: iOS silent mode mutes `expo-speech` and there's no reliable API to detect or override it ([expo/expo#10827](https://github.com/expo/expo/issues/10827)) without adding a native module + a hacky, device-dependent workaround. A one-time nudge is the pragmatic call.
- Shown once per install, then persisted via AsyncStorage (`bambino_listen_hint_seen`).
- Aligned the Voice settings info-note icon with the app's icon convention (outline variant, `#6B5B7B`) — it was a filled orange outlier.

## Test plan
- [ ] Fresh install (or clear `bambino_listen_hint_seen`): tap Listen on the top card → banner drops down from the top; name plays.
- [ ] Banner auto-dismisses after ~4.5s and also dismisses on tap.
- [ ] Tap Listen again → banner does **not** reappear.
- [ ] Profile → Voice settings: info-note icon is the outline variant in muted purple, consistent with the section's other icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)