### PR TITLE
fix: scroll feedback form above keyboard on focus

### DIFF
--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -122,6 +122,9 @@ export default function Profile() {
   const { resetOnboarding } = useOnboarding();
   const insets = useSafeAreaInsets();
   const scrollRef = useRef<ScrollView>(null);
+  // Live scroll offset, so FeedbackSection can scroll its (deeply nested) form
+  // above the keyboard on focus via measureInWindow + this offset.
+  const scrollYRef = useRef(0);
 
   useFocusEffect(
     useCallback(() => {
@@ -348,6 +351,10 @@ export default function Profile() {
         style={styles.scrollView}
         keyboardShouldPersistTaps="handled"
         keyboardDismissMode="on-drag"
+        onScroll={(event) => {
+          scrollYRef.current = event.nativeEvent.contentOffset.y;
+        }}
+        scrollEventThrottle={16}
         contentContainerStyle={{
           paddingTop: insets.top + 16,
           paddingBottom: 120,
@@ -635,7 +642,7 @@ export default function Profile() {
               <Ionicons name="chevron-forward" size={22} color="#A89BB5" />
             </Pressable>
           </View>
-          <FeedbackSection />
+          <FeedbackSection scrollRef={scrollRef} scrollYRef={scrollYRef} />
           <View style={styles.settingsCard}>
             <Pressable
               style={styles.settingsCardRow}

--- a/components/settings/feedback-section.tsx
+++ b/components/settings/feedback-section.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useState } from 'react';
-import { View, Text, Pressable, TextInput, StyleSheet, Keyboard } from 'react-native';
+import { useCallback, useRef, useState, type RefObject } from 'react';
+import { View, Text, Pressable, TextInput, StyleSheet, Keyboard, ScrollView } from 'react-native';
 import { useFocusEffect } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { useAction } from 'convex/react';
@@ -24,9 +24,18 @@ const PLACEHOLDERS: Record<string, string> = {
 
 type Category = 'bug' | 'feature' | 'general';
 
-export function FeedbackSection() {
+type FeedbackSectionProps = {
+  // The profile screen's ScrollView + its live scroll offset, so the input and
+  // submit button can be lifted above the keyboard on focus. The form sits near
+  // the bottom of a long scroll view that doesn't auto-scroll to a focused field.
+  scrollRef?: RefObject<ScrollView | null>;
+  scrollYRef?: RefObject<number>;
+};
+
+export function FeedbackSection({ scrollRef, scrollYRef }: FeedbackSectionProps) {
   const { colors } = useTheme();
   const submitFeedback = useAction(api.feedback.submitFeedback);
+  const containerRef = useRef<View>(null);
 
   const [isExpanded, setIsExpanded] = useState(false);
   const [category, setCategory] = useState<Category | null>(null);
@@ -69,8 +78,25 @@ export function FeedbackSection() {
     }
   }, [category, message, submitFeedback]);
 
+  // Lift the whole feedback form above the keyboard on focus. measureInWindow
+  // returns the section's true on-screen position regardless of how deeply it's
+  // nested (Fabric-safe, unlike measureLayout/findNodeHandle). Combine it with
+  // the live scroll offset to recover a content offset, then scroll the
+  // section's top near the top of the screen so the header, input, and submit
+  // button all clear the keyboard.
+  const handleInputFocus = useCallback(() => {
+    const scroll = scrollRef?.current;
+    const container = containerRef.current;
+    if (!scroll || !container) return;
+    container.measureInWindow((_x, winY) => {
+      const currentScrollY = scrollYRef?.current ?? 0;
+      const targetTopY = 80; // desired on-screen Y for the section's top
+      scroll.scrollTo({ y: Math.max(currentScrollY + winY - targetTopY, 0), animated: true });
+    });
+  }, [scrollRef, scrollYRef]);
+
   return (
-    <View style={styles.container}>
+    <View ref={containerRef} style={styles.container}>
       <Pressable style={styles.headerRow} onPress={() => setIsExpanded(!isExpanded)}>
         <Ionicons name="chatbubble-outline" size={22} color="#6B5B7B" style={{ marginRight: 12 }} />
         <View style={styles.headerContent}>
@@ -123,6 +149,7 @@ export function FeedbackSection() {
               </View>
 
               <TextInput
+                onFocus={handleInputFocus}
                 style={[
                   styles.textInput,
                   {


### PR DESCRIPTION
## Summary
- The "Share Feedback" form sits near the bottom of the profile `ScrollView`, which doesn't auto-scroll to a focused field — so the input and submit button were covered by the keyboard.
- On focus, the section now measures its true on-screen position via `measureInWindow` (Fabric/new-architecture-safe, unlike `measureLayout`/`findNodeHandle`) and combines it with the ScrollView's live scroll offset to scroll the whole form clear of the keyboard.
- `profile.tsx` tracks the scroll offset (`onScroll` → `scrollYRef`) and threads it + the `scrollRef` into `FeedbackSection`.

## Test plan
- [ ] Profile tab → expand "Share Feedback" → pick a category → focus the text box
- [ ] Form (header, pills, input, Submit button) scrolls up above the keyboard
- [ ] No red-box / runtime error on focus
- [ ] Submit still works; tapping outside / scrolling dismisses the keyboard as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)