### PR TITLE
refactor: standardize button text styling via shared tokens

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -8,7 +8,7 @@ import Animated, { FadeInDown, FadeInUp } from 'react-native-reanimated';
 import { GradientBackground } from '@/components/ui/gradient-background';
 import { GradientButton } from '@/components/ui/gradient-button';
 import { StyledInput } from '@/components/ui/styled-input';
-import { Fonts } from '@/constants/theme';
+import { BUTTON_TEXT, Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { Events, trackEvent } from '@/lib/analytics';
 import { getClerkErrorMessage, reportClerkError } from '@/lib/clerk-errors';
@@ -242,9 +242,7 @@ export default function SignIn() {
               className="mb-6 flex-row justify-end"
             >
               <Pressable onPress={handleForgotPassword}>
-                <Text className="text-sm" style={{ color: colors.primary }}>
-                  Forgot password?
-                </Text>
+                <Text style={[BUTTON_TEXT.link, { color: colors.primary }]}>Forgot password?</Text>
               </Pressable>
             </Animated.View>
 
@@ -304,9 +302,7 @@ export default function SignIn() {
             >
               <Text className="text-gray-600">Don&apos;t have an account? </Text>
               <Pressable onPress={() => router.replace('/(auth)/sign-up')}>
-                <Text className="font-semibold" style={{ color: colors.primary }}>
-                  Sign Up
-                </Text>
+                <Text style={[BUTTON_TEXT.link, { color: colors.primary }]}>Sign Up</Text>
               </Pressable>
             </Animated.View>
           </>
@@ -349,9 +345,7 @@ export default function SignIn() {
                   setNewPassword('');
                 }}
               >
-                <Text className="font-semibold" style={{ color: colors.primary }}>
-                  Back to Sign In
-                </Text>
+                <Text style={[BUTTON_TEXT.link, { color: colors.primary }]}>Back to Sign In</Text>
               </Pressable>
             </Animated.View>
           </>

--- a/app/(auth)/sign-up.tsx
+++ b/app/(auth)/sign-up.tsx
@@ -8,7 +8,7 @@ import Animated, { FadeInDown, FadeInUp } from 'react-native-reanimated';
 import { GradientBackground } from '@/components/ui/gradient-background';
 import { GradientButton } from '@/components/ui/gradient-button';
 import { StyledInput } from '@/components/ui/styled-input';
-import { Fonts } from '@/constants/theme';
+import { BUTTON_TEXT, Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { trackEvent, Events } from '@/lib/analytics';
 import { getClerkErrorMessage, reportClerkError } from '@/lib/clerk-errors';
@@ -203,9 +203,7 @@ export default function SignUp() {
                 setError('');
               }}
             >
-              <Text className="font-semibold" style={{ color: colors.primary }}>
-                Back to Sign Up
-              </Text>
+              <Text style={[BUTTON_TEXT.link, { color: colors.primary }]}>Back to Sign Up</Text>
             </Pressable>
           </Animated.View>
         </Pressable>
@@ -304,9 +302,7 @@ export default function SignUp() {
         >
           <Text className="text-gray-600">Already have an account? </Text>
           <Pressable onPress={() => router.replace('/(auth)/sign-in')}>
-            <Text className="font-semibold" style={{ color: colors.primary }}>
-              Sign In
-            </Text>
+            <Text style={[BUTTON_TEXT.link, { color: colors.primary }]}>Sign In</Text>
           </Pressable>
         </Animated.View>
 

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -27,7 +27,7 @@ import { SearchResultCard } from '@/components/dashboard/search-result-card';
 import { NameDetailModal } from '@/components/name-detail/name-detail-modal';
 import { Paywall } from '@/components/paywall';
 import { useEffectivePremium } from '@/hooks/use-effective-premium';
-import { Fonts } from '@/constants/theme';
+import { BUTTON_TEXT, Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { trackScreen } from '@/lib/analytics';
 import { decodeConvexError } from '@/lib/convex-errors';
@@ -1027,12 +1027,7 @@ function TabBar({ activeTab, onTabChange }: TabBarProps) {
           size={20}
           color={activeTab === 'liked' ? colors.primary : '#6B5B7B'}
         />
-        <Text
-          style={[
-            styles.tabText,
-            activeTab === 'liked' && { color: colors.primary, fontWeight: '600' as const },
-          ]}
-        >
+        <Text style={[styles.tabText, activeTab === 'liked' && { color: colors.primary }]}>
           Liked
         </Text>
       </Pressable>
@@ -1045,12 +1040,7 @@ function TabBar({ activeTab, onTabChange }: TabBarProps) {
           size={20}
           color={activeTab === 'rejected' ? colors.primary : '#6B5B7B'}
         />
-        <Text
-          style={[
-            styles.tabText,
-            activeTab === 'rejected' && { color: colors.primary, fontWeight: '600' as const },
-          ]}
-        >
+        <Text style={[styles.tabText, activeTab === 'rejected' && { color: colors.primary }]}>
           Rejected
         </Text>
       </Pressable>
@@ -1086,8 +1076,7 @@ const styles = StyleSheet.create({
     gap: 6,
   },
   tabText: {
-    fontSize: 14,
-    fontFamily: Fonts?.sans,
+    ...BUTTON_TEXT.pill,
     color: '#6B5B7B',
   },
   loadingContainer: {
@@ -1130,8 +1119,7 @@ const styles = StyleSheet.create({
     zIndex: 10,
   },
   createButtonText: {
-    fontSize: 16,
-    fontWeight: '600',
+    ...BUTTON_TEXT.cta,
     color: '#fff',
   },
   listContent: {
@@ -1166,8 +1154,7 @@ const styles = StyleSheet.create({
     elevation: 6,
   },
   bulkActionText: {
-    fontSize: 16,
-    fontWeight: '600',
+    ...BUTTON_TEXT.cta,
     color: '#fff',
   },
   graceBanner: {

--- a/app/(tabs)/matches.tsx
+++ b/app/(tabs)/matches.tsx
@@ -7,7 +7,7 @@ import { Ionicons } from '@expo/vector-icons';
 import * as Sentry from '@sentry/react-native';
 import { useRouter, useFocusEffect } from 'expo-router';
 import { api } from '@/convex/_generated/api';
-import { Fonts } from '@/constants/theme';
+import { BUTTON_TEXT, Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { useEffectivePremium } from '@/hooks/use-effective-premium';
 import { Events, trackEvent, trackScreen } from '@/lib/analytics';
@@ -666,8 +666,7 @@ const styles = StyleSheet.create({
     zIndex: 10,
   },
   ctaButtonText: {
-    fontSize: 15,
-    fontFamily: Fonts?.title || 'Gabarito_800ExtraBold',
+    ...BUTTON_TEXT.cta,
     color: '#fff',
   },
 });

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -38,7 +38,7 @@ import {
 } from '@/components/settings';
 import { GradientBackground } from '@/components/ui/gradient-background';
 import { GradientButton } from '@/components/ui/gradient-button';
-import { Fonts } from '@/constants/theme';
+import { BUTTON_TEXT, Fonts } from '@/constants/theme';
 import { useOnboarding } from '@/hooks/use-onboarding';
 import { useTheme } from '@/contexts/theme-context';
 import { useProfilePhoto } from '@/hooks/use-profile-photo';
@@ -822,8 +822,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   restoreButtonText: {
-    fontSize: 13,
-    fontFamily: Fonts?.sans,
+    ...BUTTON_TEXT.link,
     color: '#A89BB5',
   },
   premiumBannerWrap: {
@@ -872,10 +871,8 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
   },
   premiumUpgradeText: {
+    ...BUTTON_TEXT.pill,
     color: '#fff',
-    fontFamily: Fonts?.sans,
-    fontWeight: '700',
-    fontSize: 13,
   },
   premiumActiveRow: {
     borderRadius: 16,
@@ -979,9 +976,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#fef2f2',
   },
   unlinkButtonText: {
-    fontSize: 14,
-    fontFamily: Fonts?.sans,
-    fontWeight: '600',
+    ...BUTTON_TEXT.link,
     color: '#ef4444',
   },
   noPartner: {
@@ -1028,11 +1023,7 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     borderRadius: 10,
   },
-  shareActionText: {
-    fontSize: 14,
-    fontFamily: Fonts?.sans,
-    fontWeight: '600',
-  },
+  shareActionText: BUTTON_TEXT.pill,
   linkPartnerWrap: {
     alignSelf: 'stretch',
   },
@@ -1044,8 +1035,7 @@ const styles = StyleSheet.create({
     marginTop: 8,
   },
   deleteAccountText: {
-    fontSize: 14,
-    fontFamily: Fonts?.sans,
+    ...BUTTON_TEXT.link,
     color: '#A89BB5',
   },
 });

--- a/components/onboarding/onboarding-screens.tsx
+++ b/components/onboarding/onboarding-screens.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { View, Text, Pressable, StyleSheet, FlatList, Dimensions } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { Fonts } from '@/constants/theme';
+import { BUTTON_TEXT } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { Events, trackEvent } from '@/lib/analytics';
 import { WelcomeSplash } from './welcome-splash';
@@ -158,9 +158,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   ctaText: {
-    fontSize: 15,
-    fontWeight: '700',
+    ...BUTTON_TEXT.cta,
     color: '#FFFFFF',
-    fontFamily: Fonts?.sans,
   },
 });

--- a/components/partner/name-confirmation-modal.tsx
+++ b/components/partner/name-confirmation-modal.tsx
@@ -16,7 +16,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { Ionicons } from '@expo/vector-icons';
 import * as Sentry from '@sentry/react-native';
 import { api } from '@/convex/_generated/api';
-import { Fonts } from '@/constants/theme';
+import { BUTTON_TEXT, Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { useProfilePhoto } from '@/hooks/use-profile-photo';
 import { AnimatedBottomSheet } from '@/components/ui/animated-bottom-sheet';
@@ -198,7 +198,7 @@ export function NameConfirmationModal({
           {isConfirming ? (
             <ActivityIndicator color="#fff" size="small" />
           ) : (
-            <Text style={styles.confirmButtonText}>{mode === 'edit' ? 'Save' : 'Looks Good!'}</Text>
+            <Text style={styles.confirmButtonText}>{mode === 'edit' ? 'Save' : 'Looks Good'}</Text>
           )}
         </Pressable>
 
@@ -320,8 +320,7 @@ const styles = StyleSheet.create({
     elevation: 4,
   },
   confirmButtonText: {
-    fontSize: 16,
-    fontFamily: Fonts?.title || 'Gabarito_800ExtraBold',
+    ...BUTTON_TEXT.cta,
     color: '#fff',
   },
   buttonDisabled: {

--- a/components/partner/partner-link-modal.tsx
+++ b/components/partner/partner-link-modal.tsx
@@ -13,7 +13,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useQuery, useMutation } from 'convex/react';
 import { Image } from 'expo-image';
 import { api } from '@/convex/_generated/api';
-import { Fonts } from '@/constants/theme';
+import { BUTTON_TEXT, Fonts } from '@/constants/theme';
 import { Paywall } from '@/components/paywall';
 import * as Sentry from '@sentry/react-native';
 import { useTheme } from '@/contexts/theme-context';
@@ -352,10 +352,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   primaryButtonText: {
-    fontSize: 16,
-    fontFamily: Fonts?.sans,
+    ...BUTTON_TEXT.cta,
     color: '#ffffff',
-    fontWeight: '600',
   },
   buttonDisabled: {
     opacity: 0.6,
@@ -402,8 +400,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   secondaryButtonText: {
-    fontSize: 14,
-    fontFamily: Fonts?.sans,
+    ...BUTTON_TEXT.link,
     color: '#6B5B7B',
   },
 });

--- a/components/paywall.tsx
+++ b/components/paywall.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { ActivityIndicator, View, Text, Pressable, StyleSheet, Alert } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { usePurchases } from '@/hooks/use-purchases';
-import { Fonts } from '@/constants/theme';
+import { BUTTON_TEXT, Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { AnimatedBottomSheet } from '@/components/ui/animated-bottom-sheet';
 import { GradientButton } from '@/components/ui/gradient-button';
@@ -276,8 +276,7 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
   },
   restoreButtonText: {
-    fontSize: 14,
-    fontFamily: Fonts?.sans,
+    ...BUTTON_TEXT.link,
     color: '#6B5B7B',
   },
   errorState: {

--- a/components/popularity/year-range-selector.tsx
+++ b/components/popularity/year-range-selector.tsx
@@ -1,5 +1,5 @@
 import { View, Text, Pressable, StyleSheet } from 'react-native';
-import { Fonts } from '@/constants/theme';
+import { BUTTON_TEXT } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 
 type YearRange = '20' | '50' | 'all';
@@ -28,9 +28,7 @@ export function YearRangeSelector({ selected, onSelect }: YearRangeSelectorProps
             style={[styles.pill, isActive && { backgroundColor: colors.primaryLight }]}
             onPress={() => onSelect(option.value)}
           >
-            <Text
-              style={[styles.pillText, isActive && { color: colors.primary, fontWeight: '600' }]}
-            >
+            <Text style={[styles.pillText, isActive && { color: colors.primary }]}>
               {option.label}
             </Text>
           </Pressable>
@@ -53,8 +51,8 @@ const styles = StyleSheet.create({
     backgroundColor: 'transparent',
   },
   pillText: {
-    fontSize: 12,
-    fontFamily: Fonts?.sans,
+    ...BUTTON_TEXT.pill,
+    fontSize: 12, // compact 3-up control; keep tight to avoid overflow
     color: '#6B5B7B', // textSecondary
   },
 });

--- a/components/push/push-priming-sheet.tsx
+++ b/components/push/push-priming-sheet.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { ActivityIndicator, View, Text, Pressable, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { Fonts } from '@/constants/theme';
+import { BUTTON_TEXT, Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { AnimatedBottomSheet } from '@/components/ui/animated-bottom-sheet';
 
@@ -109,9 +109,7 @@ const styles = StyleSheet.create({
     borderRadius: 12,
   },
   allowButtonText: {
-    fontSize: 16,
-    fontFamily: Fonts?.sans,
-    fontWeight: '600',
+    ...BUTTON_TEXT.cta,
     color: '#fff',
   },
   dismissButton: {
@@ -119,9 +117,5 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     paddingVertical: 14,
   },
-  dismissButtonText: {
-    fontSize: 16,
-    fontFamily: Fonts?.sans,
-    fontWeight: '600',
-  },
+  dismissButtonText: BUTTON_TEXT.cta,
 });

--- a/components/search/category-toggle-row.tsx
+++ b/components/search/category-toggle-row.tsx
@@ -1,5 +1,5 @@
 import { View, Text, Switch, Pressable, StyleSheet } from 'react-native';
-import { Fonts } from '@/constants/theme';
+import { BUTTON_TEXT } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 
 interface CategoryToggleRowProps {
@@ -19,7 +19,7 @@ export function CategoryToggleRow({ label, isActive, onToggle }: CategoryToggleR
       accessibilityLabel={label}
       style={[styles.row, { shadowColor: colors.secondary }]}
     >
-      <Text style={[styles.name, isActive && styles.nameActive]}>{label}</Text>
+      <Text style={styles.name}>{label}</Text>
       {/* Visual indicator only. The row Pressable owns the tap; without this the
           Switch's own onValueChange fired alongside the row press, double-firing
           onToggle and reverting the change (#191). pointerEvents="none" lets
@@ -50,14 +50,9 @@ const styles = StyleSheet.create({
     elevation: 4,
   },
   name: {
+    ...BUTTON_TEXT.pill,
     flex: 1,
     marginRight: 12,
-    fontSize: 13,
-    fontFamily: Fonts?.sans,
     color: '#2D1B4E',
-    fontWeight: '500',
-  },
-  nameActive: {
-    fontWeight: '700',
   },
 });

--- a/components/search/gender-filter-selector.tsx
+++ b/components/search/gender-filter-selector.tsx
@@ -1,5 +1,5 @@
 import { View, Text, Pressable, StyleSheet } from 'react-native';
-import { Fonts } from '@/constants/theme';
+import { BUTTON_TEXT } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { useSkinTone } from '@/contexts/skin-tone-context';
 import { getGenderEmoji } from '@/constants/skin-tone';
@@ -68,12 +68,10 @@ const styles = StyleSheet.create({
     fontSize: 16,
   },
   label: {
-    fontSize: 14,
-    fontFamily: Fonts?.sans,
+    ...BUTTON_TEXT.pill,
     color: '#6B5B7B',
   },
   labelSelected: {
     color: '#2D1B4E',
-    fontWeight: '600',
   },
 });

--- a/components/search/origin-toggle-row.tsx
+++ b/components/search/origin-toggle-row.tsx
@@ -1,5 +1,5 @@
 import { View, Text, Switch, Pressable, StyleSheet } from 'react-native';
-import { Fonts } from '@/constants/theme';
+import { BUTTON_TEXT } from '@/constants/theme';
 import { getOriginFlag } from '@/constants/origins';
 import { useTheme } from '@/contexts/theme-context';
 
@@ -21,7 +21,7 @@ export function OriginToggleRow({ origin, isActive, onToggle }: OriginToggleRowP
       style={[styles.row, { shadowColor: colors.secondary }]}
     >
       <View style={styles.textContainer}>
-        <Text style={[styles.name, isActive && styles.nameActive]}>
+        <Text style={styles.name}>
           {getOriginFlag(origin)} {origin}
         </Text>
       </View>
@@ -59,12 +59,7 @@ const styles = StyleSheet.create({
     marginRight: 12,
   },
   name: {
-    fontSize: 13,
-    fontFamily: Fonts?.sans,
+    ...BUTTON_TEXT.pill,
     color: '#2D1B4E',
-    fontWeight: '500',
-  },
-  nameActive: {
-    fontWeight: '700',
   },
 });

--- a/components/settings/feedback-section.tsx
+++ b/components/settings/feedback-section.tsx
@@ -6,7 +6,7 @@ import { useAction } from 'convex/react';
 import * as Sentry from '@sentry/react-native';
 import { api } from '@/convex/_generated/api';
 import { decodeConvexError } from '@/lib/convex-errors';
-import { Fonts } from '@/constants/theme';
+import { BUTTON_TEXT, Fonts } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 import { GradientButton } from '@/components/ui/gradient-button';
 
@@ -230,9 +230,8 @@ const styles = StyleSheet.create({
     gap: 4,
   },
   categoryLabel: {
-    fontSize: 11,
-    fontFamily: Fonts?.sans,
-    fontWeight: '600',
+    ...BUTTON_TEXT.pill,
+    fontSize: 11, // 3-up row with long labels; keep tight to avoid wrapping
     textAlign: 'center',
   },
   textInput: {

--- a/components/ui/gradient-button.tsx
+++ b/components/ui/gradient-button.tsx
@@ -2,7 +2,7 @@ import { ActivityIndicator, Pressable, Text, View, StyleSheet } from 'react-nati
 import { LinearGradient } from 'expo-linear-gradient';
 import Animated, { useSharedValue, useAnimatedStyle, withSpring } from 'react-native-reanimated';
 import { Ionicons } from '@expo/vector-icons';
-import { Fonts, Gradients as DefaultGradients } from '@/constants/theme';
+import { BUTTON_TEXT, Gradients as DefaultGradients } from '@/constants/theme';
 import { useTheme } from '@/contexts/theme-context';
 
 type ButtonVariant = 'primary' | 'secondary' | 'danger';
@@ -106,9 +106,7 @@ const styles = StyleSheet.create({
     elevation: 4,
   },
   gradientText: {
-    fontSize: 16,
-    fontFamily: Fonts?.sans,
-    fontWeight: '600',
+    ...BUTTON_TEXT.cta,
     color: '#ffffff',
   },
   secondaryButton: {
@@ -119,11 +117,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#ffffff',
     borderWidth: 1.5,
   },
-  secondaryText: {
-    fontSize: 16,
-    fontFamily: Fonts?.sans,
-    fontWeight: '600',
-  },
+  secondaryText: BUTTON_TEXT.cta,
   contentRow: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -3,7 +3,7 @@
  * There are many other ways to style your app. For example, [Nativewind](https://www.nativewind.dev/), [Tamagui](https://tamagui.dev/), [unistyles](https://reactnativeunistyles.vercel.app), etc.
  */
 
-import { Platform } from 'react-native';
+import { Platform, type TextStyle } from 'react-native';
 
 export type ThemeKey = 'pink' | 'mint' | 'blue' | 'yellow';
 
@@ -195,3 +195,25 @@ export const Fonts = Platform.select({
     title: 'Gabarito_800ExtraBold',
   },
 });
+
+/**
+ * Canonical button-label typography. Buttons must read as one design language,
+ * so all tappable labels share the system `sans` family and a fixed weight —
+ * color/background carry state (selected, variant), never the font family or weight.
+ *
+ * Spread a token into a label's style and set color at the call site:
+ *   <Text style={[BUTTON_TEXT.cta, { color: '#fff' }]}>…</Text>
+ *
+ * Override `fontSize` only where a layout is genuinely space-constrained
+ * (e.g. a compact 3-up segmented control); keep family and weight intact.
+ */
+export const BUTTON_TEXT: Record<'cta' | 'pill' | 'link' | 'badge', TextStyle> = {
+  /** Full-width primary / secondary / danger calls-to-action. */
+  cta: { fontFamily: Fonts?.sans, fontSize: 16, fontWeight: '600' },
+  /** Segmented controls, filter chips, and tab labels. */
+  pill: { fontFamily: Fonts?.sans, fontSize: 14, fontWeight: '600' },
+  /** Inline text links ("Forgot password?", "Cancel"). */
+  link: { fontFamily: Fonts?.sans, fontSize: 14, fontWeight: '600' },
+  /** Small status badges and counters. */
+  badge: { fontFamily: Fonts?.sans, fontSize: 11, fontWeight: '700', letterSpacing: 0.3 },
+};


### PR DESCRIPTION
## Summary
- Add canonical `BUTTON_TEXT` tokens (`cta`/`pill`/`link`/`badge`) to `constants/theme.ts` — all `Fonts.sans`-based with a fixed weight, so color/background carries state (selected/variant), never the font family or weight. `GradientButton` now consumes them.
- Fix the worst drift: Matches empty-state CTAs ("Upgrade to Premium", "Share Your Code", "Start Swiping") and NameConfirmationModal "Save" rendered in **Gabarito ExtraBold @15px** instead of sans/16/600.
- Remove the unselected→selected font-weight jump (400→600/700) in all segmented/toggle/tab controls — constant 600, no more layout shift on selection.
- Route auth links, profile/paywall/partner/onboarding/push/feedback buttons through the tokens. Also drop the exclamation from "Looks Good".

## Behavioral changes (intentional, visible)
- Switch rows (category/origin) no longer bold the active label — the Switch is the state indicator.
- Unselected segmented/tab/pill labels are slightly bolder (600 vs prior 400/500).
- "Restore Purchase" / "Delete Account" went 400→600 weight (still muted gray, still clearly secondary).

## Left as-is (different role, internally consistent)
Decorative badges (paywall "Premium" header, multiplayer Premium tag, match-card Chosen/Proposed), inline Terms/Privacy links in fine print, settings nav rows, and names/headings (keep `Fonts.title`).

## Test plan
- [x] `npm run lint` — clean
- [x] `tsc --noEmit` — 0 type errors
- [ ] Visual pass: auth, swipe filters, dashboard tabs + bulk actions, matches empty states, profile, paywall, onboarding, feedback pills

🤖 Generated with [Claude Code](https://claude.com/claude-code)