### PR TITLE
fix: reword rejected empty-state copy to "appear here"

### DIFF
--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -769,7 +769,7 @@ export default function Dashboard() {
       <Text style={styles.emptyDescription}>
         {activeTab === 'liked'
           ? "Swipe right on names you love — they'll land right here!"
-          : 'Names you swipe left on will drift over here.'}
+          : 'Names you swipe left on will appear here.'}
       </Text>
       <Pressable
         style={[styles.createButton, { backgroundColor: colors.primary }]}


### PR DESCRIPTION
## Summary
- Reword the rejected-names empty state from "Names you swipe left on will drift over here." to "Names you swipe left on will appear here." for plainer, clearer copy.

## Test plan
- Open the Dashboard, switch to the Rejected tab with no rejected names, and confirm the empty state reads "Names you swipe left on will appear here."

🤖 Generated with [Claude Code](https://claude.com/claude-code)