### PR TITLE
Remove em-dashes from user-facing copy

### DIFF
--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -768,7 +768,7 @@ export default function Dashboard() {
       </Text>
       <Text style={styles.emptyDescription}>
         {activeTab === 'liked'
-          ? "Swipe right on names you love — they'll land right here!"
+          ? "Swipe right on names you love and they'll land right here!"
           : 'Names you swipe left on will appear here.'}
       </Text>
       <Pressable
@@ -832,7 +832,7 @@ export default function Dashboard() {
               <View style={styles.gatedIconRow}>
                 <Ionicons name="lock-closed-outline" size={20} color={colors.primary} />
                 <Text style={[styles.gatedText, { color: colors.textSecondary }]}>
-                  +{gatedCount} more name{gatedCount !== 1 ? 's' : ''} — upgrade to view all
+                  +{gatedCount} more name{gatedCount !== 1 ? 's' : ''}. Upgrade to view all
                 </Text>
               </View>
               <Ionicons name="chevron-forward" size={16} color={colors.textMuted} />

--- a/app/(tabs)/matches.tsx
+++ b/app/(tabs)/matches.tsx
@@ -450,7 +450,7 @@ export default function Matches() {
                 <>
                   A match is any name you and your partner{' '}
                   <Text style={styles.emptyDescriptionBold}>both swipe right</Text> on.{' '}
-                  <Text style={styles.emptyDescriptionBold}>Keep swiping</Text> — they’ll show up
+                  <Text style={styles.emptyDescriptionBold}>Keep swiping</Text> and they’ll show up
                   here.
                 </>
               )}

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -222,7 +222,7 @@ export default function Profile() {
     if (partnerInfo?.shareCode) {
       try {
         await Share.share({
-          message: `I'm using Bambino to pick a baby name — join me! Download the app, then enter my code to link up: ${partnerInfo.shareCode}`,
+          message: `I'm using Bambino to pick a baby name. Join me! Download the app, then enter my code to link up: ${partnerInfo.shareCode}`,
         });
         trackEvent(Events.PARTNER_CODE_SHARED);
       } catch (error) {

--- a/components/paywall.tsx
+++ b/components/paywall.tsx
@@ -17,7 +17,7 @@ interface PaywallProps {
 
 const TRIGGER_MESSAGES: Record<NonNullable<PaywallProps['trigger']>, string> = {
   swipe_limit: "You've used all 25 of your free swipes",
-  partner_limit: 'Connect your partner — one plan covers you both',
+  partner_limit: 'Connect your partner. One plan covers you both',
   dashboard_limit: 'See all your liked names',
 };
 

--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -488,7 +488,7 @@ export const seedAppReviewDemo = internalMutation({
     if (sortedMatches[0]) {
       await ctx.db.patch(sortedMatches[0]._id, {
         isFavorite: true,
-        notes: 'Love this one — strong and classic.',
+        notes: 'Love this one, strong and classic.',
         rank: 1,
         updatedAt: Date.now(),
       });

--- a/convex/partners.ts
+++ b/convex/partners.ts
@@ -358,7 +358,7 @@ export const regenerateShareCode = mutation({
     if (user.partnerId) {
       throw convexError(
         'PARTNER_ALREADY_LINKED',
-        'You already have a partner — share code is no longer needed',
+        'You already have a partner, so the share code is no longer needed',
       );
     }
 

--- a/hooks/use-profile-photo.ts
+++ b/hooks/use-profile-photo.ts
@@ -38,7 +38,7 @@ export function useProfilePhoto(user: UserResource | null | undefined) {
     if (!asset || !asset.base64) {
       Alert.alert(
         'Could not read image',
-        'Please try a different photo. (HEIC images sometimes fail — try converting to JPG.)',
+        'Please try a different photo. (HEIC images sometimes fail; try converting to JPG.)',
       );
       Sentry.captureMessage('Profile photo: missing asset or base64', {
         level: 'warning',


### PR DESCRIPTION
## Summary

Audited the app for em-dashes and reworded **user-facing copy** to drop them (per the "no em-dashes in copy" preference). Eight strings changed:

- Matches & Dashboard empty states
- Profile partner-share message
- Paywall `partner_limit` line
- Profile-photo "could not read image" alert
- `regenerateShareCode` already-linked error
- App Review demo seed note (`admin.ts`)

## Intentionally left untouched
- **Standalone `—` "no value" placeholders** (unranked names, empty stat tiles) — a typographic convention, not prose; confirmed to keep.
- **Code comments / JSDoc / JSX comments** — not user-facing.
- **Internal Slack-webhook strings** (`convex/feedback.ts`) — sent to the team channel, not app users.

Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
