### PR TITLE
Restyle grey tappable buttons to clear colors

### DIFF
--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -826,16 +826,16 @@ export default function Dashboard() {
         ListFooterComponent={
           gatedCount > 0 ? (
             <Pressable
-              style={[styles.gatedBanner, { borderColor: colors.border }]}
+              style={[styles.gatedBanner, { borderColor: colors.primary }]}
               onPress={() => setShowPaywall(true)}
             >
               <View style={styles.gatedIconRow}>
                 <Ionicons name="lock-closed-outline" size={20} color={colors.primary} />
-                <Text style={[styles.gatedText, { color: colors.textSecondary }]}>
+                <Text style={[styles.gatedText, { color: colors.primary }]}>
                   +{gatedCount} more name{gatedCount !== 1 ? 's' : ''}. Upgrade to view all
                 </Text>
               </View>
-              <Ionicons name="chevron-forward" size={16} color={colors.textMuted} />
+              <Ionicons name="chevron-forward" size={16} color={colors.primary} />
             </Pressable>
           ) : likedStatus === 'LoadingMore' ? (
             <View style={styles.listFooterLoader}>

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -450,7 +450,9 @@ export default function Profile() {
               {isRestoring ? (
                 <ActivityIndicator size="small" color={colors.primary} />
               ) : (
-                <Text style={styles.restoreButtonText}>Restore Purchase</Text>
+                <Text style={[styles.restoreButtonText, { color: colors.primary }]}>
+                  Restore Purchase
+                </Text>
               )}
             </Pressable>
           </Animated.View>

--- a/components/paywall.tsx
+++ b/components/paywall.tsx
@@ -160,9 +160,11 @@ export function Paywall({ visible, onClose, trigger = 'swipe_limit' }: PaywallPr
           accessibilityRole="button"
         >
           {isRestoring ? (
-            <ActivityIndicator size="small" color="#6B5B7B" />
+            <ActivityIndicator size="small" color={colors.primary} />
           ) : (
-            <Text style={styles.restoreButtonText}>Restore Purchase</Text>
+            <Text style={[styles.restoreButtonText, { color: colors.primary }]}>
+              Restore Purchase
+            </Text>
           )}
         </Pressable>
       </AnimatedBottomSheet>


### PR DESCRIPTION
## Summary

Follow-up to the de-greyed Decline buttons: an app-wide sweep for grey **tappable** elements that read as disabled.

Restyled:
- **Dashboard "upgrade to view all" gated banner** — its border, text, and chevron were grey (`colors.border` / `textSecondary` / `textMuted`) even though it's tappable and opens the paywall. Recolored to the theme primary so it reads as an upgrade CTA.
- **"Restore Purchase" links** (paywall + profile) — were grey text (`#6B5B7B` / `#A89BB5`). Switched to the theme primary colour so they read as tappable. Kept as text *links* (not filled buttons) so they stay visually subordinate to the primary CTA they sit beside.

Intentionally left as-is (not "disabled-looking" — these uses of grey are correct):
- Toggle / segmented-control **unselected** states (filters, feedback/report category pills, voice options, gender toggles) — grey = "not selected".
- Bottom-sheet **handle bars**, info-card backgrounds, dividers.
- The deliberately de-emphasised **"Delete Account"** link.
- `MatchDetailModal` is dead code (never rendered).

Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
