### PR TITLE
feat: persistent declined-note banner on Matches tab

### DIFF
--- a/app/(tabs)/matches.tsx
+++ b/app/(tabs)/matches.tsx
@@ -17,6 +17,7 @@ import {
   MatchCard,
   MatchesHeader,
   ProposalBanner,
+  DeclinedNoteBanner,
   ProposeSheet,
   ProposalConflictSheet,
   DeclineSheet,
@@ -99,6 +100,7 @@ export default function Matches() {
   const chosenName = useQuery(api.matches.getChosenName);
   const currentUser = useQuery(api.users.getCurrentUser);
   const pendingProposal = useQuery(api.matches.getPendingProposal);
+  const declinedNote = useQuery(api.matches.getLatestDeclinedProposal);
 
   // Close the report sheet if the proposal it targets disappears (partner
   // withdrew/accepted, or unlinked) so it can't act on a stale match. (#185)
@@ -130,6 +132,7 @@ export default function Matches() {
   const respondToProposalMutation = useMutation(api.matches.respondToProposal);
   const withdrawProposalMutation = useMutation(api.matches.withdrawProposal);
   const clearChosenNameMutation = useMutation(api.matches.clearChosenName);
+  const dismissDeclinedNoteMutation = useMutation(api.matches.dismissDeclinedNote);
 
   // Task 13: Trigger celebration for proposer when partner accepts
   useEffect(() => {
@@ -241,6 +244,17 @@ export default function Matches() {
       ],
     );
   }, [chosenName, clearChosenNameMutation]);
+
+  // Dismiss the declined-note banner. Non-destructive (the Rejected tag + the
+  // detail note stay), so no confirmation — just hide it.
+  const handleDismissDeclinedNote = useCallback(async () => {
+    if (!declinedNote) return;
+    try {
+      await dismissDeclinedNoteMutation({ matchId: declinedNote.matchId });
+    } catch (error) {
+      alertMatchMutationError(error, 'Could not dismiss the note.');
+    }
+  }, [declinedNote, dismissDeclinedNoteMutation]);
 
   const handleWithdrawProposal = useCallback(
     async (matchId: Id<'matches'>, nameName: string) => {
@@ -533,6 +547,18 @@ export default function Matches() {
               <Text style={[BUTTON_TEXT.link, { color: colors.tabActive }]}>Clear</Text>
             </Pressable>
           </View>
+        )}
+
+        {/* Declined-note banner — proposer's most recent declined proposal.
+            Hidden while a name is chosen or a proposal is pending (those banners
+            take precedence; a pending proposal can't also be the latest declined). */}
+        {!chosenName && !pendingProposal && declinedNote && declinedNote.name && (
+          <DeclinedNoteBanner
+            declinerName={declinedNote.declinerName}
+            nameName={declinedNote.name.name}
+            message={declinedNote.declineMessage}
+            onDismiss={handleDismissDeclinedNote}
+          />
         )}
 
         {/* Match list */}

--- a/components/matches/declined-note-banner.tsx
+++ b/components/matches/declined-note-banner.tsx
@@ -1,0 +1,82 @@
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { Fonts } from '@/constants/theme';
+import { useTheme } from '@/contexts/theme-context';
+
+interface DeclinedNoteBannerProps {
+  declinerName: string;
+  nameName: string;
+  message: string;
+  onDismiss: () => void;
+}
+
+// Shown to the proposer when their most recent proposal was declined with a
+// note. Informational only (no actions) — the X dismisses the banner without
+// touching the card's Rejected tag or the detail-sheet note, both of which
+// persist until the name is re-proposed. See convex/matches.ts
+// getLatestDeclinedProposal / dismissDeclinedNote.
+export function DeclinedNoteBanner({
+  declinerName,
+  nameName,
+  message,
+  onDismiss,
+}: DeclinedNoteBannerProps) {
+  const { colors } = useTheme();
+
+  return (
+    <View
+      style={[styles.banner, { backgroundColor: colors.primaryLight, borderColor: colors.primary }]}
+    >
+      <Ionicons name="chatbubble-ellipses-outline" size={20} color={colors.primary} />
+      <View style={styles.textContainer}>
+        <Text style={[styles.text, { color: colors.tabActive }]}>
+          {declinerName} declined <Text style={styles.nameText}>{nameName}</Text>
+        </Text>
+        <Text style={styles.message}>&ldquo;{message}&rdquo;</Text>
+      </View>
+      <Pressable
+        style={styles.dismiss}
+        onPress={onDismiss}
+        hitSlop={10}
+        accessibilityRole="button"
+        accessibilityLabel="Dismiss decline note"
+      >
+        <Ionicons name="close-circle" size={24} color={colors.primary} />
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    marginHorizontal: 16,
+    marginBottom: 12,
+    borderRadius: 16,
+    borderWidth: 1.5,
+    padding: 16,
+  },
+  textContainer: {
+    flex: 1,
+  },
+  text: {
+    fontSize: 15,
+    fontFamily: Fonts?.sans,
+    lineHeight: 22,
+  },
+  nameText: {
+    fontFamily: Fonts?.title || 'Gabarito_800ExtraBold',
+  },
+  message: {
+    fontSize: 13,
+    fontFamily: Fonts?.sans,
+    color: '#6B5B7B',
+    fontStyle: 'italic',
+    marginTop: 4,
+  },
+  dismiss: {
+    padding: 4,
+  },
+});

--- a/components/matches/index.ts
+++ b/components/matches/index.ts
@@ -4,6 +4,7 @@ export { MatchDetailModal } from './match-detail-modal';
 export { MatchesHeader } from './matches-header';
 export { MatchToast } from './match-toast';
 export { ProposalBanner } from './proposal-banner';
+export { DeclinedNoteBanner } from './declined-note-banner';
 export { ProposeSheet } from './propose-sheet';
 export { ProposalConflictSheet } from './proposal-conflict-sheet';
 export { DeclineSheet } from './decline-sheet';

--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -587,3 +587,109 @@ export const unlinkUsers = internalMutation({
     return { success: true };
   },
 });
+
+// Dev helper: set up the declined-note banner for a proposer so it can be
+// tested end-to-end. Converts one existing match between the proposer and their
+// partner into "proposed by <proposer>, then declined with a note" as the
+// proposer's most recent proposal. Also clears any chosen name / pending
+// proposal in the partnership, since both take banner precedence over the
+// declined-note banner. Run:
+//   npx convex run admin:seedDeclinedNoteDemo '{"proposerEmail":"george5793@gmail.com"}'
+export const seedDeclinedNoteDemo = internalMutation({
+  args: {
+    proposerEmail: v.string(),
+    // Optional: target a specific matched name; defaults to the first match.
+    name: v.optional(v.string()),
+    // Optional: the decline note; defaults to a realistic sample.
+    message: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const proposer = await ctx.db
+      .query('users')
+      .withIndex('by_email', (q) => q.eq('email', args.proposerEmail))
+      .unique();
+    if (!proposer) return { error: `Proposer not found: ${args.proposerEmail}` };
+    if (!proposer.partnerId) return { error: `${args.proposerEmail} has no linked partner` };
+
+    const partner = await ctx.db.get(proposer.partnerId);
+    if (!partner) return { error: 'Partner record missing' };
+
+    const [u1, u2] =
+      proposer._id < partner._id ? [proposer._id, partner._id] : [partner._id, proposer._id];
+
+    const matches = await ctx.db
+      .query('matches')
+      .withIndex('by_user1_user2', (q) => q.eq('user1Id', u1).eq('user2Id', u2))
+      .collect();
+    if (matches.length === 0) {
+      return { error: 'No matches between these partners to convert. Create a match first.' };
+    }
+
+    const now = Date.now();
+    const note =
+      args.message ??
+      'Not sure about this one, it reminds me of someone from school. Can we keep looking?';
+
+    // Clear anything that would take banner precedence (chosen name / pending
+    // proposal both hide the declined-note banner).
+    let clearedChosen = 0;
+    let clearedPending = 0;
+    for (const m of matches) {
+      if (m.isChosen) {
+        await ctx.db.patch(m._id, { isChosen: false, updatedAt: now });
+        clearedChosen++;
+      }
+      if (m.proposalStatus === 'pending') {
+        await ctx.db.patch(m._id, {
+          proposedBy: undefined,
+          proposedAt: undefined,
+          proposalMessage: undefined,
+          proposalStatus: undefined,
+          respondedAt: undefined,
+          declineMessage: undefined,
+          declineNoteDismissed: undefined,
+          updatedAt: now,
+        });
+        clearedPending++;
+      }
+    }
+
+    // Pick the target match (by name if provided, else the first one).
+    let target = matches[0];
+    if (args.name) {
+      for (const m of matches) {
+        const nm = await ctx.db.get(m.nameId);
+        if (nm?.name.toLowerCase() === args.name.toLowerCase()) {
+          target = m;
+          break;
+        }
+      }
+    }
+
+    // Make it the proposer's most recent proposal, declined with a note.
+    await ctx.db.patch(target._id, {
+      proposedBy: proposer._id,
+      proposedAt: now,
+      proposalMessage: 'What do you think of this one?',
+      proposalStatus: 'declined',
+      respondedAt: now,
+      declineMessage: note,
+      declineNoteDismissed: undefined,
+      isChosen: false,
+      updatedAt: now,
+    });
+
+    const nameDoc = await ctx.db.get(target.nameId);
+
+    return {
+      ok: true,
+      proposer: proposer.email,
+      proposerName: proposer.name,
+      declinerName: partner.name,
+      declinedName: nameDoc?.name,
+      note,
+      clearedChosen,
+      clearedPending,
+    };
+  },
+});

--- a/convex/matches.ts
+++ b/convex/matches.ts
@@ -322,6 +322,9 @@ export const proposeName = mutation({
       proposalStatus: 'pending',
       respondedAt: undefined,
       declineMessage: undefined,
+      // Fresh slate on (re-)propose: any prior decline note + its dismissed
+      // banner state are cleared so a new decline starts clean.
+      declineNoteDismissed: undefined,
       updatedAt: now,
     });
 
@@ -415,11 +418,18 @@ export const respondToProposal = mutation({
       if (match.proposedBy) {
         const name = await ctx.db.get(match.nameId);
         const responderName = user.name ?? 'Your partner';
+        // Signal that a note exists (nudging the proposer into the app to read
+        // it) without putting the raw, unmoderated message on the lock screen —
+        // the note + Report affordance both live in the match detail sheet.
+        const hasNote = !!args.message?.trim();
+        const subject = name ? name.name : 'your suggestion';
 
         await ctx.scheduler.runAfter(0, internal.notifications.sendPushNotification, {
           userId: match.proposedBy,
           title: `${responderName} declined your proposal`,
-          body: name ? `They passed on ${name.name}.` : 'They passed on your suggestion.',
+          body: hasNote
+            ? `They passed on ${subject} and left a note.`
+            : `They passed on ${subject}.`,
           data: { type: 'proposal_declined', matchId: args.matchId },
         });
       }
@@ -509,6 +519,70 @@ export const getPendingProposal = query({
       proposerName: proposer?.name ?? 'Your partner',
       isCurrentUserProposer: pendingMatch.proposedBy === user._id,
     };
+  },
+});
+
+// The proposer's declined-note banner. Returns their MOST RECENT proposal (by
+// proposedAt) only when it was declined with a non-empty note and the proposer
+// hasn't dismissed it. Keying on the latest proposal means making a newer
+// proposal automatically supersedes this (the "Waiting for response" banner
+// takes over) and there's only ever one to show. Older declined notes remain
+// in each card's detail sheet. Distinct from the legacy getDeclinedProposal
+// stub below: dismissing here hides the banner but keeps the Rejected tag and
+// the note (both persist until the name is re-proposed).
+export const getLatestDeclinedProposal = query({
+  args: {},
+  handler: async (ctx) => {
+    const user = await getCurrentUserOrNull(ctx);
+    if (!user || !user.partnerId) return null;
+
+    const matches = await getPartnershipMatches(ctx, user._id, user.partnerId);
+
+    // The latest proposal *I* made, by proposedAt.
+    let latest: Doc<'matches'> | null = null;
+    for (const m of matches) {
+      if (m.proposedBy !== user._id || m.proposedAt === undefined) continue;
+      if (!latest || m.proposedAt > (latest.proposedAt ?? 0)) latest = m;
+    }
+
+    const note = latest?.declineMessage?.trim();
+    if (!latest || latest.proposalStatus !== 'declined' || latest.declineNoteDismissed || !note) {
+      return null;
+    }
+
+    const name = await ctx.db.get(latest.nameId);
+    const decliner = await ctx.db.get(getOtherUserId(latest, user._id));
+
+    return {
+      matchId: latest._id,
+      name,
+      declineMessage: note,
+      declinerName: decliner?.name ?? 'Your partner',
+    };
+  },
+});
+
+// Dismiss the declined-note banner: hides the banner only. The Rejected tag and
+// the detail-sheet note stay until the name is re-proposed (which resets this).
+// Auth-gated + partnership-checked like every other match write.
+export const dismissDeclinedNote = mutation({
+  args: { matchId: v.id('matches') },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUserOrThrow(ctx);
+
+    const match = await ctx.db.get(args.matchId);
+    if (!match) {
+      throw convexError('MATCH_NOT_FOUND', 'Match not found');
+    }
+
+    assertCurrentPartner(user, match);
+
+    await ctx.db.patch(args.matchId, {
+      declineNoteDismissed: true,
+      updatedAt: Date.now(),
+    });
+
+    return { success: true as const };
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -197,6 +197,10 @@ export default defineSchema({
     ),
     respondedAt: v.optional(v.number()),
     declineMessage: v.optional(v.string()),
+    // Set true when the proposer dismisses the declined-note banner. Hides the
+    // banner only — the Rejected tag and the detail-sheet note persist until
+    // the name is re-proposed (which clears this back to undefined).
+    declineNoteDismissed: v.optional(v.boolean()),
     matchedAt: v.number(),
     createdAt: v.number(),
     updatedAt: v.number(),


### PR DESCRIPTION
## Summary
- Adds a **DeclinedNoteBanner** to the top of the Matches tab so the proposer sees the partner's decline note directly, instead of it being buried one tap deep in the name detail sheet.
- `getLatestDeclinedProposal` returns the proposer's most recent proposal (by `proposedAt`) only when it's declined, has a non-empty note, and isn't dismissed — so making a new proposal auto-supersedes the banner and only one ever shows.
- **Clear** (`dismissDeclinedNote` + new `declineNoteDismissed` field) hides the banner only; the red "Rejected" tag and the detail-sheet note both persist until the name is re-proposed (which resets the flag alongside `declineMessage`). Banner is gated off while a name is chosen or a proposal is pending.
- Decline **push notification** now signals a note exists ("… and left a note") without putting the raw, unmoderated text on the lock screen (the note stays in-app, where the Report affordance lives); falls back to the prior templated body when there's no note.
- Adds `admin:seedDeclinedNoteDemo` dev helper (mirrors `seedAppReviewDemo`) to set the banner up end-to-end for a proposer.

Note: schema change is an additive optional field (`declineNoteDismissed`), so the prod auto-deploy on merge is backward-compatible.

## Test plan
- [ ] In dev as **george5793@gmail.com**, open Matches → banner shows "Alex declined Olivia" + the note. (Seed/re-seed: `npx convex run admin:seedDeclinedNoteDemo '{"proposerEmail":"george5793@gmail.com"}'`)
- [ ] Tap **Clear** → banner hides; the Olivia card keeps its Rejected tag and the note still shows in its detail sheet.
- [ ] Make a new proposal → declined banner disappears and the "Waiting for response" banner takes over.
- [ ] Re-propose the declined name → Rejected tag + detail note clear.
- [ ] Decline a proposal with a note → proposer's push reads "… and left a note"; without a note, the prior templated body is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)